### PR TITLE
docs(release): cut v0.2.0 CHANGELOG, add SemVer + deprecation policy, harden tag script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.2.0] - 2026-04-25
+
+> Tag `v0.2.0` shipped on 2026-04-04 but never received a CHANGELOG entry.
+> This entry back-fills the previous `[Unreleased]` section verbatim. From
+> this release on, every tag MUST be accompanied by a corresponding CHANGELOG
+> entry — enforced by `tag-modules.sh` (see `docs/RELEASING.md`).
+>
+> The `kafka/v0.2.0` and `kafka/testutil/v0.2.0` tags are orphans from when
+> the kafka provider lived at `/kafka`; the package now lives at
+> `/messaging/kafka` and is versioned in lock-step with `messaging`.
+
 ### Changed (Breaking API Changes)
 - **workload**: `RegisterFactory()` global and `New(cfg, providerCfg, log)` removed. `New` now requires an explicit `*FactoryRegistry` as its first argument: `New(registry, cfg, providerCfg, log)`. Provider packages (`docker`, `kubernetes`) no longer register themselves via `init()`; call their `Register(registry)` function from your composition root. `NewComponent` likewise now takes the registry as its first argument.
 - **llm**: `RegisterDialect()`, `GetDialect()`, and `Dialects()` package-level functions removed. `New(cfg)` is replaced by `New(registry, cfg)` taking an explicit `*DialectRegistry`. Provider packages (`anthropic`, `gemini`, `openai`) no longer register via `init()`; call their `Register(registry)` function instead.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,113 @@
