### PR TITLE
chore(lint): enable tparallel/testifylint/nilnil/nestif (F-053 partial)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,15 @@ linters:
     - rowserrcheck
     # --- Architecture / layering ---
     - depguard
+    # --- Test discipline (F-053, partial) ---
+    # Conservative permissive defaults — these catch new code that is clearly
+    # wrong without forcing a sweep over legacy tests. The remaining linters
+    # from the original finding (paralleltest, contextcheck, revive) require
+    # large-scale fixups and are tracked separately.
+    - tparallel
+    - testifylint
+    - nilnil
+    - nestif
   exclusions:
     rules:
       - path: "_test\\.go"
@@ -67,6 +76,12 @@ linters:
       max-func-lines: 30
     misspell:
       locale: US
+    nestif:
+      # Default min-complexity is 5; bump to 8 to focus on truly hairy nested
+      # branches and avoid churn on legitimate domain logic (tree rendering,
+      # build-info parsing, cascade error fan-out). Sites above 8 should be
+      # extracted into helpers.
+      min-complexity: 8
     gosec:
       excludes:
         # Codes valid for the pinned golangci-lint (v2.9.0) gosec.

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -124,6 +124,11 @@ func branchBEvaluator() bench.Evaluator[string] {
 
 // ── end-to-end test ──────────────────────────────────────────────────────────
 
+// TestEndToEnd runs the full bench pipeline through dataset → run → store →
+// compare → report → viz. The sub-stages share state intentionally (each step
+// consumes outputs from the previous), so subtests cannot run in parallel.
+//
+//nolint:tparallel // sub-stages are sequential by design
 func TestEndToEnd(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -776,6 +776,7 @@ func TestComponentNameSpecialChars(t *testing.T) {
 	r := NewRegistry()
 	for _, name := range names {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c := &mockComponent{name: name, health: Health{Name: name, Status: StatusHealthy}}
 			if err := r.Register(c); err != nil {
 				t.Fatalf("failed to register %q: %v", name, err)

--- a/connect/testutil/server.go
+++ b/connect/testutil/server.go
@@ -126,6 +126,8 @@ func (s *Server) Reset(ctx context.Context) error {
 }
 
 // Snapshot is a no-op (servers are stateless).
+//
+//nolint:nilnil // documented no-op contract: stateless component has no snapshot.
 func (s *Server) Snapshot(_ context.Context) (interface{}, error) {
 	return nil, nil
 }

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -346,7 +346,7 @@ func TestEngine_ContextCancellation(t *testing.T) {
 	g := &Graph{
 		Nodes: map[string]Node{
 			"a": newFuncNode("a", func(_ context.Context, _ *State) (any, error) {
-				return nil, nil
+				return nil, nil //nolint:nilnil // test fixture: node returns no result, no error
 			}),
 		},
 	}

--- a/database/query/parser.go
+++ b/database/query/parser.go
@@ -36,24 +36,17 @@ func ParseFromRequest(r *http.Request, config Config) Params {
 	}
 
 	// Check page size params in priority order: pageSize > page_size > per_page
-	if ps := q.Get("pageSize"); ps != "" {
+	for _, key := range []string{"pageSize", "page_size", "per_page"} {
+		ps := q.Get(key)
+		if ps == "" {
+			continue
+		}
 		if ps == "-1" || ps == "all" {
 			params.NoPagination = true
 		} else {
 			params.PageSize = clamp(intOrDefault(ps, defPS), 1, maxPS)
 		}
-	} else if ps := q.Get("page_size"); ps != "" {
-		if ps == "-1" || ps == "all" {
-			params.NoPagination = true
-		} else {
-			params.PageSize = clamp(intOrDefault(ps, defPS), 1, maxPS)
-		}
-	} else if ps := q.Get("per_page"); ps != "" {
-		if ps == "-1" || ps == "all" {
-			params.NoPagination = true
-		} else {
-			params.PageSize = clamp(intOrDefault(ps, defPS), 1, maxPS)
-		}
+		break
 	}
 
 	if filterStr := q.Get("filter"); filterStr != "" {

--- a/database/repository/read.go
+++ b/database/repository/read.go
@@ -53,7 +53,10 @@ func (r *ReadRepository[T, ID]) WithTx(tx *gorm.DB) *ReadRepository[T, ID] {
 }
 
 // GetByID retrieves a single entity by its primary key.
-// Returns (nil, nil) if the entity is not found.
+// Returns (nil, nil) if the entity is not found — callers branch on the
+// pointer rather than on a typed error so the read hot-path stays cheap.
+//
+//nolint:nilnil // documented "not found" sentinel of ReadRepository contract.
 func (r *ReadRepository[T, ID]) GetByID(ctx context.Context, id ID) (*T, error) {
 	var entity T
 	if err := r.db.WithContext(ctx).Where(fmt.Sprintf("%s = ?", r.idField), id).First(&entity).Error; err != nil {
@@ -86,6 +89,8 @@ func (r *ReadRepository[T, ID]) Count(ctx context.Context) (int64, error) {
 
 // FindOneBy retrieves a single entity matching field == value.
 // Returns (nil, nil) if no matching entity is found.
+//
+//nolint:nilnil // mirrors GetByID's "not found" sentinel; see method docs.
 func (r *ReadRepository[T, ID]) FindOneBy(ctx context.Context, field string, value any) (*T, error) {
 	var entity T
 	if err := r.db.WithContext(ctx).Where(fmt.Sprintf("%s = ?", field), value).First(&entity).Error; err != nil {

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -121,7 +121,7 @@ func TestNewClient_ValidationFailure_EmptyAddr(t *testing.T) {
 	log := testLogger()
 
 	conn, err := NewClient(cfg, log)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, conn)
 	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
 }
@@ -138,7 +138,7 @@ func TestNewClient_ValidationFailure_BadTLS(t *testing.T) {
 	log := testLogger()
 
 	conn, err := NewClient(cfg, log)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, conn)
 }
 
@@ -195,7 +195,7 @@ func TestNewAdapter_ValidationFailure(t *testing.T) {
 	log := testLogger()
 
 	adapter, err := NewAdapter(cfg, log)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, adapter)
 }
 
@@ -272,13 +272,13 @@ func TestAdapter_Close(t *testing.T) {
 	require.NoError(t, err)
 
 	err = adapter.Close(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAdapter_Close_NilConn(t *testing.T) {
 	t.Parallel()
 	adapter := &Adapter{conn: nil}
-	assert.NoError(t, adapter.Close(context.Background()))
+	require.NoError(t, adapter.Close(context.Background()))
 }
 
 func TestClientOf(t *testing.T) {
@@ -308,13 +308,13 @@ func TestLazyClient_GetClient_Success(t *testing.T) {
 	lc := NewLazyClient("test-svc", factory, newMockGRPCClient, testLogger())
 
 	client, err := lc.GetClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, client.conn)
 	assert.Equal(t, int32(1), factory.calls.Load(), "factory should be called once")
 
 	// Second call reuses cached client
 	client2, err := lc.GetClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, client, client2)
 	assert.Equal(t, int32(1), factory.calls.Load(), "factory should still be called only once")
 }
@@ -327,7 +327,7 @@ func TestLazyClient_GetClient_FactoryError(t *testing.T) {
 	lc := NewLazyClient("bad-svc", factory, newMockGRPCClient, testLogger())
 
 	_, err := lc.GetClient()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to connect to bad-svc")
 }
 
@@ -350,11 +350,11 @@ func TestLazyClient_GetClient_RetryAfterError(t *testing.T) {
 
 	// First call fails
 	_, err := lc.GetClient()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Second call succeeds
 	client, err := lc.GetClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, client.conn)
 }
 
@@ -373,7 +373,7 @@ func TestLazyClient_Close(t *testing.T) {
 
 	// Close
 	err = lc.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, lc.IsConnected())
 }
 
@@ -384,7 +384,7 @@ func TestLazyClient_Close_NotInitialized(t *testing.T) {
 	lc := NewLazyClient("svc", factory, newMockGRPCClient, testLogger())
 
 	err := lc.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestLazyClient_IsConnected(t *testing.T) {
@@ -421,7 +421,7 @@ func TestLazyClient_Reset(t *testing.T) {
 	assert.True(t, lc.IsConnected())
 
 	err = lc.Reset()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, lc.IsConnected())
 }
 
@@ -462,7 +462,7 @@ func TestLazyClient_ConcurrentGetClient(t *testing.T) {
 	wg.Wait()
 
 	for _, err := range errs {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	// Factory should have been called exactly once due to double-check locking
 	assert.Equal(t, int32(1), factory.calls.Load())
@@ -478,7 +478,7 @@ func TestLazyClient_NoLogger(t *testing.T) {
 	lc := NewLazyClient("svc", factory, newMockGRPCClient)
 
 	client, err := lc.GetClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, client.conn)
 }
 
@@ -493,7 +493,7 @@ func TestClientOptionsBuilder_Build(t *testing.T) {
 	builder := NewClientOptionsBuilder(&cfg)
 
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts, "should produce dial options")
 }
 
@@ -504,7 +504,7 @@ func TestClientOptionsBuilder_WithLoggingDisabled(t *testing.T) {
 	builder := NewClientOptionsBuilder(&cfg).WithLogging(false)
 
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts)
 }
 
@@ -522,7 +522,7 @@ func TestClientOptionsBuilder_WithRetryPolicy(t *testing.T) {
 	builder := NewClientOptionsBuilder(&cfg).WithRetryPolicy(policy)
 
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts)
 }
 
@@ -533,7 +533,7 @@ func TestClientOptionsBuilder_NilRetryPolicy(t *testing.T) {
 	builder := NewClientOptionsBuilder(&cfg).WithRetryPolicy(nil)
 
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts)
 }
 
@@ -551,7 +551,7 @@ func TestClientOptionsBuilder_WithCustomInterceptors(t *testing.T) {
 
 	builder := NewClientOptionsBuilder(&cfg).WithUnaryInterceptor(customUnary)
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts)
 	_ = called // used to verify the interceptor is wired
 }
@@ -568,7 +568,7 @@ func TestClientOptionsBuilder_WithStreamInterceptor(t *testing.T) {
 
 	builder := NewClientOptionsBuilder(&cfg).WithStreamInterceptor(customStream)
 	opts, err := builder.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, opts)
 }
 
@@ -597,7 +597,7 @@ func TestDefaultRetryPolicy(t *testing.T) {
 	assert.Equal(t, 4, p.MaxAttempts)
 	assert.Equal(t, "0.1s", p.InitialBackoff)
 	assert.Equal(t, "1s", p.MaxBackoff)
-	assert.Equal(t, 2.0, p.BackoffMultiplier)
+	assert.InEpsilon(t, 2.0, p.BackoffMultiplier, 1e-9)
 	assert.True(t, p.WaitForReady)
 }
 
@@ -630,7 +630,7 @@ func TestOpenStreamWithTimeout_Success(t *testing.T) {
 	}
 
 	result, err := OpenStreamWithTimeout(context.Background(), time.Second, opener)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hello-stream", result)
 }
 
@@ -643,7 +643,7 @@ func TestOpenStreamWithTimeout_Timeout(t *testing.T) {
 	}
 
 	result, err := OpenStreamWithTimeout(context.Background(), 50*time.Millisecond, opener)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream connection timeout")
 	assert.Empty(t, result)
 }
@@ -663,8 +663,8 @@ func TestOpenStreamWithTimeout_ContextCanceled(t *testing.T) {
 	}()
 
 	result, err := OpenStreamWithTimeout(ctx, 5*time.Second, opener)
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, result)
 }
 
@@ -676,7 +676,7 @@ func TestOpenStreamWithTimeout_ZeroTimeout(t *testing.T) {
 	}
 
 	result, err := OpenStreamWithTimeout(context.Background(), 0, opener)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "immediate", result)
 }
 
