### PR TITLE
fix(architecture): break worker→sse layering, add depguard, honor caller ctx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,8 @@ linters:
     # --- SQL safety ---
     - sqlclosecheck
     - rowserrcheck
+    # --- Architecture / layering ---
+    - depguard
   exclusions:
     rules:
       - path: "_test\\.go"
@@ -81,6 +83,42 @@ linters:
       errorf: true
       asserts: true
       comparison: true
+    depguard:
+      # Enforce architectural layering: foundation packages must not import
+      # transport packages. Closes F-014; prevents F-012 (worker → sse) from
+      # recurring.
+      #
+      # Tiers:
+      #   foundation : transport-agnostic primitives & utilities
+      #   transport  : protocol-specific adapters (HTTP, SSE, gRPC, etc.)
+      #   integration: composes foundation + transport
+      #   (integration packages may import either; not enforced here)
+      rules:
+        foundation:
+          list-mode: lax
+          files:
+            - "$gokit/worker/**/*.go"
+            - "$gokit/errors/**/*.go"
+            - "$gokit/logger/**/*.go"
+            - "$gokit/validation/**/*.go"
+            - "$gokit/hook/**/*.go"
+            - "$gokit/util/**/*.go"
+            - "$gokit/version/**/*.go"
+            - "$gokit/encryption/**/*.go"
+            - "$gokit/schema/**/*.go"
+            - "$gokit/resilience/**/*.go"
+            - "$gokit/httpclient/**/*.go"
+          deny:
+            - pkg: github.com/kbukum/gokit/sse
+              desc: "foundation packages must not import transport (sse). Define a local interface and accept any concrete that satisfies it. See F-012."
+            - pkg: github.com/kbukum/gokit/server
+              desc: "foundation packages must not import transport (server)."
+            - pkg: github.com/kbukum/gokit/grpc
+              desc: "foundation packages must not import transport (grpc)."
+            - pkg: github.com/kbukum/gokit/connect
+              desc: "foundation packages must not import transport (connect)."
+            - pkg: github.com/kbukum/gokit/bootstrap
+              desc: "foundation packages must not import integration (bootstrap)."
 
 issues:
   max-issues-per-linter: 0

--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -297,19 +297,38 @@ func (a *App[C]) Startup(ctx context.Context) error {
 	return a.startup(ctx)
 }
 
-// Shutdown performs graceful shutdown. Use when managing your own lifecycle.
+// Shutdown performs graceful shutdown using the supplied ctx. If ctx has no
+// deadline, the configured gracefulTimeout is applied. If ctx has a deadline
+// shorter than gracefulTimeout, ctx wins.
+//
+// Use when managing your own lifecycle (e.g. when not relying on signal
+// handling via Run).
 func (a *App[C]) Shutdown(ctx context.Context) error {
-	return a.stop()
+	return a.shutdownWith(ctx)
 }
 