+# Releasing
+
+The mechanical steps to cut a release of `gokit`. For *what* counts as a
+breaking change vs a feature vs a fix, see `policy/SEMVER.md` and
+`policy/DEPRECATION.md`.
+
+## Prerequisites
+
+- You are listed in `MAINTAINERS.md` and have push access to `kbukum/gokit`.
+- Your local clone is on `main` with no uncommitted changes.
+- `git`, `gh`, and `go` are on your `$PATH`.
+- Your commits are GPG-signed (`git config commit.gpgsign true`) — release
+  tags must be signed.
+
+## 1. Decide the version
+
+```sh
+# What's the latest tag?
+git tag --sort=-v:refname | head -1
+
+# What changed since then?
+git log --oneline $(git describe --tags --abbrev=0)..HEAD
+```
+
+Use the [SEMVER policy](./policy/SEMVER.md) to pick the next version. While
+in `0.x`, every release with a breaking change in the `[Unreleased]`
+CHANGELOG section bumps MINOR; otherwise PATCH.
+
+## 2. Update the CHANGELOG
+
+1. Open `CHANGELOG.md`.
+2. Replace `## [Unreleased]` with `## [vX.Y.Z] - YYYY-MM-DD`.
+3. Add a fresh empty `## [Unreleased]` section above it.
+4. If `[Unreleased]` is empty, refuse to release — there is nothing to ship.
+5. Update the link reference at the bottom of the file (if present).
+
+The `tag-modules.sh` script will refuse to tag if `[Unreleased]` is the only
+populated section, or if `[vX.Y.Z]` for the version you're cutting doesn't
+exist in the file.
+
+## 3. Tag every module
+
+```sh
+./tag-modules.sh vX.Y.Z          # local-only dry run
+./tag-modules.sh vX.Y.Z --push   # push tags to origin
+```
+
+The script will:
+- Refuse to run with a dirty working tree (`git status --porcelain` non-empty).
+- Refuse to overwrite existing tags unless `--force` is passed.
+- Refuse if `CHANGELOG.md` lacks a `## [vX.Y.Z]` section.
+- Create signed annotated tags (`git tag -s -a vX.Y.Z -m "..."`) using your
+  configured GPG key.
+- Tag the root and every sub-module in lock-step.
+
+## 4. Cut the GitHub Release
+
+Once the tag is on `origin`, generate release notes from the CHANGELOG and
+create the GitHub Release via `gh`:
+
+```sh
+./scripts/release-notes.sh vX.Y.Z > /tmp/notes.md
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/notes.md
+```
+
+The release-notes script extracts the matching CHANGELOG section verbatim
+and prepends a generated summary line and a link to the full diff.
+
+GitHub Releases are mandatory; downstream tooling (`go install`, `dependabot`,
+`pkg.go.dev`) only surface signal when both the tag *and* the Release exist.
+
+## 5. Verify on `pkg.go.dev`
+
+```sh
+gh browse --no-browser
+# then visit
+#   https://pkg.go.dev/github.com/kbukum/gokit@vX.Y.Z
+```
+
+Trigger a re-fetch if needed:
+
+```sh
+GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit@vX.Y.Z
+```
+
+## 6. Announce
+
+- Post in the project's discussion / README "Latest" section.
+- Open a "post-release smoke test" issue against the next sprint milestone.
+
+## Hotfix releases
+
+Hotfixes follow the same flow but skip the `[Unreleased]` rotation if the
+fix is targeted at an older line:
+
+```sh
+git checkout v0.2.0
+git checkout -b hotfix/v0.2.1
+# … apply fix …
+# add a `## [0.2.1] - YYYY-MM-DD` section to CHANGELOG.md
+./tag-modules.sh v0.2.1 --push
+```
+
+## Pre-releases
+
+```sh
+./tag-modules.sh v0.3.0-rc.1 --push
+gh release create v0.3.0-rc.1 --prerelease --title "v0.3.0-rc.1" \
+  --notes-file /tmp/notes.md
+```
+
+Pre-releases bypass the CHANGELOG check (the `-rc.N` / `-beta.N` suffix is
+detected by `tag-modules.sh`).

--- a/docs/policy/DEPRECATION.md
+++ b/docs/policy/DEPRECATION.md
@@ -1,0 +1,77 @@
+# Deprecation Policy
+
+This policy applies once a module reaches `1.0.0`. While in `0.x.y` we may
+remove APIs in any MINOR release (see `SEMVER.md`), but we still try to
+follow the spirit of this document where practical.
+
+## Lifecycle of a deprecated API
+
+```
+   stable ──► deprecated ──► removed
+              ↑           ↑
+              MINOR       MAJOR
+              release     release (≥ 1 MINOR later)
+```
+
+1. **Deprecation** — the API is marked deprecated in a MINOR release.
+2. **Cohabitation** — the new and old APIs coexist for at least one full MINOR
+   release cycle (target: 6 months of calendar time, minimum: 1 MINOR).
+3. **Removal** — the deprecated API is removed in the next MAJOR release.
+
+We never remove a deprecated API in a PATCH or MINOR release after `1.0.0`.
+
+## How we mark deprecation
+
+Every deprecated symbol carries:
+
+1. A `// Deprecated:` doc comment **on the line directly above the
+   declaration** (this is the form `gopls`, `staticcheck`, `golangci-lint`,
+   and `pkg.go.dev` recognise).
+2. The version it was deprecated in.
+3. The replacement (or `no replacement, will be removed in vX.Y.Z`).
+
+```go
+// Deprecated: since v1.2.0; use [auth.NewVerifier] which threads context.
+// Will be removed in v2.0.0.
+func NewAuthChecker(cfg Config) *Checker { … }
+```
+
+3. A CHANGELOG entry under `### Deprecated` for the release that introduced
+   the deprecation.
+4. (Where helpful) a runtime `slog.Warn` from the package's first call,
+   gated by `sync.Once`, naming the replacement. This is optional — only
+   do it for hot-path APIs where a doc comment is easy to miss.
+
+## What counts as a deprecation-eligible change
+
+- Removing a function, method, type, constant, or variable.
+- Removing a field from a struct (when the struct is part of the public API).
+- Adding a method to an exported interface.
+- Tightening a parameter or return type.
+- Changing observable runtime behaviour in a way callers might depend on.
+
+The following are **not** deprecations and may ship in a single MINOR/PATCH:
+
+- Adding a new method to a struct.
+- Adding a new field to a struct (only if the struct is **not** required to be
+  literal-constructed by callers — anything with `unkeyed-fields` warnings
+  needs a deprecation).
+- Tightening behaviour to fix a documented bug.
+
+## Security exception
+
+A vulnerability fix may break API in a PATCH release if no compatible fix
+exists. This is the only exception. Such releases are flagged with `SECURITY:`
+in the CHANGELOG and announced via GitHub Security Advisories.
+
+## Deprecation checklist for maintainers
+
+Before merging a deprecation PR:
+
+- [ ] `// Deprecated:` comment on the symbol with version + replacement.
+- [ ] CHANGELOG `### Deprecated` entry under `[Unreleased]`.
+- [ ] Replacement API exists and is documented.
+- [ ] If the replacement requires a non-trivial migration, add a
+      `## Migration` block to the CHANGELOG entry showing before/after.
+- [ ] Removal date / version recorded in `docs/policy/DEPRECATIONS.csv`
+      (sortable list — create on first deprecation).