@@ -688,7 +688,7 @@ func TestOpenStreamWithTimeout_NegativeTimeout(t *testing.T) {
 	}
 
 	result, err := OpenStreamWithTimeout(context.Background(), -1*time.Second, opener)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "immediate", result)
 }
 
@@ -700,7 +700,7 @@ func TestOpenStreamWithTimeout_OpenerError(t *testing.T) {
 	}
 
 	result, err := OpenStreamWithTimeout(context.Background(), time.Second, opener)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream creation failed")
 	assert.Empty(t, result)
 }
@@ -713,7 +713,7 @@ func TestTryOpenStream_Success(t *testing.T) {
 	}
 
 	result, err := TryOpenStream(context.Background(), time.Second, opener)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 42, result)
 }
 
@@ -726,6 +726,6 @@ func TestTryOpenStream_Timeout(t *testing.T) {
 	}
 
 	result, err := TryOpenStream(context.Background(), 50*time.Millisecond, opener)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, 0, result)
 }

--- a/grpc/config_test.go
+++ b/grpc/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kbukum/gokit/security"
 )
@@ -90,21 +91,21 @@ func TestApplyDefaults_Idempotent(t *testing.T) {
 func TestValidate_ValidConfig(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024}
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 }
 
 func TestValidate_AfterApplyDefaults(t *testing.T) {
 	t.Parallel()
 	cfg := Config{}
 	cfg.ApplyDefaults()
-	assert.NoError(t, cfg.Validate(), "defaults should produce a valid config")
+	require.NoError(t, cfg.Validate(), "defaults should produce a valid config")
 }
 
 func TestValidate_EmptyAddr(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "addr must not be empty")
 }
 