-// stop gracefully shuts down all components within the graceful timeout.
+// stop is invoked by the internal signal handler. It seeds shutdown with a
+// fresh context bounded by gracefulTimeout because the original Run ctx is
+// already canceled by the time we get here.
 func (a *App[C]) stop() error {
+	ctx, cancel := context.WithTimeout(context.Background(), a.gracefulTimeout)
+	defer cancel()
+	return a.shutdownWith(ctx)
+}
+
+// shutdownWith runs the actual shutdown sequence. If ctx has no deadline,
+// gracefulTimeout is applied so a misbehaving Stop cannot block forever.
+func (a *App[C]) shutdownWith(parent context.Context) error {
 	a.Logger.Info("Shutting down application", map[string]interface{}{
 		"timeout": a.gracefulTimeout.String(),
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), a.gracefulTimeout)
-	defer cancel()
+	ctx := parent
+	var cancel context.CancelFunc
+	if _, hasDeadline := parent.Deadline(); !hasDeadline {
+		ctx, cancel = context.WithTimeout(parent, a.gracefulTimeout)
+		defer cancel()
+	}
 
 	var shutdownErrs []error
 

--- a/component/registry.go
+++ b/component/registry.go
@@ -9,6 +9,12 @@ import (
 	"github.com/kbukum/gokit/logger"
 )
 
+// DefaultStopTimeout is applied to a component's Stop call only when the
+// caller-supplied context has no deadline. A bounded fallback prevents a
+// stuck Stop from blocking shutdown forever, while still letting callers
+// pass a tighter deadline by attaching one to ctx.
+const DefaultStopTimeout = 10 * time.Second
+
 // componentEntry holds a component and its started state.
 type componentEntry struct {
 	component Component
@@ -21,6 +27,11 @@ type Registry struct {
 	entries []*componentEntry
 	lookup  map[string]*componentEntry
 	mu      sync.RWMutex
+	// lifecycleMu serializes StartAll / StopAll against each other and
+	// against themselves so callers cannot interleave a boot and a shutdown.
+	// It is held for the duration of those operations, but does NOT block
+	// concurrent reads (Get/All/HealthAll) or new Register calls.
+	lifecycleMu sync.Mutex
 }
 
 // NewRegistry creates a new component registry.
@@ -62,31 +73,38 @@ func (r *Registry) Register(c Component) error {
 // If a component fails to start, all components that were successfully
 // started during this call are rolled back (stopped in reverse order).
 // Components started by a previous call are NOT rolled back.
+//
+// The Component.Start call runs without holding any registry lock so
+// readers (Get / All / HealthAll) and concurrent Register calls are not
+// blocked for the duration of the boot sequence.
 func (r *Registry) StartAll(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 
-	// Collect indices of components that need starting.
-	var pending []int
-	for i, entry := range r.entries {
+	// Snapshot entries that need starting under the read lock.
+	r.mu.RLock()
+	pending := make([]*componentEntry, 0, len(r.entries))
+	for _, entry := range r.entries {
 		if !entry.started {
-			pending = append(pending, i)
+			pending = append(pending, entry)
 		}
 	}
+	total := len(r.entries)
+	r.mu.RUnlock()
+
 	if len(pending) == 0 {
 		return nil
 	}
 
 	logger.Debug("Starting components", map[string]interface{}{
 		"pending": len(pending),
-		"total":   len(r.entries),
+		"total":   total,
 	})
 
-	// Track which entries we start in this call for rollback.
-	var startedThisCall []int
+	// Track entries started in this call for rollback.
+	startedThisCall := make([]*componentEntry, 0, len(pending))
 
-	for _, idx := range pending {
-		entry := r.entries[idx]
+	for _, entry := range pending {
 		name := entry.component.Name()
 
 		logger.Debug("Starting component", map[string]interface{}{"component": name})
@@ -95,13 +113,15 @@ func (r *Registry) StartAll(ctx context.Context) error {
 				"component": name,
 				"error":     err.Error(),
 			})
-			// Rollback: stop components started during this call (reverse order).
-			r.rollbackLocked(ctx, startedThisCall)
+			r.rollback(ctx, startedThisCall)
 			return fmt.Errorf("failed to start %s: %w", name, err)
 		}
 
+		r.mu.Lock()
 		entry.started = true
-		startedThisCall = append(startedThisCall, idx)
+		r.mu.Unlock()
+		startedThisCall = append(startedThisCall, entry)
+
 		logger.Debug("Component started", map[string]interface{}{"component": name})
 	}
 
@@ -109,42 +129,54 @@ func (r *Registry) StartAll(ctx context.Context) error {
 	return nil
 }
 
-// rollbackLocked stops the entries at the given indices in reverse order.
-// Caller must hold r.mu.
-func (r *Registry) rollbackLocked(ctx context.Context, indices []int) {
-	for i := len(indices) - 1; i >= 0; i-- {
-		entry := r.entries[indices[i]]
+// rollback stops the given entries in reverse order. lifecycleMu is already
+// held by the caller (StartAll); no other Start/Stop can interleave.
+func (r *Registry) rollback(ctx context.Context, entries []*componentEntry) {
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
 		name := entry.component.Name()
-		stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		stopCtx, cancel := stopContext(ctx)
 		if err := entry.component.Stop(stopCtx); err != nil {
 			logger.Error("Rollback stop failed", map[string]interface{}{
 				"component": name,
 				"error":     err.Error(),
 			})
 		}
-		entry.started = false
 		cancel()
+		r.mu.Lock()
+		entry.started = false
+		r.mu.Unlock()
 	}
 }
 
 // StopAll gracefully stops all components in reverse registration order.
+//
+// Each Component.Stop runs with the caller's ctx; if ctx has no deadline,
+// DefaultStopTimeout is applied per-component as a safety net (closes
+// F-075: hardcoded shutdown deadlines no longer clobber a caller-supplied
+// deadline).
 func (r *Registry) StopAll(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+
+	// Snapshot started entries (reverse order) under the read lock.
+	r.mu.RLock()
+	toStop := make([]*componentEntry, 0, len(r.entries))
+	for i := len(r.entries) - 1; i >= 0; i-- {
+		if r.entries[i].started {
+			toStop = append(toStop, r.entries[i])
+		}
+	}
+	r.mu.RUnlock()
 
 	logger.Info("Stopping all components")
 
 	var errs []error
-	for i := len(r.entries) - 1; i >= 0; i-- {
-		entry := r.entries[i]
-		if !entry.started {
-			continue
-		}
-
+	for _, entry := range toStop {
 		name := entry.component.Name()
 		logger.Debug("Stopping component", map[string]interface{}{"component": name})
 
-		stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		stopCtx, cancel := stopContext(ctx)
 		if err := entry.component.Stop(stopCtx); err != nil {
 			errs = append(errs, fmt.Errorf("failed to stop %s: %w", name, err))
 			logger.Error("Component stop failed", map[string]interface{}{
@@ -154,8 +186,11 @@ func (r *Registry) StopAll(ctx context.Context) error {
 		} else {
 			logger.Info("Component stopped", map[string]interface{}{"component": name})
 		}
-		entry.started = false
 		cancel()
+
+		r.mu.Lock()
+		entry.started = false
+		r.mu.Unlock()
 	}
 
 	if len(errs) > 0 {
@@ -164,6 +199,16 @@ func (r *Registry) StopAll(ctx context.Context) error {
 
 	logger.Info("All components stopped successfully")
 	return nil
+}
+
+// stopContext returns a context for an individual Component.Stop call. If
+// the parent already has a deadline, it is used as-is. Otherwise a
+// DefaultStopTimeout is applied as a bounded safety net.
+func stopContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := parent.Deadline(); ok {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, DefaultStopTimeout)
 }
 
 // HealthAll returns health status for all registered components.

--- a/worker/sse_bridge.go
+++ b/worker/sse_bridge.go
@@ -5,9 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-
-	"github.com/kbukum/gokit/sse"
 )
+
+// Broadcaster is the minimal SSE-style fan-out abstraction the worker
+// package depends on. Defined locally so the worker package stays
+// transport-agnostic — anything matching this method set (notably
+// *sse.Hub) satisfies it without an import edge.
+type Broadcaster interface {
+	BroadcastToPattern(pattern string, data []byte)
+}
 
 // SSEBridgeOption configures an SSEBridge.
 type SSEBridgeOption func(*sseBridgeConfig)
@@ -42,12 +48,12 @@ func WithEnvelope(fn func(event Event[any]) any) SSEBridgeOption {
 // real-time progress streaming.
 type SSEBridge[I, O any] struct {
 	pool        *Pool[I, O]
-	broadcaster sse.Broadcaster
+	broadcaster Broadcaster
 	cfg         sseBridgeConfig
 }
 
 // NewSSEBridge creates a bridge that forwards pool events to an SSE broadcaster.
-func NewSSEBridge[I, O any](pool *Pool[I, O], broadcaster sse.Broadcaster, opts ...SSEBridgeOption) *SSEBridge[I, O] {
+func NewSSEBridge[I, O any](pool *Pool[I, O], broadcaster Broadcaster, opts ...SSEBridgeOption) *SSEBridge[I, O] {
 	cfg := sseBridgeConfig{}
 	for _, opt := range opts {
 		opt(&cfg)


### PR DESCRIPTION
## Summary

Closes the architecture cluster from the engineering review (3 issues, 4 findings).

| # | Finding | Site | Fix |
|---|---|---|---|
| #42 | F-012 | `worker/sse_bridge.go:9` worker→sse import | Define `worker.Broadcaster` interface locally; drop sse import. `*sse.Hub` still satisfies it. |
| #44 | F-014 | `.golangci.yml` no depguard | Added foundation→transport rule set; prevents F-012 from recurring. |
| #61 | F-078 | `component/registry.go` write lock during boot | Snapshot under RLock, run Start/Stop without registry lock, re-acquire briefly to flip `started`. |
| #61 | F-075 | `component/registry.go` + `bootstrap/app.go` hardcoded `10*time.Second` shutdown | Honor caller-supplied ctx deadline; fall back to `DefaultStopTimeout` only when ctx has none. `bootstrap.Shutdown(ctx)` no longer discards ctx. |

## Why "depend on a local interface" instead of moving the bridge to `sse/`

The naive fix (move `sse_bridge.go` to `sse/worker_bridge.go`) just inverts the edge — it would make the transport package import the foundation package, which is **also** a layering violation. The right pattern when both packages are libraries is **dependency inversion**: the consumer (worker) declares the abstraction it needs (`Broadcaster` with one method), and any concrete implementation (`*sse.Hub`, in-memory mock, etc.) satisfies it without an import edge in either direction. Go's structural interface satisfaction makes this zero-friction — no call-site change in any of the 4 test files or external usages.

## Depguard rule

The new rule fires on imports from the listed foundation directories to any of `sse / server / grpc / connect / bootstrap`. It uses `list-mode: lax` so non-listed packages are unaffected (no broad opt-in cost). Audited against the current tree — zero violations after fix-1.

## Boot-sequence lock contention (F-078)

Before: `StartAll` held `r.mu.Lock()` for the entire boot. If a component's `Start` took 30 seconds (e.g. waiting on a database), every `Get`, `All`, `HealthAll`, and `Register` call from elsewhere blocked for 30 seconds.

After: a separate `lifecycleMu` serializes `StartAll`/`StopAll` against each other (so two boots can't race), but `r.mu` is held only briefly to (a) snapshot pending entries and (b) flip `entry.started` after each successful Start. Component.Start runs lock-free.

## Shutdown ctx semantics (F-075)

| Caller pattern | Old behaviour | New behaviour |
|---|---|---|
| `Shutdown(ctx)` with deadline | ctx ignored, used `Background+gracefulTimeout` | Uses caller ctx |
| `Shutdown(ctx)` no deadline | Used `Background+gracefulTimeout` | Uses caller ctx with `gracefulTimeout` applied as fallback |
| Signal handler internal `stop()` | `Background+gracefulTimeout` | Same (Run ctx is already cancelled by then) |
| `registry.StopAll(ctx)` per-component | Hardcoded 10s wraps every Stop | Honors caller ctx; 10s only when ctx has no deadline |

Backwards-compatible for the common case (no deadline + default `gracefulTimeout`); fixes the bug for callers who pass a deadline.

## Verification (local)

```
$ golangci-lint run --timeout=3m ./...
0 issues.

$ go test -race -count=1 -timeout=120s ./...
ok  github.com/kbukum/gokit/bootstrap     2.067s
ok  github.com/kbukum/gokit/component     6.404s
ok  github.com/kbukum/gokit/worker        3.438s
... (all 23 packages pass)
```

## Risk

- **API**: `worker.NewSSEBridge` signature now takes `worker.Broadcaster` instead of `sse.Broadcaster`. Source-compatible because both interfaces have identical single-method shapes; any caller passing a `*sse.Hub` continues to compile.
- **Lock semantics**: a `Component.Start` that internally calls `Registry.Register` no longer self-deadlocks (was previously not possible since the lock was held). Component implementations doing fan-out via the registry now work.
- **Shutdown ctx**: callers who passed a `context.WithTimeout(Background(), 1*time.Second)` to `Shutdown` previously got `gracefulTimeout` (could be 30s) and their 1s was discarded. Now they get 1s. This is the documented intent.

## Follow-ups

- F-076 worker/keyedpool.go (lock-held-during-Submit) — separate PR
- F-077 messaging consumer.Stop ctx-less — separate PR
- Foundation tier could be widened over time as more packages prove transport-free

Closes #42, #44, #61

---
*Filed via the issue-remediation prompt.*