--- a/docs/policy/SEMVER.md
+++ b/docs/policy/SEMVER.md
@@ -1,0 +1,72 @@
+# Semantic Versioning Policy
+
+`gokit` follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+with the multi-module clarifications below.
+
+## Versioning surface
+
+`gokit` is a Go *workspace* with one root module (`github.com/kbukum/gokit`) and
+33 sub-modules (e.g. `github.com/kbukum/gokit/storage`, `…/server`, …). **Each
+module is versioned independently**, even though we currently cut all tags in
+lock-step. The lock-step practice is convenience, not contract — consumers
+should pin per module.
+
+## Pre-1.0 (`0.x.y`)
+
+While the project is in `0.x.y`:
+
+- **MINOR** (`0.X.0`) bumps **may** contain breaking API changes. Every break is
+  documented in `CHANGELOG.md` under `### Changed (Breaking API Changes)` for
+  the affected module.
+- **PATCH** (`0.x.Y`) bumps are bug fixes, performance improvements, internal
+  refactors, and **non-breaking** additions. PATCH releases never break the
+  public API.
+- We will not promote a module to `1.0.0` until its public API is settled and we
+  are willing to commit to the full `1.x` compatibility contract for at least
+  12 months.
+
+## Post-1.0 (`1.x.y` and beyond)
+
+- **MAJOR** (`X.0.0`) — breaking change to a stable public API. Requires a
+  deprecation cycle (see `DEPRECATION.md`) of at least one MINOR release
+  before the breaking change ships.
+- **MINOR** (`x.Y.0`) — backwards-compatible additions and behaviour changes.
+  Marking an API as deprecated is a MINOR change.
+- **PATCH** (`x.y.Z`) — backwards-compatible bug and security fixes only.
+
+## What counts as the public API
+
+For a Go module, the public API is every exported identifier reachable via
+`go doc <module>/...` from the `main` branch. This includes:
+
+- Exported types, functions, methods, constants, variables.
+- The signatures and observable behaviour of all of the above.
+- Documented invariants in package or symbol doc comments.
+- Declared interfaces — adding a method to an exported interface is a break.
+
+The following are explicitly **not** part of the public API and may change in
+any release:
+
+- Anything in an `internal/` package.
+- Test helpers in `*/testutil/` packages — these track the parent module
+  version but make no API-stability promises.
+- Generated code (`*.pb.go`, mock files) — when the upstream IDL/source changes.
+- Dependency versions, beyond the documented minimum Go toolchain version.
+
+## Module-level version skew
+
+Sub-modules may temporarily be at different versions when a focused fix ships
+(e.g. `storage/v0.2.1` while the rest of the workspace stays at `v0.2.0`).
+The next root-level release brings everything back into lock-step.
+
+## Pre-release identifiers
+
+Pre-releases use SemVer suffixes: `v0.3.0-rc.1`, `v0.3.0-beta.2`. Pre-release
+tags do not require CHANGELOG entries but **must** be reproducible builds (no
+moving Go-toolchain reference, no floating action SHAs).
+
+## See also
+
+- `DEPRECATION.md` — how we deprecate and eventually remove APIs.
+- `../RELEASING.md` — the mechanical release process.
+- `../../GOVERNANCE.md` — who can cut a release and how.

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# scripts/release-notes.sh — extract a CHANGELOG section for `gh release create`.
+#
+# Usage:
+#   scripts/release-notes.sh v0.2.0 > /tmp/notes.md
+#   gh release create v0.2.0 --notes-file /tmp/notes.md
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 1
+fi
+
+NOVER="${VERSION#v}"
+CHANGELOG="$(dirname "$0")/../CHANGELOG.md"
+
+if ! grep -qE "^## \[${NOVER}\]" "$CHANGELOG"; then
+  echo "error: CHANGELOG.md has no '## [${NOVER}]' section" >&2
+  exit 1
+fi
+
+# Find previous tag for the diff link.
+PREV=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${VERSION}$" | head -1 || true)
+
+cat <<EOF
+## ${VERSION}
+
+EOF
+
+awk -v ver="$NOVER" '
+  $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+  flag && /^## \[/ {flag=0}
+  flag {print}
+' "$CHANGELOG"
+
+if [ -n "$PREV" ]; then
+  echo
+  echo "**Full Changelog**: https://github.com/kbukum/gokit/compare/${PREV}...${VERSION}"
+fi