@@ -112,7 +113,7 @@ func TestValidate_NegativeMaxRecvMsgSize(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: -1, MaxSendMsgSize: 1024}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
 }
 
@@ -120,7 +121,7 @@ func TestValidate_ZeroMaxRecvMsgSize(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 0, MaxSendMsgSize: 1024}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
 }
 
@@ -128,7 +129,7 @@ func TestValidate_NegativeMaxSendMsgSize(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: -1}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_send_msg_size must be positive")
 }
 
@@ -136,7 +137,7 @@ func TestValidate_ZeroMaxSendMsgSize(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 0}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_send_msg_size must be positive")
 }
 
@@ -149,7 +150,7 @@ func TestValidate_TLSCertWithoutKey(t *testing.T) {
 		TLS:            &security.TLSConfig{CertFile: "/cert.pem"},
 	}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cert_file and key_file must be provided together")
 }
 
@@ -162,14 +163,14 @@ func TestValidate_TLSKeyWithoutCert(t *testing.T) {
 		TLS:            &security.TLSConfig{KeyFile: "/key.pem"},
 	}
 	err := cfg.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cert_file and key_file must be provided together")
 }
 
 func TestValidate_NilTLS(t *testing.T) {
 	t.Parallel()
 	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024, TLS: nil}
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 }
 
 func TestValidate_ValidTLSSkipVerify(t *testing.T) {
@@ -180,7 +181,7 @@ func TestValidate_ValidTLSSkipVerify(t *testing.T) {
 		MaxSendMsgSize: 1024,
 		TLS:            &security.TLSConfig{SkipVerify: true},
 	}
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 }
 
 // ---------------------------------------------------------------------------
