### PR TITLE
fix: guard FuzzExtractToken against panics from malformed fuzz inputs

### DIFF
--- a/server/middleware/auth_fuzz_test.go
+++ b/server/middleware/auth_fuzz_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -14,14 +13,19 @@ func FuzzExtractToken(f *testing.F) {
 	f.Add("", "/x?access=abc", "Authorization", "Bearer", "access")
 
 	f.Fuzz(func(t *testing.T, header, rawURL, headerName, scheme, queryParam string) {
-		// httptest.NewRequest panics on invalid URLs; skip inputs that would panic.
-		if _, err := url.ParseRequestURI(rawURL); err != nil {
-			t.Skip("invalid URL")
-		}
-
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		req := httptest.NewRequest(http.MethodGet, rawURL, nil)
+
+		// httptest.NewRequest panics on various malformed inputs; skip those.
+		var req *http.Request
+		func() {
+			defer func() { recover() }() //nolint:errcheck // intentional: skip panics from invalid fuzz inputs
+			req = httptest.NewRequest(http.MethodGet, rawURL, nil)
+		}()
+		if req == nil {
+			t.Skip("invalid request")
+		}
+
 		if headerName == "" {
 			headerName = "Authorization"
 		}


### PR DESCRIPTION
## Problem

The `FuzzExtractToken` fuzz test panics when the fuzzer generates invalid URL inputs (e.g. bare numbers like `"0"`, malformed HTTP versions). `httptest.NewRequest` panics on these inputs rather than returning an error, causing the fuzz smoke CI job to fail.

## Fix

Wrap `httptest.NewRequest` in a recover block and skip the fuzz iteration when the request cannot be constructed. This is the standard pattern for fuzz tests that call panic-prone stdlib functions.

## CI Context

The gosec exclusions were already fixed in main (commit 52e27ea). This PR addresses the remaining fuzz failure blocking PR #7 (dependabot action bumps).