--- a/tag-modules.sh
+++ b/tag-modules.sh
@@ -61,14 +61,58 @@ echo -e "Force update: $([ "$FORCE_TAG" = true ] && echo "${GREEN}Yes${NC}" || e
 echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
 echo ""
 
-# Check if git working directory is clean
+# Check if git working directory is clean (refuse, don't prompt — releases
+# must be reproducible and signed from a known-good tree).
 if [ -n "$(git status --porcelain)" ]; then
-  echo -e "${YELLOW}⚠ Warning: Working directory has uncommitted changes${NC}"
-  read -p "Continue anyway? (y/N) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo -e "${RED}✗ Working directory has uncommitted changes.${NC}"
+  echo -e "  Releases must be cut from a clean tree so the tag SHA matches"
+  echo -e "  exactly what's on origin/main. Stash or commit first."
+  git --no-pager status --short
+  exit 1
+fi
+
+# Refuse to tag if HEAD is not on origin/main (or the version's release branch
+# for hotfixes — anything matching hotfix/${VERSION}).
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+expected="main"
+case "$current_branch" in
+  hotfix/${VERSION}|hotfix/${VERSION#v}) expected="$current_branch" ;;
+esac
+if [ "$current_branch" != "$expected" ]; then
+  echo -e "${RED}✗ Refusing to tag from branch '$current_branch'.${NC}"
+  echo -e "  Releases must be cut from '$expected' (or 'hotfix/${VERSION}')."
+  exit 1
+fi
+
+# CHANGELOG check (skipped for pre-releases like v0.3.0-rc.1, v0.3.0-beta.2).
+if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if ! grep -qE "^## \[${VERSION#v}\]" CHANGELOG.md; then
+    echo -e "${RED}✗ CHANGELOG.md is missing a '## [${VERSION#v}] - YYYY-MM-DD' section.${NC}"
+    echo -e "  Add one (move items out of '## [Unreleased]') before tagging."
     exit 1
   fi
+  # Refuse if [Unreleased] is the only populated section.
+  unreleased_body=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
+  if [ -z "$(echo "$unreleased_body" | grep -v '^[[:space:]]*$' | grep -v '^_No unreleased')" ] \
+     && ! grep -qE "^## \[${VERSION#v}\]" CHANGELOG.md; then
+    echo -e "${RED}✗ Nothing to release — CHANGELOG '[Unreleased]' is empty and no [${VERSION#v}] section exists.${NC}"
+    exit 1
+  fi
+else
+  echo -e "${YELLOW}⚠ Pre-release detected (${VERSION}); skipping CHANGELOG check.${NC}"
+fi
+
+# Verify GPG signing is configured (required for signed tags).
+if ! git config --get user.signingkey >/dev/null && ! git config --get tag.gpgsign | grep -qi true; then
+  echo -e "${YELLOW}⚠ GPG tag signing is not configured.${NC}"
+  echo -e "  Run: git config --global user.signingkey <KEY-ID>"
+  echo -e "       git config --global tag.gpgsign true"
+  echo -e "  Falling back to annotated (unsigned) tags. Production releases SHOULD be signed."
+  TAG_FLAG="-a"
+  TAG_MSG_FLAG="-m"
+else
+  TAG_FLAG="-s -a"
+  TAG_MSG_FLAG="-m"
 fi
 
 # Find all module directories
@@ -81,7 +125,7 @@ if [ "$FORCE_TAG" = true ]; then
   FORCE_FLAG="-f"
 fi
 
-if git tag $FORCE_FLAG "$VERSION" 2>/dev/null; then
+if git tag $FORCE_FLAG $TAG_FLAG "$VERSION" $TAG_MSG_FLAG "Release $VERSION" 2>/dev/null; then
   echo -e "${GREEN}✓ Created tag: ${VERSION}${NC}"
 else
   if [ "$FORCE_TAG" = false ]; then
@@ -108,7 +152,7 @@ for modfile in $MODULES; do
   
   echo -e "\n${YELLOW}▶ Tagging submodule: ${module_name} → ${tag_name}${NC}"
   
-  if git tag $FORCE_FLAG "$tag_name" 2>/dev/null; then
+  if git tag $FORCE_FLAG $TAG_FLAG "$tag_name" $TAG_MSG_FLAG "Release ${module_name} ${VERSION}" 2>/dev/null; then
     echo -e "${GREEN}✓ Created tag: ${tag_name}${NC}"
   else
     if [ "$FORCE_TAG" = false ]; then


### PR DESCRIPTION
## Summary

Closes the release-governance cluster from the OSS engineering review (`docs/REVIEW.md`). All changes are docs/scripts — no production code.

## Root cause

The repo had 23 git tags but **0 GitHub Releases**, a CHANGELOG that hadn't been rotated since `0.1.5` despite `v0.2.0` being out for 3 weeks, no SemVer or deprecation policy, and a `tag-modules.sh` that prompted on dirty trees and produced unsigned tags. Releases were de-facto unreviewable.

## Fix

| Finding | Change |
|---|---|
| F-027 (#57), F-069 (#71) | Cut `[Unreleased]` → `[0.2.0] - 2026-04-25` in `CHANGELOG.md`; back-fills the existing `v0.2.0` tag with its missing entry. |
| F-098 (#84) | Documented the orphan `kafka/v0.2.0` tags inside the `[0.2.0]` entry. |
| F-028 (#58) | New `docs/policy/SEMVER.md` — multi-module versioning contract, pre-1.0 vs 1.x rules, public-API surface, pre-release identifiers. |
| F-028 (#58) | New `docs/policy/DEPRECATION.md` — minimum 1-MINOR cohabitation, `// Deprecated:` format, CHANGELOG requirements, security exception. |
| F-026 (#56) | New `docs/RELEASING.md` — mechanical process from version-pick to `pkg.go.dev` verification, with hotfix and pre-release flows. |
| F-067, F-068 (#71) | Hardened `tag-modules.sh`: refuses dirty trees (no more prompt), refuses non-`main` branches (except `hotfix/${VERSION}`), refuses if CHANGELOG lacks `## [vX.Y.Z]`, produces signed annotated tags when GPG is configured. |
| (new) | `scripts/release-notes.sh` extracts the matching CHANGELOG section for `gh release create --notes-file`. |

## Verification (local)

```
$ scripts/release-notes.sh v0.2.0    # emits valid release notes for `gh release create`
$ bash -n tag-modules.sh             # syntax OK
$ scripts/check_changelog_unreleased.sh
CHANGELOG [Unreleased] heading check passed.
```

## Risk

Pure docs / build-time scripts. The only behavioural change for maintainers is `tag-modules.sh` refusing rather than prompting on dirty trees — this is the intended improvement.

## Follow-ups

- #56 — actual cutting of GH Releases for the existing 23 tags requires maintainer GPG key.
- #71 / F-067 — long-term, switch to per-module SemVer (lock-step is convenience, not contract).
- #84 / F-099 — verify Makefile `tag` / `tag-push` targets stay aligned with `tag-modules.sh`.

Closes #57, #58
Refs #56, #71, #84

---
*Filed via the issue-remediation prompt.*