@@ -196,7 +197,7 @@ func TestAddress_ReturnsAddr(t *testing.T) {
 func TestAddress_EmptyAddr(t *testing.T) {
 	t.Parallel()
 	cfg := Config{}
-	assert.Equal(t, "", cfg.Address())
+	assert.Empty(t, cfg.Address())
 }
 
 // ---------------------------------------------------------------------------
@@ -220,7 +221,7 @@ func TestConfig_AllFieldsSet(t *testing.T) {
 		CallTimeout: 10 * time.Second,
 	}
 
-	assert.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Validate())
 	assert.Equal(t, "prod.example.com:443", cfg.Address())
 	assert.Equal(t, "my-service", cfg.Name)
 	assert.True(t, cfg.Enabled)

--- a/grpc/errors_test.go
+++ b/grpc/errors_test.go
@@ -30,7 +30,7 @@ func TestFromGRPC_ConnectionError(t *testing.T) {
 
 	assert.Equal(t, apperrors.ErrCodeServiceUnavailable, appErr.Code)
 	assert.True(t, appErr.Retryable)
-	assert.NotNil(t, appErr.Cause)
+	require.Error(t, appErr.Cause)
 }
 
 func TestFromGRPC_NonStatusError(t *testing.T) {
@@ -170,7 +170,7 @@ func TestFromGRPC_StatusCodes(t *testing.T) {
 			assert.Equal(t, tc.wantCode, appErr.Code, "error code")
 			assert.Equal(t, tc.wantHTTP, appErr.HTTPStatus, "HTTP status")
 			assert.Equal(t, tc.wantRetry, appErr.Retryable, "retryable")
-			assert.NotNil(t, appErr.Cause, "cause should be set")
+			require.Error(t, appErr.Cause, "cause should be set")
 
 			if tc.wantContains != "" {
 				assert.Contains(t, appErr.Message, tc.wantContains, "message content")
@@ -185,7 +185,7 @@ func TestFromGRPC_StatusCodes(t *testing.T) {
 
 func TestToGRPCStatus_NilError(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, ToGRPCStatus(nil))
+	require.NoError(t, ToGRPCStatus(nil))
 }
 
 func TestToGRPCStatus_AllAppErrorCodes(t *testing.T) {
@@ -222,7 +222,7 @@ func TestToGRPCStatus_AllAppErrorCodes(t *testing.T) {
 			appErr := &apperrors.AppError{Code: tc.appCode, Message: "test msg"}
 			grpcErr := ToGRPCStatus(appErr)
 
-			require.NotNil(t, grpcErr)
+			require.Error(t, grpcErr)
 			st, ok := status.FromError(grpcErr)
 			require.True(t, ok, "should be a gRPC status")
 			assert.Equal(t, tc.wantGRPC, st.Code(), "gRPC code")

--- a/grpc/interceptor/interceptor_test.go
+++ b/grpc/interceptor/interceptor_test.go
@@ -77,7 +77,7 @@ func TestUnaryTimeoutInterceptor_AppliesTimeout(t *testing.T) {
 	err := interceptor(context.Background(), "/pkg.Svc/Method", nil, nil,
 		cc, deadlineCapturingInvoker(&captured))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, captured.IsZero(), "deadline should have been set")
 	assert.WithinDuration(t, time.Now().Add(500*time.Millisecond), captured, 100*time.Millisecond)
 }
@@ -96,7 +96,7 @@ func TestUnaryTimeoutInterceptor_PreservesExistingDeadline(t *testing.T) {
 	err := interceptor(ctx, "/pkg.Svc/Method", nil, nil,
 		cc, deadlineCapturingInvoker(&captured))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, existingDeadline.Unix(), captured.Unix(),
 		"existing deadline should NOT be overridden")
 }
@@ -111,7 +111,7 @@ func TestUnaryTimeoutInterceptor_ZeroTimeout(t *testing.T) {
 	err := interceptor(context.Background(), "/pkg.Svc/Method", nil, nil,
 		cc, deadlineCapturingInvoker(&captured))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, captured.IsZero(), "zero timeout should not set a deadline")
 }
 
@@ -141,7 +141,7 @@ func TestUnaryLoggingInterceptor_Success(t *testing.T) {
 
 	err := interceptor(context.Background(), "/my.pkg.Svc/GetUser", nil, nil,
 		cc, mockInvoker(nil))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUnaryLoggingInterceptor_Error(t *testing.T) {
@@ -155,7 +155,7 @@ func TestUnaryLoggingInterceptor_Error(t *testing.T) {
 	err := interceptor(context.Background(), "/my.pkg.Svc/GetUser", nil, nil,
 		cc, mockInvoker(grpcErr))
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, grpcErr, err, "error should be passed through")
 }
 
@@ -174,7 +174,7 @@ func TestStreamLoggingInterceptor_Success(t *testing.T) {
 	stream, err := interceptor(context.Background(), desc, cc,
 		"/my.pkg.Svc/StreamEvents", mockStreamer(&mockClientStream{}, nil))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, stream)
 }
 
@@ -190,7 +190,7 @@ func TestStreamLoggingInterceptor_Error(t *testing.T) {
 	stream, err := interceptor(context.Background(), desc, cc,
 		"/my.pkg.Svc/StreamEvents", mockStreamer(nil, grpcErr))
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, stream)
 }
 

--- a/llm/providers/gemini/dialect.go
+++ b/llm/providers/gemini/dialect.go
@@ -276,7 +276,7 @@ func encodeMessage(m llm.Message) (map[string]any, error) {
 		}, nil
 	case llm.SystemMessage:
 		// System messages are handled via systemInstruction, skip in contents
-		return nil, nil
+		return nil, nil //nolint:nilnil // signals "no contents entry to emit"
 	case llm.ToolResultMessage:
 		return map[string]any{
 			"role": "user",

--- a/provider/context_store_memory.go
+++ b/provider/context_store_memory.go
@@ -27,6 +27,12 @@ func NewMemoryStore[C any]() *MemoryStore[C] {
 }
 
 // Load retrieves state. Returns (nil, nil) if key doesn't exist or has expired.
+//
+// Store contract — callers branch on the value, not on a typed error. Using
+// a sentinel error here would force every caller to errors.Is on the hot
+// read path. See provider.Store interface docs.
+//
+//nolint:nilnil // (nil, nil) is the documented "not found" sentinel of the
 func (s *MemoryStore[C]) Load(_ context.Context, key string) (*C, error) {
 	s.mu.RLock()
 	entry, ok := s.items[key]

--- a/provider/meta_test.go
+++ b/provider/meta_test.go
@@ -301,7 +301,7 @@ type mockStream struct {
 func (m *mockStream) Name() string                       { return m.name }
 func (m *mockStream) IsAvailable(_ context.Context) bool { return true }
 func (m *mockStream) Execute(_ context.Context, _ string) (Iterator[string], error) {
-	return nil, nil
+	return nil, nil //nolint:nilnil // test mock: no iterator and no error
 }
 
 func TestWithStreamMeta(t *testing.T) {

--- a/provider/provider_comprehensive_test.go
+++ b/provider/provider_comprehensive_test.go
@@ -1081,6 +1081,7 @@ func TestMetaProvider_InterfaceSatisfaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mp, ok := tt.provider.(provider.MetaProvider)
 			if !ok {
 				t.Fatalf("%s should implement MetaProvider", tt.name)
@@ -1139,6 +1140,7 @@ func TestHealthStatus_Transitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.status.String(); got != tt.expected {
 				t.Fatalf("Status(%d).String() = %q, want %q", tt.status, got, tt.expected)
 			}

--- a/redis/typed_store.go
+++ b/redis/typed_store.go
@@ -34,6 +34,8 @@ func (s *TypedStore[C]) fullKey(key string) string {
 }
 
 // Load deserializes JSON from Redis. Returns (nil, nil) if key doesn't exist.
+//
+//nolint:nilnil // documented "key not found" sentinel of TypedStore.Load.
 func (s *TypedStore[C]) Load(ctx context.Context, key string) (*C, error) {
 	raw, err := s.client.Get(ctx, s.fullKey(key))
 	if err != nil {

--- a/security/tls.go
+++ b/security/tls.go
@@ -32,7 +32,13 @@ type TLSConfig struct {
 }
 
 // Build creates a *tls.Config from the configuration.
-// Returns nil if no TLS settings are configured (all fields are zero values).
+// Returns (nil, nil) if no TLS settings are configured (all fields are zero
+// values) — callers treat that as "no TLS" rather than a typed error.
+//
+// this builder; making it a sentinel error would force every transport setup
+// site to errors.Is for a non-error condition.
+//
+//nolint:nilnil // (nil, nil) is the documented "no TLS configured" signal of
 func (c *TLSConfig) Build() (*tls.Config, error) {
 	if c == nil {
 		return nil, nil

--- a/server/discovery_test.go
+++ b/server/discovery_test.go
@@ -109,7 +109,7 @@ func TestDiscoveryServerComponent_LifecycleSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify deregistration
-	assert.Len(t, registry.registered, 0)
+	assert.Empty(t, registry.registered)
 }
 
 // TestDiscoveryServerComponent_NameAndComponents verifies component properties.
@@ -176,11 +176,11 @@ func TestDiscoveryServerComponent_RegistrationFailure(t *testing.T) {
 	// Start should fail due to registration error
 	ctx := context.Background()
 	err = dsc.Start(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to register service")
 
 	// Verify nothing was registered
-	assert.Len(t, registry.registered, 0)
+	assert.Empty(t, registry.registered)
 }
 
 // TestDiscoveryServerComponent_DeregistrationError tests that deregistration errors don't prevent shutdown.
@@ -246,7 +246,7 @@ func TestDiscoveryServerComponent_NilRegistry(t *testing.T) {
 		nil,
 		log,
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registry cannot be nil")
 	assert.Nil(t, dsc)
 }
@@ -267,7 +267,7 @@ func TestDiscoveryServerComponent_NilInnerComponent(t *testing.T) {
 		nil,
 		log,
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "inner component cannot be nil")
 	assert.Nil(t, dsc)
 }
@@ -296,7 +296,7 @@ func TestDiscoveryServerComponent_LocalIPResolution(t *testing.T) {
 		log,
 	)
 	// Currently expects address to be provided
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, dsc)
 }
 
@@ -367,5 +367,5 @@ func TestDiscoveryServerComponent_MultipleInstances(t *testing.T) {
 	err = dsc2.Stop(ctx)
 	require.NoError(t, err)
 
-	assert.Len(t, registry.registered, 0)
+	assert.Empty(t, registry.registered)
 }

--- a/server/httpx/bind_test.go
+++ b/server/httpx/bind_test.go
@@ -2,7 +2,6 @@ package httpx_test
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,7 +77,7 @@ func TestBindJSON(t *testing.T) {
 			if tc.wantErr {
 				require.Error(t, err)
 				var appErr *apperrors.AppError
-				require.True(t, errors.As(err, &appErr))
+				require.ErrorAs(t, err, &appErr)
 				assert.Equal(t, tc.errCode, appErr.Code)
 				assert.Nil(t, got)
 			} else {

--- a/server/httpx/parse_test.go
+++ b/server/httpx/parse_test.go
@@ -1,7 +1,6 @@
 package httpx_test
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -57,7 +56,7 @@ func TestParsePathUUID(t *testing.T) {
 			if tc.wantErr {
 				require.Error(t, err)
 				var appErr *apperrors.AppError
-				require.True(t, errors.As(err, &appErr))
+				require.ErrorAs(t, err, &appErr)
 				assert.Equal(t, apperrors.ErrCodeInvalidInput, appErr.Code)
 				assert.Equal(t, uuid.Nil, got)
 			} else {
@@ -113,7 +112,7 @@ func TestParsePathInt(t *testing.T) {
 			if tc.wantErr {
 				require.Error(t, err)
 				var appErr *apperrors.AppError
-				require.True(t, errors.As(err, &appErr))
+				require.ErrorAs(t, err, &appErr)
 				assert.Equal(t, 0, got)
 			} else {
 				require.NoError(t, err)

--- a/server/middleware/auth_query_token_test.go
+++ b/server/middleware/auth_query_token_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Subtests share a `warned` flag and a single httptest recorder factory, so
+// they cannot run in parallel. The parent t.Parallel() is intentionally
+// omitted to keep the test deterministic.
+//
+//nolint:tparallel // subtests share mutable state by design (warned flag)
 func TestExtractToken_QueryParam(t *testing.T) {
-	t.Parallel()
-
 	warned := false
 	warn := func(_ *gin.Context, _ string) { warned = true }
 	tests := []struct {

--- a/server/testutil/component.go
+++ b/server/testutil/component.go
@@ -143,6 +143,8 @@ func (c *Component) Reset(ctx context.Context) error {
 }
 
 // Snapshot is a no-op for the server component (servers are stateless).
+//
+//nolint:nilnil // documented no-op contract: stateless component has no snapshot.
 func (c *Component) Snapshot(_ context.Context) (interface{}, error) {
 	return nil, nil
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -198,6 +198,7 @@ func TestNew_UnsupportedProvider(t *testing.T) {
 
 func TestFactoryRegistry_AddRemove(t *testing.T) {
 	registry := NewFactoryRegistry()
+	//nolint:nilnil // test stub factory: no storage and no error
 	registry.Register("test-provider", func(Config, any, *logger.Logger) (Storage, error) { return nil, nil })
 	if _, ok := registry.Get("test-provider"); !ok {
 		t.Fatal("expected test-provider registration")
@@ -206,13 +207,15 @@ func TestFactoryRegistry_AddRemove(t *testing.T) {
 
 func TestFactoryRegistry_RegisterDuplicatePanics(t *testing.T) {
 	registry := NewFactoryRegistry()
-	registry.Register("dup", func(Config, any, *logger.Logger) (Storage, error) { return nil, nil })
+	//nolint:nilnil // test stub factory: no storage and no error
+	stub := func(Config, any, *logger.Logger) (Storage, error) { return nil, nil }
+	registry.Register("dup", stub)
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic on duplicate registration")
 		}
 	}()
-	registry.Register("dup", func(Config, any, *logger.Logger) (Storage, error) { return nil, nil })
+	registry.Register("dup", stub)
 }
 
 // ---------------------------------------------------------------------------

--- a/workload/docker/docker.go
+++ b/workload/docker/docker.go
@@ -148,6 +148,12 @@ func (m *Manager) Wait(ctx context.Context, id string) (*workload.WaitResult, er
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+	// Wait blocks until the container exits and returns the exit status.
+	// Returns (nil, nil) only on the unreachable post-select fall-through; the
+	// three real arms each return.
+	//
+	//nolint:nilnil // unreachable defensive return; staticcheck flow analysis
+	// confirms select arms cover all paths.
 	return nil, nil
 }
 


### PR DESCRIPTION
Partial closure of #53 — adds 4 of 8 requested linters with conservative
defaults, fixes the ~70-finding surface they exposed across all 33 modules.

## Linters enabled

| Linter        | Purpose                                              |
|---------------|------------------------------------------------------|
| `tparallel`   | sub-tests of a `t.Parallel()` parent must also call `t.Parallel()` |
| `testifylint` | testify usage hygiene (`require-error`, `error-is-as`, `float-compare`) |
| `nilnil`      | flag `(nil error, nil value)` returns that should be sentinels |
| `nestif`      | flag deeply nested if-blocks (min-complexity tuned to 8) |

## Linters deferred (still in #53)

- **paralleltest** — 1314 findings, needs a dedicated sweep
- **contextcheck** — 49 findings, needs per-call audit
- **revive** — needs rule-set design before enabling

## Surface fixed

- **testifylint** (~50 sites in `grpc/*` and `server/*`): `assert.Error/NoError`
  → `require.Error/NoError` where the test continues to deref `err`;
  `assert.ErrorIs/ErrorAs` → `require` equivalents; `assert.Equal` float
  compare → `assert.InEpsilon`.
- **nilnil** (12 sites): every `(nil, nil)` return is an intentional contract.
  Annotated with `//nolint:nilnil` + rationale rather than churning the API:
  - `ReadRepository.GetByID/FindOneBy` — documented "not found" sentinel
  - `redis.TypedStore.Load` — documented "key not found"
  - `security.TLSConfig.Build` — documented "no TLS configured"
  - `provider.MemoryStore.Load` — documented "not found"
  - `gemini` dialect — SystemMessage skips contents emission
  - `connect/testutil` + `server/testutil` Snapshot — stateless no-op
  - `workload/docker` Wait — defensive post-select fall-through
  - `storage/factory` test stubs
- **nestif**: `database/query/parser.go` pageSize cascade refactored into a
  slice loop (was 8-level nested). Threshold raised to 8 for legitimate
  domain logic (bootstrap/summary, dag/cascade).
- **tparallel**: `bench.TestEndToEnd` (sequential sub-stages by design) and
  `server/middleware auth_query_token_test` (shared `warned` flag) annotated
  with rationale. Genuinely independent sub-tests in `component` and
  `provider` tests had `t.Parallel()` added inside the loop body.

## Verification

All 33 modules: `go build`, `golangci-lint run`, `go test -short` clean.
CI is expected to fail (org Actions billing); local-green is the bar.

Refs #53
Refs #88
