### PR TITLE
fix: shared registry, typed DI keys, remove panic helpers (#43, #45, #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- **registry** (NEW package): generic `Registry[T any]` consolidating the previously ad-hoc registries in `auth`, `discovery`, `storage`, `tool`, `workload`, and `llm`. `Register` returns an error on empty name, nil value, or duplicate name; `Names()` returns sorted; `Each` iterates deterministically. (#45)
+- **di**: typed-key DI surface layered on top of `UnifiedContainer`:
+  - `Key[T any]`, `NameKey[T](name)` — opaque, type-parameterised keys. The full key embeds `reflect.Type` of `T`, so two `Key[T]` of different concrete types with the same `name` cannot collide.
+  - `Provide[T](c, key, ctor)` / `ProvideSingleton[T](c, key, value)` — generic registration; constructor signature is validated up front (must return `T` or `(T, error)`).
+  - `ResolveKey[T](c, key)` / `MustResolveKey[T](c, key)` — generic resolution, no type assertions in caller code. (#43)
+
+### Changed (Breaking API Changes)
+- **auth**: `Registry.Register` now returns `error` on duplicate registration instead of silently overwriting. `Registry.MustGet` removed — use `Get`.
+- **tool**: `Registry.MustRegister` removed — use `Register` (which returns `error`). (#46)
+- **workload**: `FactoryRegistry.MustRegister` removed — use `Register`. (#46)
+- **llm**: `DialectRegistry.MustRegister` removed — use `Register`. (#46)
+- **storage**: `FactoryRegistry.Register` now returns `error` (was panic on duplicate). Provider `Register` functions (`local.Register`, `s3.Register`, `supabase.Register`) likewise return `error`.
+- **discovery**: `ProviderRegistry.Register` now returns `error` (was panic). `NewComponent(registry, cfg, log, opts...)` now returns `(*Component, error)` — previously panicked. Provider `Register` functions (`static.Register`, `consul.Register`) return `error`.
+- **di**: `UnifiedContainer.MustResolve` method removed. The free function `di.MustResolve[T](container, key)` is **kept** (issue #46 explicitly allows `Must*` for `init()` / test / CLI scope, where this helper is idiomatic).
+- **auth/authctx**: `MustGet[T]` removed — use `Get[T]`. (#46)
+- **server/middleware**: `MustTenantFromContext` removed — use `TenantFromContext`. (#46)
+- **agent**: `MustPromptTemplate` and `PromptBuilder.MustBuild` removed — use `NewPromptTemplate` / `Build`. (#46)
+
+### Internal
+- All 6 first-party registries are now thin wrappers around `registry.Registry[T]`. Subsequent registries should use the shared package directly.
 
 ## [0.2.0] - 2026-04-25
 

--- a/agent/prompt.go
+++ b/agent/prompt.go
@@ -69,16 +69,6 @@ func NewPromptTemplate(name, tmpl string) (*PromptTemplate, error) {
 	return &PromptTemplate{tmpl: t}, nil
 }
 
-// MustPromptTemplate is like NewPromptTemplate but panics on parse error.
-// Use for templates known at compile time.
-func MustPromptTemplate(name, tmpl string) *PromptTemplate {
-	pt, err := NewPromptTemplate(name, tmpl)
-	if err != nil {
-		panic(err)
-	}
-	return pt
-}
-
 // Render executes the template with the given data and returns the result.
 func (pt *PromptTemplate) Render(data any) (string, error) {
 	var buf bytes.Buffer
@@ -159,13 +149,4 @@ func (b *PromptBuilder) Build() (string, error) {
 		parts = append(parts, s.content)
 	}
 	return strings.Join(parts, b.separator), nil
-}
-
-// MustBuild is like Build but panics on error.
-func (b *PromptBuilder) MustBuild() string {
-	result, err := b.Build()
-	if err != nil {
-		panic(err)
-	}
-	return result
 }

--- a/agent/prompt_test.go
+++ b/agent/prompt_test.go
@@ -34,17 +34,14 @@ func TestNew_InvalidTemplate(t *testing.T) {
 	}
 }
 
-func TestMustNew_Panics(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for invalid template")
-		}
-	}()
-	agent.MustPromptTemplate("bad", "{{.Unclosed")
+func TestNew_InvalidReturnsError(t *testing.T) {
+	if _, err := agent.NewPromptTemplate("bad", "{{.Unclosed"); err == nil {
+		t.Fatal("expected error for invalid template")
+	}
 }
 
 func TestMustNew_Valid(t *testing.T) {
-	pt := agent.MustPromptTemplate("ok", "static prompt")
+	pt := mustTmpl(t, "ok", "static prompt")
 	got, err := pt.Render(nil)
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -55,7 +52,7 @@ func TestMustNew_Valid(t *testing.T) {
 }
 
 func TestRender_Error(t *testing.T) {
-	pt := agent.MustPromptTemplate("err", "{{.Missing.Field}}")
+	pt := mustTmpl(t, "err", "{{.Missing.Field}}")
 	_, err := pt.Render(struct{}{})
 	if err == nil {
 		t.Fatal("expected render error for missing field")
@@ -66,7 +63,7 @@ func TestRender_Error(t *testing.T) {
 }
 
 func TestRenderToMessage(t *testing.T) {
-	pt := agent.MustPromptTemplate("sys", "You are {{.Role}}.")
+	pt := mustTmpl(t, "sys", "You are {{.Role}}.")
 	msg, err := pt.RenderToMessage(struct{ Role string }{"a helpful assistant"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -84,7 +81,7 @@ func TestRenderToMessage(t *testing.T) {
 }
 
 func TestRenderToMessage_Error(t *testing.T) {
-	pt := agent.MustPromptTemplate("err", "{{.Missing.Field}}")
+	pt := mustTmpl(t, "err", "{{.Missing.Field}}")
 	_, err := pt.RenderToMessage(struct{}{})
 	if err == nil {
 		t.Fatal("expected error")
@@ -94,7 +91,7 @@ func TestRenderToMessage_Error(t *testing.T) {
 // --- Built-in Function Tests ---
 
 func TestFunc_Join(t *testing.T) {
-	pt := agent.MustPromptTemplate("join", `{{join .Items ", "}}`)
+	pt := mustTmpl(t, "join", `{{join .Items ", "}}`)
 	got, err := pt.Render(struct{ Items []string }{[]string{"a", "b", "c"}})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -105,7 +102,7 @@ func TestFunc_Join(t *testing.T) {
 }
 
 func TestFunc_Upper(t *testing.T) {
-	pt := agent.MustPromptTemplate("upper", `{{upper .Text}}`)
+	pt := mustTmpl(t, "upper", `{{upper .Text}}`)
 	got, err := pt.Render(struct{ Text string }{"hello"})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -116,7 +113,7 @@ func TestFunc_Upper(t *testing.T) {
 }
 
 func TestFunc_Lower(t *testing.T) {
-	pt := agent.MustPromptTemplate("lower", `{{lower .Text}}`)
+	pt := mustTmpl(t, "lower", `{{lower .Text}}`)
 	got, err := pt.Render(struct{ Text string }{"HELLO"})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -127,7 +124,7 @@ func TestFunc_Lower(t *testing.T) {
 }
 
 func TestFunc_Trim(t *testing.T) {
-	pt := agent.MustPromptTemplate("trim", `{{trim .Text}}`)
+	pt := mustTmpl(t, "trim", `{{trim .Text}}`)
 	got, err := pt.Render(struct{ Text string }{"  hello  "})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -138,7 +135,7 @@ func TestFunc_Trim(t *testing.T) {
 }
 
 func TestFunc_Indent(t *testing.T) {
-	pt := agent.MustPromptTemplate("indent", `{{indent 4 .Text}}`)
+	pt := mustTmpl(t, "indent", `{{indent 4 .Text}}`)
 	got, err := pt.Render(struct{ Text string }{"line1\nline2\nline3"})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -150,7 +147,7 @@ func TestFunc_Indent(t *testing.T) {
 }
 
 func TestFunc_Indent_PreservesBlankLines(t *testing.T) {
-	pt := agent.MustPromptTemplate("indent-blank", `{{indent 2 .Text}}`)
+	pt := mustTmpl(t, "indent-blank", `{{indent 2 .Text}}`)
 	got, err := pt.Render(struct{ Text string }{"a\n\nb"})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -162,7 +159,7 @@ func TestFunc_Indent_PreservesBlankLines(t *testing.T) {
 }
 
 func TestFunc_ToJSON(t *testing.T) {
-	pt := agent.MustPromptTemplate("json", `{{toJSON .Data}}`)
+	pt := mustTmpl(t, "json", `{{toJSON .Data}}`)
 	data := struct {
 		Data map[string]string
 	}{
@@ -178,7 +175,7 @@ func TestFunc_ToJSON(t *testing.T) {
 }
 
 func TestFunc_Default_UsesValue(t *testing.T) {
-	pt := agent.MustPromptTemplate("def-val", `{{default "fallback" .Name}}`)
+	pt := mustTmpl(t, "def-val", `{{default "fallback" .Name}}`)
 	got, err := pt.Render(struct{ Name string }{"Alice"})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -189,7 +186,7 @@ func TestFunc_Default_UsesValue(t *testing.T) {
 }
 
 func TestFunc_Default_UsesFallback(t *testing.T) {
-	pt := agent.MustPromptTemplate("def-fb", `{{default "fallback" .Name}}`)
+	pt := mustTmpl(t, "def-fb", `{{default "fallback" .Name}}`)
 	got, err := pt.Render(struct{ Name string }{""})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -200,7 +197,7 @@ func TestFunc_Default_UsesFallback(t *testing.T) {
 }
 
 func TestFunc_Default_NilUsesFallback(t *testing.T) {
-	pt := agent.MustPromptTemplate("def-nil", `{{default "none" .Val}}`)
+	pt := mustTmpl(t, "def-nil", `{{default "none" .Val}}`)
 	got, err := pt.Render(map[string]any{"Val": nil})
 	if err != nil {
 		t.Fatalf("render error: %v", err)
@@ -268,7 +265,7 @@ func TestPromptBuilder_SectionIf_False(t *testing.T) {
 }
 
 func TestPromptBuilder_SectionTemplate(t *testing.T) {
-	tmpl := agent.MustPromptTemplate("ctx", "Current page: {{.Page}}")
+	tmpl := mustTmpl(t, "ctx", "Current page: {{.Page}}")
 	got, err := agent.NewPromptBuilder().
 		Section("role", "You are a page assistant.").
 		SectionTemplate("context", tmpl, struct{ Page string }{"Home"}).
@@ -283,7 +280,7 @@ func TestPromptBuilder_SectionTemplate(t *testing.T) {
 }
 
 func TestPromptBuilder_SectionTemplate_Error(t *testing.T) {
-	tmpl := agent.MustPromptTemplate("bad", "{{.Missing.Deep}}")
+	tmpl := mustTmpl(t, "bad", "{{.Missing.Deep}}")
 	_, err := agent.NewPromptBuilder().
 		SectionTemplate("broken", tmpl, struct{}{}).
 		Build()
@@ -305,31 +302,32 @@ func TestPromptBuilder_Empty(t *testing.T) {
 	}
 }
 
-func TestPromptBuilder_MustBuild(t *testing.T) {
-	got := agent.NewPromptBuilder().
+func TestPromptBuilder_Build(t *testing.T) {
+	got, err := agent.NewPromptBuilder().
 		Section("a", "hello").
-		MustBuild()
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
 	if got != "hello" {
 		t.Errorf("got %q, want %q", got, "hello")
 	}
 }
 
-func TestPromptBuilder_MustBuild_Panics(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic from MustBuild")
-		}
-	}()
-	tmpl := agent.MustPromptTemplate("bad", "{{.Missing.Deep}}")
-	agent.NewPromptBuilder().
+func TestPromptBuilder_Build_PropagatesError(t *testing.T) {
+	tmpl := mustTmpl(t, "bad", "{{.Missing.Deep}}")
+	_, err := agent.NewPromptBuilder().
 		SectionTemplate("broken", tmpl, struct{}{}).
-		MustBuild()
+		Build()
+	if err == nil {
+		t.Fatal("expected Build to propagate template render error")
+	}
 }
 
 // --- Integration: Config with SystemPromptTemplate ---
 
 func TestConfig_SystemPromptTemplate(t *testing.T) {
-	tmpl := agent.MustPromptTemplate("sys", "You help with {{.Topic}}. Be {{.Style}}.")
+	tmpl := mustTmpl(t, "sys", "You help with {{.Topic}}. Be {{.Style}}.")
 	data := struct {
 		Topic string
 		Style string
@@ -346,7 +344,7 @@ func TestConfig_SystemPromptTemplate(t *testing.T) {
 }
 
 func TestPromptTemplate_ComplexExample(t *testing.T) {
-	tmpl := agent.MustPromptTemplate("complex", `You are a {{.Role}} assistant.
+	tmpl := mustTmpl(t, "complex", `You are a {{.Role}} assistant.
 {{- if .Tools}}
 
 Available tools:
@@ -384,4 +382,14 @@ Rules:
 	if !strings.Contains(got, "- Be concise") {
 		t.Errorf("should contain rules, got %q", got)
 	}
+}
+
+// mustTmpl parses a template, failing the test on error.
+func mustTmpl(tb testing.TB, name, src string) *agent.PromptTemplate {
+tb.Helper()
+pt, err := agent.NewPromptTemplate(name, src)
+if err != nil {
+tb.Fatalf("NewPromptTemplate(%q): %v", name, err)
+}
+return pt
 }

--- a/auth/authctx/context.go
+++ b/auth/authctx/context.go
@@ -10,7 +10,8 @@
 //
 //	// Retrieve claims (in handlers)
 //	claims, ok := authctx.Get[*MyClaims](ctx)
-//	claims := authctx.MustGet[*MyClaims](ctx) // panics if missing
+//	// or, with a propagated error:
+//	claims, err := authctx.GetOrError[*MyClaims](ctx)
 package authctx
 
 import (
@@ -41,17 +42,6 @@ func Get[T any](ctx context.Context) (T, bool) {
 	}
 	claims, ok := val.(T)
 	return claims, ok
-}
-
-// MustGet retrieves typed authentication claims from the context.
-//
-// For use in tests and application startup only; never call from HTTP handlers or middleware.
-func MustGet[T any](ctx context.Context) T {
-	claims, ok := Get[T](ctx)
-	if !ok {
-		panic("authctx: claims not found in context or wrong type")
-	}
-	return claims
 }
 
 // ErrNoClaims is returned when claims are not found in the context.

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -6,7 +6,10 @@ toolchain go1.26.2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/kbukum/gokit v0.2.0
 	golang.org/x/crypto v0.50.0
 )
 
 require golang.org/x/sys v0.43.0 // indirect
+
+replace github.com/kbukum/gokit => ../

--- a/auth/registry.go
+++ b/auth/registry.go
@@ -3,95 +3,88 @@ package auth
 import (
 	"fmt"
 	"sync"
+
+	"github.com/kbukum/gokit/registry"
 )
 
 // Registry is a thread-safe registry of named TokenValidator instances.
 // Projects register their validators (JWT, OIDC, API key, etc.) by name
 // and retrieve them in middleware or interceptors.
 //
+// Registry is a thin wrapper around the shared
+// [github.com/kbukum/gokit/registry.Registry] type that adds
+// auth-specific "default validator" semantics.
+//
 // Usage:
 //
 //	reg := auth.NewRegistry()
-//	reg.Register("jwt", jwtSvc.AsValidator())
-//	reg.Register("apikey", auth.TokenValidatorFunc(myAPIKeyValidator))
-//	reg.SetDefault("jwt")
+//	if err := reg.Register("jwt", jwtSvc.AsValidator()); err != nil { ... }
+//	if err := reg.Register("apikey", auth.TokenValidatorFunc(myAPIKeyValidator)); err != nil { ... }
+//	if err := reg.SetDefault("jwt"); err != nil { ... }
 //
 //	// In middleware setup
 //	validator, _ := reg.Default()
 type Registry struct {
+	inner       *registry.Registry[TokenValidator]
 	mu          sync.RWMutex
-	validators  map[string]TokenValidator
 	defaultName string
 }
 
 // NewRegistry creates a new empty Registry.
 func NewRegistry() *Registry {
-	return &Registry{
-		validators: make(map[string]TokenValidator),
-	}
+	return &Registry{inner: registry.New[TokenValidator]("auth")}
 }
 
-// Register adds a named TokenValidator to the registry.
-// If this is the first validator registered, it becomes the default.
-func (r *Registry) Register(name string, v TokenValidator) {
+// Register adds a named TokenValidator. It returns an error if name is
+// empty, the validator is nil, or name is already registered. If this is
+// the first successful registration, the validator becomes the default.
+//
+// Note: prior versions silently overwrote duplicates and returned no error.
+// Callers that relied on this behavior must Unregister or use a fresh
+// Registry.
+func (r *Registry) Register(name string, v TokenValidator) error {
+	if err := r.inner.Register(name, v); err != nil {
+		return err
+	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.validators[name] = v
 	if r.defaultName == "" {
 		r.defaultName = name
 	}
+	r.mu.Unlock()
+	return nil
 }
 
 // Get returns the TokenValidator registered under the given name.
 // Returns nil and false if not found.
 func (r *Registry) Get(name string) (TokenValidator, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	v, ok := r.validators[name]
-	return v, ok
-}
-
-// MustGet returns the TokenValidator registered under the given name.
-// Panics if the name is not registered.
-func (r *Registry) MustGet(name string) TokenValidator {
-	v, ok := r.Get(name)
-	if !ok {
-		panic(fmt.Sprintf("auth: validator %q not registered", name))
-	}
-	return v
+	return r.inner.Get(name)
 }
 
 // Default returns the default TokenValidator.
 // The default is the first registered validator unless overridden with SetDefault.
 func (r *Registry) Default() (TokenValidator, bool) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.defaultName == "" {
+	name := r.defaultName
+	r.mu.RUnlock()
+	if name == "" {
 		return nil, false
 	}
-	v, ok := r.validators[r.defaultName]
-	return v, ok
+	return r.inner.Get(name)
 }
 
 // SetDefault sets the default validator by name.
 // The name must already be registered.
 func (r *Registry) SetDefault(name string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, ok := r.validators[name]; !ok {
+	if _, ok := r.inner.Get(name); !ok {
 		return fmt.Errorf("auth: validator %q not registered", name)
 	}
+	r.mu.Lock()
 	r.defaultName = name
+	r.mu.Unlock()
 	return nil
 }
 
-// Names returns all registered validator names.
+// Names returns all registered validator names in deterministic (sorted) order.
 func (r *Registry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.validators))
-	for name := range r.validators {
-		names = append(names, name)
-	}
-	return names
+	return r.inner.Names()
 }

--- a/di/container.go
+++ b/di/container.go
@@ -462,18 +462,6 @@ func (c *UnifiedContainer) GetResolver(name string) func() (interface{}, error) 
 	}
 }
 
-// MustResolve resolves name and panics on failure. Prefer the generic
-// package-level [MustResolve] helper for type-safe resolution; this method
-// exists for callers that hold only the [Container] interface and need an
-// untyped panic-on-error variant (e.g., framework wiring code).
-func (c *UnifiedContainer) MustResolve(name string) interface{} {
-	instance, err := c.Resolve(name)
-	if err != nil {
-		panic(err)
-	}
-	return instance
-}
-
 // Helper functions and options
 func WithRetryPolicy(policy *RetryPolicy) LazyOption {
 	return func(reg *ComponentRegistration) {

--- a/di/typed.go
+++ b/di/typed.go
@@ -1,0 +1,128 @@
+package di
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Key is a type-parameterised handle for a DI registration. It binds a
+// human-readable name to a concrete Go type T at compile time so that
+// registration and resolution cannot disagree on the value type without a
+// compiler error.
+//
+// Keys are values; create them with [NameKey] (typically as package-level
+// vars in a "names" or "wiring" package) and reuse them across providers
+// and consumers.
+//
+//	var loggerKey = di.NameKey[*logger.Logger]("logger")
+//
+//	di.Provide(c, loggerKey, func() (*logger.Logger, error) { return logger.New(...) })
+//	log, err := di.ResolveKey(c, loggerKey)
+//
+// See OSS-review issue F-013 / #43.
+type Key[T any] struct {
+	name string
+}
+
+// NameKey returns a typed key for the given name. The type parameter T fixes
+// the value type of every Provide/Resolve that uses this key.
+func NameKey[T any](name string) Key[T] { return Key[T]{name: name} }
+
+// Name returns the underlying string name of the key. Useful for error
+// messages and introspection only; consumers should use [ResolveKey], not
+// raw string lookups, for type safety.
+func (k Key[T]) Name() string { return k.name }
+
+// fullKey returns the unique container key for k, qualified by the concrete
+// element type of T. Two Key[T]s with different T but the same name produce
+// distinct container slots, so a Key[*Foo]("svc") and Key[*Bar]("svc")
+// coexist without collision.
+func (k Key[T]) fullKey() string {
+	t := reflect.TypeOf((*T)(nil)).Elem()
+	return t.String() + ":" + k.name
+}
+
+// Provide registers a constructor for k. The constructor must return either
+// (T) or (T, error); registration fails if the constructor does not produce
+// the expected type. Component initialisation is lazy (matching the existing
+// [Container.Register] semantics).
+func Provide[T any](c Container, k Key[T], ctor any) error {
+	if c == nil {
+		return fmt.Errorf("di: container is nil")
+	}
+	if ctor == nil {
+		return fmt.Errorf("di: constructor for %s must not be nil", k.fullKey())
+	}
+	if err := validateCtor[T](ctor); err != nil {
+		return fmt.Errorf("di: provide %s: %w", k.fullKey(), err)
+	}
+	return c.Register(k.fullKey(), ctor)
+}
+
+// ProvideSingleton registers a pre-constructed value for k.
+func ProvideSingleton[T any](c Container, k Key[T], v T) error {
+	if c == nil {
+		return fmt.Errorf("di: container is nil")
+	}
+	return c.RegisterSingleton(k.fullKey(), v)
+}
+
+// ResolveKey resolves k from c and returns the typed value. It returns an
+// error if the key is not registered or if the resolved value's type does
+// not match T (which can only happen if the container was modified through
+// the legacy untyped API).
+func ResolveKey[T any](c Container, k Key[T]) (T, error) {
+	var zero T
+	if c == nil {
+		return zero, fmt.Errorf("di: container is nil")
+	}
+	v, err := c.Resolve(k.fullKey())
+	if err != nil {
+		return zero, fmt.Errorf("di: resolve %s: %w", k.fullKey(), err)
+	}
+	out, ok := v.(T)
+	if !ok {
+		return zero, fmt.Errorf("di: %s is %T, expected %T", k.fullKey(), v, zero)
+	}
+	return out, nil
+}
+
+// MustResolveKey is the panic-on-error variant of [ResolveKey]. Reserved
+// for application startup / init / test / CLI use; do not call from
+// request-scoped code.
+func MustResolveKey[T any](c Container, k Key[T]) T {
+	v, err := ResolveKey(c, k)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// validateCtor checks that ctor is a function returning either T or
+// (T, error), accepting either no arguments, a single context.Context, or a
+// single Container — matching what [UnifiedContainer.callConstructor]
+// understands.
+func validateCtor[T any](ctor any) error {
+	fn := reflect.TypeOf(ctor)
+	if fn == nil || fn.Kind() != reflect.Func {
+		return fmt.Errorf("constructor must be a function, got %T", ctor)
+	}
+	switch fn.NumOut() {
+	case 1:
+		// must return T (or assignable)
+	case 2:
+		// must return (T, error)
+		errIface := reflect.TypeOf((*error)(nil)).Elem()
+		if !fn.Out(1).Implements(errIface) {
+			return fmt.Errorf("second return must be error, got %s", fn.Out(1))
+		}
+	default:
+		return fmt.Errorf("constructor must return (T) or (T, error), got %d returns", fn.NumOut())
+	}
+	want := reflect.TypeOf((*T)(nil)).Elem()
+	got := fn.Out(0)
+	if !got.AssignableTo(want) {
+		return fmt.Errorf("constructor returns %s, not assignable to %s", got, want)
+	}
+	return nil
+}

--- a/di/typed_test.go
+++ b/di/typed_test.go
@@ -1,0 +1,172 @@
+package di_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/di"
+)
+
+type svc struct{ N int }
+type other struct{ N int }
+
+var (
+	svcKey   = di.NameKey[*svc]("svc")
+	otherKey = di.NameKey[*other]("svc") // same name, different type — must not collide
+	intKey   = di.NameKey[int]("count")
+)
+
+func TestProvide_ResolveKey(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.Provide(c, svcKey, func() (*svc, error) {
+		return &svc{N: 42}, nil
+	}); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	got, err := di.ResolveKey(c, svcKey)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if got.N != 42 {
+		t.Fatalf("got.N = %d want 42", got.N)
+	}
+}
+
+func TestProvide_NoErrorReturn(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.Provide(c, svcKey, func() *svc { return &svc{N: 7} }); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	got, err := di.ResolveKey(c, svcKey)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if got.N != 7 {
+		t.Fatalf("got.N = %d want 7", got.N)
+	}
+}
+
+func TestProvide_KeysWithSameNameDistinctTypes(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.Provide(c, svcKey, func() *svc { return &svc{N: 1} }); err != nil {
+		t.Fatalf("Provide svc: %v", err)
+	}
+	if err := di.Provide(c, otherKey, func() *other { return &other{N: 2} }); err != nil {
+		t.Fatalf("Provide other (same name, different T): %v", err)
+	}
+	s, err := di.ResolveKey(c, svcKey)
+	if err != nil || s.N != 1 {
+		t.Fatalf("svc = %+v, err=%v", s, err)
+	}
+	o, err := di.ResolveKey(c, otherKey)
+	if err != nil || o.N != 2 {
+		t.Fatalf("other = %+v, err=%v", o, err)
+	}
+}
+
+func TestProvideSingleton(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.ProvideSingleton(c, intKey, 99); err != nil {
+		t.Fatalf("ProvideSingleton: %v", err)
+	}
+	v, err := di.ResolveKey(c, intKey)
+	if err != nil || v != 99 {
+		t.Fatalf("got %d,%v want 99,nil", v, err)
+	}
+}
+
+func TestProvide_RejectsBadCtor(t *testing.T) {
+	c := di.NewContainer()
+	cases := []struct {
+		name string
+		ctor any
+	}{
+		{"not a function", "hello"},
+		{"wrong return type", func() *other { return &other{} }},
+		{"too many returns", func() (*svc, error, int) { return nil, nil, 0 }},
+		{"second not error", func() (*svc, *svc) { return nil, nil }},
+		{"nil ctor", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := di.Provide(c, svcKey, tc.ctor); err == nil {
+				t.Fatalf("expected error for %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestResolveKey_NotRegistered(t *testing.T) {
+	c := di.NewContainer()
+	if _, err := di.ResolveKey(c, svcKey); err == nil {
+		t.Fatal("expected error for unregistered key")
+	} else if !strings.Contains(err.Error(), "svc") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveKey_PropagatesCtorError(t *testing.T) {
+	c := di.NewContainer()
+	want := errors.New("boom")
+	if err := di.Provide(c, svcKey, func() (*svc, error) { return nil, want }); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	_, err := di.ResolveKey(c, svcKey)
+	if err == nil {
+		t.Fatal("expected ResolveKey to return ctor error")
+	}
+}
+
+func TestProvide_NilContainer(t *testing.T) {
+	if err := di.Provide(nil, svcKey, func() *svc { return nil }); err == nil {
+		t.Fatal("expected error for nil container")
+	}
+	if _, err := di.ResolveKey[*svc](nil, svcKey); err == nil {
+		t.Fatal("expected error for nil container")
+	}
+}
+
+func TestKey_Name(t *testing.T) {
+	if svcKey.Name() != "svc" {
+		t.Fatalf("Name() = %q want svc", svcKey.Name())
+	}
+}
+
+// Verify that the typed surface coexists with the legacy string-keyed API:
+// resolution through Provide does not pollute the string namespace.
+func TestProvide_NoStringNamespaceCollision(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.Provide(c, svcKey, func() *svc { return &svc{N: 1} }); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	// The bare name "svc" must not be resolvable — the typed key qualifies it.
+	if _, err := c.Resolve("svc"); err == nil {
+		t.Fatal("expected raw string \"svc\" to be unregistered (typed key qualifies it)")
+	}
+}
+
+func TestMustResolveKey(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.Provide(c, svcKey, func() *svc { return &svc{N: 5} }); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	got := di.MustResolveKey(c, svcKey)
+	if got.N != 5 {
+		t.Fatalf("MustResolveKey = %+v", got)
+	}
+}
+
+// Sanity: context.Context is a tricky generic type — ensure Key[context.Context]
+// works (pure compile-time check + a noop resolve).
+func TestKey_ContextType(t *testing.T) {
+	ctxKey := di.NameKey[context.Context]("ctx")
+	c := di.NewContainer()
+	if err := di.ProvideSingleton(c, ctxKey, context.Background()); err != nil {
+		t.Fatalf("ProvideSingleton: %v", err)
+	}
+	if _, err := di.ResolveKey(c, ctxKey); err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+}

--- a/discovery/component.go
+++ b/discovery/component.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/kbukum/gokit/component"
 	"github.com/kbukum/gokit/logger"
+	"github.com/kbukum/gokit/registry"
 )
 
 // ProviderFactory creates a Registry and Discovery pair from a Config.
@@ -18,39 +18,25 @@ type ProviderFactory func(cfg Config, log *logger.Logger) (Registry, Discovery, 
 
 // ProviderRegistry stores discovery provider factories by name.
 type ProviderRegistry struct {
-	mu        sync.RWMutex
-	factories map[string]ProviderFactory
+	inner *registry.Registry[ProviderFactory]
 }
 
 // NewProviderRegistry creates an isolated discovery provider registry.
 func NewProviderRegistry() *ProviderRegistry {
-	return &ProviderRegistry{factories: make(map[string]ProviderFactory)}
+	return &ProviderRegistry{inner: registry.New[ProviderFactory]("discovery")}
 }
 
 // Register stores a discovery provider factory.
-// It panics for invalid input or duplicate names.
-func (r *ProviderRegistry) Register(name string, f ProviderFactory) {
-	if name == "" {
-		panic("discovery: provider name cannot be empty")
-	}
-	if f == nil {
-		panic(fmt.Sprintf("discovery: factory %q cannot be nil", name))
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.factories[name]; exists {
-		panic(fmt.Sprintf("discovery: provider factory %q already registered", name))
-	}
-	r.factories[name] = f
+// It returns an error for invalid input (empty name, nil factory) or duplicate names.
+//
+// Note: prior versions panicked; callers must now check the returned error.
+func (r *ProviderRegistry) Register(name string, f ProviderFactory) error {
+	return r.inner.Register(name, f)
 }
 
 // Get returns a discovery provider factory by name.
 func (r *ProviderRegistry) Get(name string) (ProviderFactory, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	f, ok := r.factories[name]
-	return f, ok
+	return r.inner.Get(name)
 }
 
 // Component wraps a Registry and Discovery pair and implements
@@ -81,22 +67,22 @@ func WithIPProbeTarget(addr string) ComponentOption {
 }
 
 // NewComponent creates a discovery Component for use with the component registry.
-// registry must not be nil; panics if it is.
-func NewComponent(registry *ProviderRegistry, cfg Config, log *logger.Logger, opts ...ComponentOption) *Component {
-	if registry == nil {
-		panic("discovery: provider registry must not be nil")
+// reg must not be nil; an error is returned if it is.
+func NewComponent(reg *ProviderRegistry, cfg Config, log *logger.Logger, opts ...ComponentOption) (*Component, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("discovery: provider registry must not be nil")
 	}
 	c := &Component{
 		cfg:           cfg,
 		log:           log.WithComponent("discovery"),
-		providers:     registry,
+		providers:     reg,
 		localIPFinder: defaultLocalIPFinder,
 		ipProbeTarget: "",
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
-	return c
+	return c, nil
 }
 
 // ensure Component satisfies component.Component.

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -24,8 +24,9 @@ type Provider struct {
 }
 
 // Register registers the consul discovery provider into the given registry.
-func Register(registry *discovery.ProviderRegistry) {
-	registry.Register("consul", func(cfg discovery.Config, log *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
+// It returns an error if "consul" is already registered.
+func Register(reg *discovery.ProviderRegistry) error {
+	return reg.Register("consul", func(cfg discovery.Config, log *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
 		// Build consul config from generic Config fields + ProviderOptions
 		consulCfg := &Config{
 			Addr:   cfg.Addr,

--- a/discovery/registry_test.go
+++ b/discovery/registry_test.go
@@ -6,14 +6,12 @@ import (
 	"github.com/kbukum/gokit/logger"
 )
 
-func TestProviderRegistry_RegisterDuplicatePanics(t *testing.T) {
+func TestProviderRegistry_RegisterDuplicateErrors(t *testing.T) {
 	r := NewProviderRegistry()
-	r.Register("static", func(Config, *logger.Logger) (Registry, Discovery, error) { return nil, nil, nil })
-
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic on duplicate provider registration")
-		}
-	}()
-	r.Register("static", func(Config, *logger.Logger) (Registry, Discovery, error) { return nil, nil, nil })
+	if err := r.Register("static", func(Config, *logger.Logger) (Registry, Discovery, error) { return nil, nil, nil }); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := r.Register("static", func(Config, *logger.Logger) (Registry, Discovery, error) { return nil, nil, nil }); err == nil {
+		t.Fatal("expected error on duplicate provider registration")
+	}
 }

--- a/discovery/static/static.go
+++ b/discovery/static/static.go
@@ -18,14 +18,17 @@ type Provider struct {
 }
 
 // Register registers the static and k8s discovery providers into the given registry.
-func Register(registry *discovery.ProviderRegistry) {
-	registry.Register("static", func(cfg discovery.Config, _ *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
+// It returns an error if either provider name is already registered.
+func Register(reg *discovery.ProviderRegistry) error {
+	if err := reg.Register("static", func(cfg discovery.Config, _ *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
 		p := NewProvider(cfg.StaticEndpoints)
 		return p, p, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	// k8s uses the static provider as a fallback.
-	registry.Register("k8s", func(cfg discovery.Config, _ *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
+	return reg.Register("k8s", func(cfg discovery.Config, _ *logger.Logger) (discovery.Registry, discovery.Discovery, error) {
 		p := NewProvider(cfg.StaticEndpoints)
 		return p, p, nil
 	})

--- a/llm/adapter_test.go
+++ b/llm/adapter_test.go
@@ -94,7 +94,7 @@ func (d *mockDialect) ParseStreamChunk(data []byte) (StreamChunk, error) {
 func TestAdapter_New_WithDialect(t *testing.T) {
 	// Register a mock dialect
 	reg := NewDialectRegistry()
-	reg.MustRegister("mock", &mockDialect{})
+	mustReg(t, reg, "mock", &mockDialect{})
 
 	a, err := New(reg, Config{
 		Dialect: "mock",

--- a/llm/dialect.go
+++ b/llm/dialect.go
@@ -2,7 +2,8 @@ package llm
 
 import (
 	"fmt"
-	"sync"
+
+	"github.com/kbukum/gokit/registry"
 )
 
 // StreamFormat indicates how a provider delivers streaming responses.
@@ -60,59 +61,30 @@ type Dialect interface {
 // application startup. Pass the populated registry to [NewWithRegistry]
 // to create an [Adapter] that resolves its dialect from the registry.
 type DialectRegistry struct {
-	mu       sync.RWMutex
-	dialects map[string]Dialect
+	inner *registry.Registry[Dialect]
 }
 
 // NewDialectRegistry creates an isolated dialect registry.
 func NewDialectRegistry() *DialectRegistry {
-	return &DialectRegistry{dialects: make(map[string]Dialect)}
+	return &DialectRegistry{inner: registry.New[Dialect]("llm")}
 }
 
 // Register adds a dialect to the registry. It returns an error on
 // programmer errors (empty name, nil dialect, duplicate name).
 func (r *DialectRegistry) Register(name string, d Dialect) error {
-	if name == "" {
-		return fmt.Errorf("llm: dialect name cannot be empty")
-	}
-	if d == nil {
-		return fmt.Errorf("llm: dialect %q cannot be nil", name)
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.dialects[name]; exists {
-		return fmt.Errorf("llm: dialect %q already registered", name)
-	}
-	r.dialects[name] = d
-	return nil
-}
-
-// MustRegister is like [DialectRegistry.Register] but panics on error.
-// Intended for application startup where a failed registration is fatal.
-func (r *DialectRegistry) MustRegister(name string, d Dialect) {
-	if err := r.Register(name, d); err != nil {
-		panic(err)
-	}
+	return r.inner.Register(name, d)
 }
 
 // Get retrieves a dialect by name.
 func (r *DialectRegistry) Get(name string) (Dialect, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	d, ok := r.dialects[name]
+	d, ok := r.inner.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("llm: unknown dialect %q (forgot to register?)", name)
 	}
 	return d, nil
 }
 
-// Names returns the names of all registered dialects.
+// Names returns the names of all registered dialects in deterministic order.
 func (r *DialectRegistry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.dialects))
-	for name := range r.dialects {
-		names = append(names, name)
-	}
-	return names
+	return r.inner.Names()
 }

--- a/llm/dialect_test.go
+++ b/llm/dialect_test.go
@@ -39,8 +39,8 @@ func TestDialectRegistry_Names(t *testing.T) {
 	t.Parallel()
 
 	reg := NewDialectRegistry()
-	reg.MustRegister("alpha", &mockDialect{name: "alpha"})
-	reg.MustRegister("beta", &mockDialect{name: "beta"})
+	mustReg(t, reg, "alpha", &mockDialect{name: "alpha"})
+	mustReg(t, reg, "beta", &mockDialect{name: "beta"})
 
 	names := reg.Names()
 	sort.Strings(names)
@@ -78,16 +78,10 @@ func TestDialectRegistry_RejectNilOrEmpty(t *testing.T) {
 	}
 }
 
-func TestDialectRegistry_MustRegisterPanicsOnError(t *testing.T) {
-	t.Parallel()
-
-	reg := NewDialectRegistry()
-	reg.MustRegister("ok", &mockDialect{name: "ok"})
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on duplicate MustRegister")
-		}
-	}()
-	reg.MustRegister("ok", &mockDialect{name: "ok"})
+// mustReg registers d on reg, failing the test on error.
+func mustReg(tb testing.TB, reg *DialectRegistry, name string, d Dialect) {
+	tb.Helper()
+	if err := reg.Register(name, d); err != nil {
+		tb.Fatalf("register %q: %v", name, err)
+	}
 }

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -13,7 +13,7 @@
 // # Server Example
 //
 //	registry := tool.NewRegistry()
-//	registry.MustRegister(myTool.AsCallable())
+//	if err := registry.Register(myTool.AsCallable()); err != nil { return err }
 //
 //	server := mcpkit.NewServer("my-service", "1.0.0", registry)
 //	server.Run(ctx, &mcp.StdioTransport{})

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -46,7 +46,7 @@ func failHandler(_ context.Context, _ struct{}) (struct{}, error) {
 func newTestRegistry(t *testing.T) *tool.Registry {
 	t.Helper()
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("add", "Add two numbers", addHandler).AsCallable())
+	mustReg(t, reg, tool.FromFunc("add", "Add two numbers", addHandler).AsCallable())
 
 	greetTool := tool.FromFunc("greet", "Greet someone", greetHandler)
 	greetTool.Def.ReadOnly = true
@@ -54,9 +54,9 @@ func newTestRegistry(t *testing.T) *tool.Registry {
 		Title:         "Greeting Tool",
 		OpenWorldHint: boolPtr(false),
 	}
-	reg.MustRegister(greetTool.AsCallable())
+	mustReg(t, reg, greetTool.AsCallable())
 
-	reg.MustRegister(tool.FromFunc("fail", "Always fails", failHandler).AsCallable())
+	mustReg(t, reg, tool.FromFunc("fail", "Always fails", failHandler).AsCallable())
 	return reg
 }
 
@@ -176,7 +176,7 @@ func TestRoundTrip(t *testing.T) {
 func TestServerWithPrefix(t *testing.T) {
 	ctx := context.Background()
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("search", "Search things", greetHandler).AsCallable())
+	mustReg(t, reg, tool.FromFunc("search", "Search things", greetHandler).AsCallable())
 
 	server := kitMcp.NewServer("test", "1.0.0", reg, kitMcp.WithPrefix("svc_"))
 
@@ -208,7 +208,7 @@ func TestServerWithPrefix(t *testing.T) {
 func TestClientWithPrefix(t *testing.T) {
 	ctx := context.Background()
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("calc", "Calculate", addHandler).AsCallable())
+	mustReg(t, reg, tool.FromFunc("calc", "Calculate", addHandler).AsCallable())
 
 	server := kitMcp.NewServer("test", "1.0.0", reg)
 
@@ -257,7 +257,7 @@ func TestClientWithPrefix(t *testing.T) {
 func TestValidation(t *testing.T) {
 	ctx := context.Background()
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("add", "Add numbers", addHandler).AsCallable())
+	mustReg(t, reg, tool.FromFunc("add", "Add numbers", addHandler).AsCallable())
 
 	server := kitMcp.NewServer("test", "1.0.0", reg)
 
@@ -358,7 +358,7 @@ func TestConvertDefinition(t *testing.T) {
 	testTool := tool.FromFunc("test_tool", "A test tool", greetHandler)
 	testTool.Def.ReadOnly = true
 	testTool.Def.Annotations = def.Annotations
-	reg.MustRegister(testTool.AsCallable())
+	mustReg(t, reg, testTool.AsCallable())
 
 	// Verify the definition is correct
 	defs := reg.List()
@@ -380,3 +380,10 @@ func mustJSON(t *testing.T, v any) json.RawMessage {
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+func mustReg(tb testing.TB, reg *tool.Registry, c tool.Callable) {
+tb.Helper()
+if err := reg.Register(c); err != nil {
+tb.Fatalf("register: %v", err)
+}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,120 @@
+// Package registry provides a single, generic, thread-safe named registry
+// used by domain packages (auth, discovery, storage, tool, workload, llm).
+//
+// Domain packages historically each carried their own ad-hoc map+mutex
+// implementation with inconsistent semantics — some panicked on duplicate,
+// some returned an error, and one silently overwrote. This package replaces
+// all of them with a single typed implementation whose Register always
+// returns an error on programmer mistakes (empty name, nil zero value,
+// duplicate name).
+//
+// See OSS-review issue F-015 / #45 and F-016 / #46.
+package registry
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+)
+
+// Registry is a thread-safe map of named values of type T.
+//
+// The zero value is not usable; construct with [New].
+type Registry[T any] struct {
+	domain string
+	mu     sync.RWMutex
+	items  map[string]T
+}
+
+// New creates an empty Registry. The domain string is used in error messages
+// (e.g. "auth", "discovery") so callers can identify which subsystem produced
+// a registration error.
+func New[T any](domain string) *Registry[T] {
+	return &Registry[T]{
+		domain: domain,
+		items:  make(map[string]T),
+	}
+}
+
+// Register adds v under name. It returns an error if name is empty, if v is
+// the zero value of an interface/pointer/func type (nil), or if name is
+// already registered.
+func (r *Registry[T]) Register(name string, v T) error {
+	if name == "" {
+		return fmt.Errorf("%s: name must not be empty", r.domain)
+	}
+	if isNil(v) {
+		return fmt.Errorf("%s: value for %q must not be nil", r.domain, name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.items[name]; exists {
+		return fmt.Errorf("%s: %q already registered", r.domain, name)
+	}
+	r.items[name] = v
+	return nil
+}
+
+// Get returns the value registered under name and a bool indicating whether
+// it was present. Callers that prefer an error should use [Registry.Lookup].
+func (r *Registry[T]) Get(name string) (T, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	v, ok := r.items[name]
+	return v, ok
+}
+
+// Lookup is the error-returning counterpart to [Registry.Get]; intended for
+// call sites that propagate the not-found case as an error.
+func (r *Registry[T]) Lookup(name string) (T, error) {
+	v, ok := r.Get(name)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("%s: %q not registered", r.domain, name)
+	}
+	return v, nil
+}
+
+// Names returns the registered names in deterministic (sorted) order.
+func (r *Registry[T]) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.items))
+	for k := range r.items {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Len returns the number of registered entries.
+func (r *Registry[T]) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.items)
+}
+
+// Each calls fn for every registered entry. Iteration order is unspecified.
+// fn must not call back into the registry (which would deadlock on the
+// underlying RWMutex).
+func (r *Registry[T]) Each(fn func(name string, v T)) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for k, v := range r.items {
+		fn(k, v)
+	}
+}
+
+// isNil reports whether v carries a nil interface/pointer/func/map/chan/slice
+// payload. Plain value types (struct, string, int, bool, ...) are never nil.
+func isNil[T any](v T) bool {
+	rv := reflect.ValueOf(&v).Elem()
+	switch rv.Kind() {
+	case reflect.Interface, reflect.Ptr, reflect.Func,
+		reflect.Map, reflect.Chan, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,127 @@
+package registry_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kbukum/gokit/registry"
+)
+
+type widget struct{ id int }
+
+type factory func() *widget
+
+func TestRegister_Get(t *testing.T) {
+	r := registry.New[*widget]("test")
+	w := &widget{id: 1}
+	if err := r.Register("a", w); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, ok := r.Get("a")
+	if !ok || got != w {
+		t.Fatalf("Get(a) = %v,%v want %v,true", got, ok, w)
+	}
+	if _, ok := r.Get("missing"); ok {
+		t.Fatalf("Get(missing) should be !ok")
+	}
+}
+
+func TestRegister_EmptyName(t *testing.T) {
+	r := registry.New[*widget]("test")
+	err := r.Register("", &widget{})
+	if err == nil || !strings.Contains(err.Error(), "name must not be empty") {
+		t.Fatalf("expected empty-name error, got %v", err)
+	}
+}
+
+func TestRegister_NilValue(t *testing.T) {
+	r := registry.New[*widget]("test")
+	err := r.Register("a", nil)
+	if err == nil || !strings.Contains(err.Error(), "must not be nil") {
+		t.Fatalf("expected nil-value error, got %v", err)
+	}
+
+	rf := registry.New[factory]("test")
+	if err := rf.Register("a", nil); err == nil {
+		t.Fatalf("nil func should error")
+	}
+}
+
+func TestRegister_Duplicate(t *testing.T) {
+	r := registry.New[*widget]("test")
+	if err := r.Register("a", &widget{}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := r.Register("a", &widget{})
+	if err == nil || !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	r := registry.New[*widget]("test")
+	if _, err := r.Lookup("missing"); err == nil {
+		t.Fatalf("Lookup(missing) should error")
+	}
+	w := &widget{id: 7}
+	_ = r.Register("a", w)
+	got, err := r.Lookup("a")
+	if err != nil || got != w {
+		t.Fatalf("Lookup(a) = %v,%v want %v,nil", got, err, w)
+	}
+}
+
+func TestNames_Sorted(t *testing.T) {
+	r := registry.New[*widget]("test")
+	for _, n := range []string{"c", "a", "b"} {
+		_ = r.Register(n, &widget{})
+	}
+	got := r.Names()
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("Names = %v want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("Names[%d]=%q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLen_Each(t *testing.T) {
+	r := registry.New[*widget]("test")
+	_ = r.Register("a", &widget{id: 1})
+	_ = r.Register("b", &widget{id: 2})
+	if r.Len() != 2 {
+		t.Fatalf("Len = %d want 2", r.Len())
+	}
+	sum := 0
+	r.Each(func(_ string, v *widget) { sum += v.id })
+	if sum != 3 {
+		t.Fatalf("Each sum = %d want 3", sum)
+	}
+}
+
+func TestRegister_Concurrent(t *testing.T) {
+	r := registry.New[*widget]("test")
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = r.Register(string(rune('a'+(i%26))), &widget{id: i})
+		}(i)
+	}
+	wg.Wait()
+	if r.Len() < 1 || r.Len() > 26 {
+		t.Fatalf("unexpected Len after concurrent registers: %d", r.Len())
+	}
+}
+
+func TestRegister_NonNilStructValueOK(t *testing.T) {
+	r := registry.New[widget]("test")
+	if err := r.Register("a", widget{id: 1}); err != nil {
+		t.Fatalf("Register struct value: %v", err)
+	}
+}

--- a/server/middleware/tenant.go
+++ b/server/middleware/tenant.go
@@ -55,13 +55,3 @@ func TenantFromContext(ctx context.Context) (string, bool) {
 func SetTenantInContext(ctx context.Context, tenantID string) context.Context {
 	return context.WithValue(ctx, tenantKey, tenantID)
 }
-
-// MustTenantFromContext retrieves the tenant ID from context and panics if missing.
-// For use in tests and application startup only; never call from HTTP handlers or middleware.
-func MustTenantFromContext(ctx context.Context) string {
-	tenantID, ok := TenantFromContext(ctx)
-	if !ok {
-		panic("tenant: ID not found in context")
-	}
-	return tenantID
-}

--- a/server/middleware/tenant_test.go
+++ b/server/middleware/tenant_test.go
@@ -106,26 +106,12 @@ func TestTenantFromContext_NotFound(t *testing.T) {
 	}
 }
 
-func TestMustTenantFromContext_Panics(t *testing.T) {
-	req := httptest.NewRequest("GET", "/test", http.NoBody)
-
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Errorf("Expected panic when tenant not found")
-		}
-	}()
-
-	MustTenantFromContext(req.Context())
-}
-
-func TestMustTenantFromContext_Success(t *testing.T) {
+func TestTenantFromContext_Set(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
 	ctx := context.WithValue(req.Context(), tenantKey, "tenant-456")
-
-	tenantID := MustTenantFromContext(ctx)
-	if tenantID != "tenant-456" {
-		t.Errorf("Expected tenant-456, got %s", tenantID)
+	tenantID, ok := TenantFromContext(ctx)
+	if !ok || tenantID != "tenant-456" {
+		t.Errorf("Expected tenant-456,true; got %s,%v", tenantID, ok)
 	}
 }
 

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -2,9 +2,9 @@ package storage
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/kbukum/gokit/logger"
+	"github.com/kbukum/gokit/registry"
 )
 
 // StorageFactory creates a Storage implementation from core config and
@@ -14,56 +14,44 @@ type StorageFactory func(cfg Config, providerCfg any, log *logger.Logger) (Stora
 
 // FactoryRegistry stores storage factories by provider name.
 type FactoryRegistry struct {
-	mu        sync.RWMutex
-	factories map[string]StorageFactory
+	inner *registry.Registry[StorageFactory]
 }
 
 // NewFactoryRegistry creates an isolated storage factory registry.
 func NewFactoryRegistry() *FactoryRegistry {
-	return &FactoryRegistry{factories: make(map[string]StorageFactory)}
+	return &FactoryRegistry{inner: registry.New[StorageFactory]("storage")}
 }
 
 // Register stores a storage backend factory for the given provider name.
-// It panics if name or factory are invalid, or if a duplicate name is registered.
-func (r *FactoryRegistry) Register(name string, f StorageFactory) {
-	if name == "" {
-		panic("storage: provider name cannot be empty")
-	}
-	if f == nil {
-		panic(fmt.Sprintf("storage: factory %q cannot be nil", name))
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.factories[name]; exists {
-		panic(fmt.Sprintf("storage: factory %q already registered", name))
-	}
-	r.factories[name] = f
+// It returns an error if name or factory are invalid, or if a duplicate
+// name is registered.
+//
+// Note: prior versions panicked on duplicate; callers must now check the
+// returned error.
+func (r *FactoryRegistry) Register(name string, f StorageFactory) error {
+	return r.inner.Register(name, f)
 }
 
 // Get returns a storage factory by provider name.
 func (r *FactoryRegistry) Get(name string) (StorageFactory, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	f, ok := r.factories[name]
-	return f, ok
+	return r.inner.Get(name)
 }
 
 // New creates a Storage implementation using the provided registry.
 // The registry is mandatory; pass an explicit *FactoryRegistry with the desired
 // provider registered (e.g. via local.Register, s3.Register, etc.).
-func New(registry *FactoryRegistry, cfg Config, providerCfg any, log *logger.Logger) (Storage, error) {
+func New(reg *FactoryRegistry, cfg Config, providerCfg any, log *logger.Logger) (Storage, error) {
 	cfg.ApplyDefaults()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	if registry == nil {
+	if reg == nil {
 		return nil, fmt.Errorf("storage: factory registry is nil")
 	}
 
 	l := log.WithComponent("storage")
 
-	f, ok := registry.Get(cfg.Provider)
+	f, ok := reg.Get(cfg.Provider)
 	if !ok {
 		return nil, fmt.Errorf("storage: unsupported provider %q (not registered)", cfg.Provider)
 	}

--- a/storage/local/local.go
+++ b/storage/local/local.go
@@ -26,8 +26,9 @@ func safePath(basePath, path string) (string, error) {
 }
 
 // Register registers the local storage provider into the given registry.
-func Register(registry *storage.FactoryRegistry) {
-	registry.Register(storage.ProviderLocal, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
+// It returns an error if the provider is already registered.
+func Register(reg *storage.FactoryRegistry) error {
+	return reg.Register(storage.ProviderLocal, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
 		c := &Config{}
 		if providerCfg != nil {
 			pc, ok := providerCfg.(*Config)

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -16,8 +16,9 @@ import (
 )
 
 // Register registers the S3 storage provider into the given registry.
-func Register(registry *storage.FactoryRegistry) {
-	registry.Register(storage.ProviderS3, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
+// It returns an error if the provider is already registered.
+func Register(reg *storage.FactoryRegistry) error {
+	return reg.Register(storage.ProviderS3, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
 		c := &Config{}
 		if providerCfg != nil {
 			pc, ok := providerCfg.(*Config)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -199,23 +199,24 @@ func TestNew_UnsupportedProvider(t *testing.T) {
 func TestFactoryRegistry_AddRemove(t *testing.T) {
 	registry := NewFactoryRegistry()
 	//nolint:nilnil // test stub factory: no storage and no error
-	registry.Register("test-provider", func(Config, any, *logger.Logger) (Storage, error) { return nil, nil })
+	if err := registry.Register("test-provider", func(Config, any, *logger.Logger) (Storage, error) { return nil, nil }); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
 	if _, ok := registry.Get("test-provider"); !ok {
 		t.Fatal("expected test-provider registration")
 	}
 }
 
-func TestFactoryRegistry_RegisterDuplicatePanics(t *testing.T) {
+func TestFactoryRegistry_RegisterDuplicateErrors(t *testing.T) {
 	registry := NewFactoryRegistry()
 	//nolint:nilnil // test stub factory: no storage and no error
 	stub := func(Config, any, *logger.Logger) (Storage, error) { return nil, nil }
-	registry.Register("dup", stub)
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic on duplicate registration")
-		}
-	}()
-	registry.Register("dup", stub)
+	if err := registry.Register("dup", stub); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := registry.Register("dup", stub); err == nil {
+		t.Fatal("expected error on duplicate registration")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/storage/supabase/supabase.go
+++ b/storage/supabase/supabase.go
@@ -16,8 +16,9 @@ import (
 )
 
 // Register registers the Supabase storage provider into the given registry.
-func Register(registry *storage.FactoryRegistry) {
-	registry.Register(storage.ProviderSupabase, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
+// It returns an error if the provider is already registered.
+func Register(reg *storage.FactoryRegistry) error {
+	return reg.Register(storage.ProviderSupabase, func(cfg storage.Config, providerCfg any, log *logger.Logger) (storage.Storage, error) {
 		c := &Config{}
 		if providerCfg != nil {
 			pc, ok := providerCfg.(*Config)

--- a/tool/registry.go
+++ b/tool/registry.go
@@ -5,69 +5,46 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/kbukum/gokit/registry"
 )
 
 // Registry manages a collection of callable tools.
 // It is concurrent-safe for reads and writes.
 type Registry struct {
-	tools map[string]Callable
-	mu    sync.RWMutex
+	inner *registry.Registry[Callable]
 }
 
 // NewRegistry creates an empty tool registry.
 func NewRegistry() *Registry {
-	return &Registry{
-		tools: make(map[string]Callable),
-	}
+	return &Registry{inner: registry.New[Callable]("tool")}
 }
 
 // Register adds a tool to the registry.
 // Returns an error if a tool with the same name already exists.
 func (r *Registry) Register(t Callable) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	name := t.Definition().Name
-	if _, exists := r.tools[name]; exists {
-		return fmt.Errorf("tool %q already registered", name)
+	if t == nil {
+		return fmt.Errorf("tool: callable must not be nil")
 	}
-	r.tools[name] = t
-	return nil
-}
-
-// MustRegister registers a tool and panics on error.
-func (r *Registry) MustRegister(t Callable) {
-	if err := r.Register(t); err != nil {
-		panic(err)
-	}
+	return r.inner.Register(t.Definition().Name, t)
 }
 
 // Get retrieves a tool by name.
 func (r *Registry) Get(name string) (Callable, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	t, ok := r.tools[name]
-	return t, ok
+	return r.inner.Get(name)
 }
 
 // List returns the definitions of all registered tools.
 func (r *Registry) List() []Definition {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	defs := make([]Definition, 0, len(r.tools))
-	for _, t := range r.tools {
+	defs := make([]Definition, 0, r.inner.Len())
+	r.inner.Each(func(_ string, t Callable) {
 		defs = append(defs, t.Definition())
-	}
+	})
 	return defs
 }
 
 // Len returns the number of registered tools.
-func (r *Registry) Len() int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return len(r.tools)
-}
+func (r *Registry) Len() int { return r.inner.Len() }
 
 // Call invokes a tool by name with raw JSON input.
 func (r *Registry) Call(ctx *Context, name string, input json.RawMessage) (*Result, error) {
@@ -149,30 +126,20 @@ func (r *Registry) CallBatch(ctx *Context, calls []BatchCall) []BatchResult {
 
 // Names returns the names of all registered tools.
 func (r *Registry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	names := make([]string, 0, len(r.tools))
-	for name := range r.tools {
-		names = append(names, name)
-	}
-	return names
+	return r.inner.Names()
 }
 
 // Search returns definitions matching a keyword query against name and description.
 func (r *Registry) Search(query string) []Definition {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	q := strings.ToLower(query)
 	var result []Definition
-	for _, t := range r.tools {
+	r.inner.Each(func(_ string, t Callable) {
 		def := t.Definition()
 		if strings.Contains(strings.ToLower(def.Name), q) ||
 			strings.Contains(strings.ToLower(def.Description), q) {
 			result = append(result, def)
 		}
-	}
+	})
 	return result
 }
 
@@ -182,17 +149,13 @@ func (r *Registry) Filter(opts ...FilterOption) []Definition {
 	for _, opt := range opts {
 		opt(cfg)
 	}
-
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	var result []Definition
-	for _, t := range r.tools {
+	r.inner.Each(func(_ string, t Callable) {
 		def := t.Definition()
 		if matchesFilter(def, cfg) {
 			result = append(result, def)
 		}
-	}
+	})
 	return result
 }
 

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -308,8 +308,8 @@ func TestRegistry_DuplicateName(t *testing.T) {
 
 func TestRegistry_List(t *testing.T) {
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("a", "Tool A", doSearch).AsCallable())
-	reg.MustRegister(tool.FromFunc("b", "Tool B", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("a", "Tool A", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("b", "Tool B", doSearch).AsCallable())
 
 	defs := reg.List()
 	if len(defs) != 2 {
@@ -319,7 +319,7 @@ func TestRegistry_List(t *testing.T) {
 
 func TestRegistry_Call(t *testing.T) {
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("search", "Search", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("search", "Search", doSearch).AsCallable())
 
 	result, err := reg.Call(tool.Background(), "search", json.RawMessage(`{"query":"test"}`))
 	if err != nil {
@@ -345,9 +345,9 @@ func TestRegistry_CallNotFound(t *testing.T) {
 
 func TestRegistry_Search(t *testing.T) {
 	reg := tool.NewRegistry()
-	reg.MustRegister(tool.FromFunc("search_videos", "Search for videos", doSearch).AsCallable())
-	reg.MustRegister(tool.FromFunc("clip_media", "Clip media content", doSearch).AsCallable())
-	reg.MustRegister(tool.FromFunc("analyze", "Analyze content quality", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("search_videos", "Search for videos", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("clip_media", "Clip media content", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("analyze", "Analyze content quality", doSearch).AsCallable())
 
 	defs := reg.Search("search")
 	if len(defs) != 1 {
@@ -386,10 +386,10 @@ func TestRegistry_CallBatch(t *testing.T) {
 
 	reg := tool.NewRegistry()
 
-	reg.MustRegister(&readOnlyCallable{
+	mustReg(t, reg, &readOnlyCallable{
 		Callable: tool.FromFunc("read_tool", "Reads data", readFn).AsCallable(),
 	})
-	reg.MustRegister(tool.FromFunc("write_tool", "Writes data", writeFn).AsCallable())
+	mustReg(t, reg, tool.FromFunc("write_tool", "Writes data", writeFn).AsCallable())
 
 	calls := []tool.BatchCall{
 		{Name: "read_tool", ID: "c1", Input: json.RawMessage(`{"query":"a"}`)},
@@ -421,13 +421,13 @@ func TestRegistry_CallBatch(t *testing.T) {
 func TestRegistry_Filter(t *testing.T) {
 	reg := tool.NewRegistry()
 
-	reg.MustRegister(tool.FromFunc("search", "Search", doSearch).
+	mustReg(t, reg, tool.FromFunc("search", "Search", doSearch).
 		WithAnnotations(tool.Annotations{Category: "discovery", Tags: []string{"search"}}).
 		AsCallable())
-	reg.MustRegister(tool.FromFunc("clip", "Clip", doSearch).
+	mustReg(t, reg, tool.FromFunc("clip", "Clip", doSearch).
 		WithAnnotations(tool.Annotations{Category: "media"}).
 		AsCallable())
-	reg.MustRegister(tool.FromFunc("other", "Other", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("other", "Other", doSearch).AsCallable())
 
 	defs := reg.Filter(tool.WithCategory("discovery"))
 	if len(defs) != 1 {
@@ -459,16 +459,16 @@ func TestAnnotations_ExecutionHint(t *testing.T) {
 func TestRegistry_FilterByExecutionHint(t *testing.T) {
 	reg := tool.NewRegistry()
 
-	reg.MustRegister(tool.FromFunc("validate", "Validate", doSearch).
+	mustReg(t, reg, tool.FromFunc("validate", "Validate", doSearch).
 		WithAnnotations(tool.Annotations{ExecutionHint: "ui"}).
 		AsCallable())
-	reg.MustRegister(tool.FromFunc("process", "Process", doSearch).
+	mustReg(t, reg, tool.FromFunc("process", "Process", doSearch).
 		WithAnnotations(tool.Annotations{ExecutionHint: "backend"}).
 		AsCallable())
-	reg.MustRegister(tool.FromFunc("submit", "Submit", doSearch).
+	mustReg(t, reg, tool.FromFunc("submit", "Submit", doSearch).
 		WithAnnotations(tool.Annotations{ExecutionHint: "hybrid"}).
 		AsCallable())
-	reg.MustRegister(tool.FromFunc("plain", "Plain", doSearch).AsCallable())
+	mustReg(t, reg, tool.FromFunc("plain", "Plain", doSearch).AsCallable())
 
 	defs := reg.Filter(tool.WithExecutionHint("ui"))
 	if len(defs) != 1 || defs[0].Name != "validate" {
@@ -617,4 +617,12 @@ func TestAsProvider(t *testing.T) {
 	if out.Total != 2 {
 		t.Errorf("expected total=2, got %d", out.Total)
 	}
+}
+
+// mustReg registers t on reg, failing the test on error.
+func mustReg(tb testing.TB, reg *tool.Registry, c tool.Callable) {
+tb.Helper()
+if err := reg.Register(c); err != nil {
+tb.Fatalf("register: %v", err)
+}
 }

--- a/workload/factory.go
+++ b/workload/factory.go
@@ -2,9 +2,9 @@ package workload
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/kbukum/gokit/logger"
+	"github.com/kbukum/gokit/registry"
 )
 
 // ManagerFactory creates a Manager implementation from core config and
@@ -20,78 +20,46 @@ type ManagerFactory func(cfg Config, providerCfg any, log *logger.Logger) (Manag
 // [github.com/kbukum/gokit/workload/docker.Register]) to populate it
 // before passing it to [New].
 type FactoryRegistry struct {
-	mu        sync.RWMutex
-	factories map[string]ManagerFactory
+	inner *registry.Registry[ManagerFactory]
 }
 
 // NewFactoryRegistry creates an isolated workload factory registry.
 func NewFactoryRegistry() *FactoryRegistry {
-	return &FactoryRegistry{factories: make(map[string]ManagerFactory)}
+	return &FactoryRegistry{inner: registry.New[ManagerFactory]("workload")}
 }
 
 // Register stores a workload backend factory for the given provider name.
 // It returns an error if name or factory are invalid, or if a duplicate
-// name is registered. This is a programmer error in production but is
-// reported as a value to keep test code path-deterministic.
+// name is registered.
 func (r *FactoryRegistry) Register(name string, f ManagerFactory) error {
-	if name == "" {
-		return fmt.Errorf("workload: provider name cannot be empty")
-	}
-	if f == nil {
-		return fmt.Errorf("workload: factory %q cannot be nil", name)
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.factories[name]; exists {
-		return fmt.Errorf("workload: factory %q already registered", name)
-	}
-	r.factories[name] = f
-	return nil
-}
-
-// MustRegister is like [FactoryRegistry.Register] but panics on error.
-// Intended for application startup where a failed registration is fatal.
-func (r *FactoryRegistry) MustRegister(name string, f ManagerFactory) {
-	if err := r.Register(name, f); err != nil {
-		panic(err)
-	}
+	return r.inner.Register(name, f)
 }
 
 // Get returns a workload factory by provider name.
 func (r *FactoryRegistry) Get(name string) (ManagerFactory, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	f, ok := r.factories[name]
-	return f, ok
+	return r.inner.Get(name)
 }
 
-// Names returns the registered provider names in unspecified order.
+// Names returns the registered provider names in deterministic (sorted) order.
 func (r *FactoryRegistry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.factories))
-	for n := range r.factories {
-		names = append(names, n)
-	}
-	return names
+	return r.inner.Names()
 }
 
 // New creates a workload Manager using the provided registry. The registry
 // is mandatory: pass an explicit *FactoryRegistry with the desired
 // providers registered (for example via docker.Register, kubernetes.Register).
-func New(registry *FactoryRegistry, cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+func New(reg *FactoryRegistry, cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 	cfg.ApplyDefaults()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	if registry == nil {
+	if reg == nil {
 		return nil, fmt.Errorf("workload: factory registry is nil")
 	}
 
 	l := log.WithComponent("workload")
 
-	f, ok := registry.Get(cfg.Provider)
+	f, ok := reg.Get(cfg.Provider)
 	if !ok {
 		return nil, fmt.Errorf("workload: unsupported provider %q (not registered)", cfg.Provider)
 	}

--- a/workload/workload_test.go
+++ b/workload/workload_test.go
@@ -852,7 +852,7 @@ func TestConfig_DefaultLabels(t *testing.T) {
 
 func TestFactory_RegisterAndCreate(t *testing.T) {
 	reg := NewFactoryRegistry()
-	reg.MustRegister("test-provider", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+	mustReg(t, reg, "test-provider", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 		return newMockManager(), nil
 	})
 
@@ -923,7 +923,7 @@ func TestComponent_StartDisabled(t *testing.T) {
 
 func TestComponent_StartWithRegisteredFactory(t *testing.T) {
 	reg := NewFactoryRegistry()
-	reg.MustRegister("mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+	mustReg(t, reg, "mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 		return newMockManager(), nil
 	})
 
@@ -948,7 +948,7 @@ func TestComponent_StartUnknownProvider(t *testing.T) {
 
 func TestComponent_Stop(t *testing.T) {
 	reg := NewFactoryRegistry()
-	reg.MustRegister("mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+	mustReg(t, reg, "mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 		return newMockManager(), nil
 	})
 
@@ -988,7 +988,7 @@ func TestComponent_HealthNotInitialized(t *testing.T) {
 
 func TestComponent_HealthWithManager(t *testing.T) {
 	reg := NewFactoryRegistry()
-	reg.MustRegister("mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+	mustReg(t, reg, "mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 		return newMockManager(), nil
 	})
 
@@ -1006,7 +1006,7 @@ func TestComponent_HealthCheckFails(t *testing.T) {
 	reg := NewFactoryRegistry()
 	unhealthy := newMockManager()
 	unhealthy.healthy = false
-	reg.MustRegister("mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
+	mustReg(t, reg, "mock", func(cfg Config, providerCfg any, log *logger.Logger) (Manager, error) {
 		return unhealthy, nil
 	})
 
@@ -1198,4 +1198,12 @@ func TestComponent_ImplementsComponent(t *testing.T) {
 
 func TestComponent_ImplementsDescribable(t *testing.T) {
 	var _ component.Describable = (*Component)(nil)
+}
+
+// mustReg registers f on reg, failing the test on error.
+func mustReg(tb testing.TB, reg *FactoryRegistry, name string, f ManagerFactory) {
+tb.Helper()
+if err := reg.Register(name, f); err != nil {
+tb.Fatalf("register: %v", err)
+}
 }


### PR DESCRIPTION
Addresses three OSS-review architectural findings in one PR.

Closes #43
Closes #45
Closes #46

(#5 was already merged on main; nothing to do.)

## #45 — Single generic registry

New `github.com/kbukum/gokit/registry` package providing a single generic `Registry[T any]`. The 6 ad-hoc first-party registries (`auth`, `tool`, `workload`, `llm`, `storage`, `discovery`) are now thin wrappers around it. `Register` returns an error on empty name / nil value / duplicate name; `Names()` is sorted; `Each` iterates deterministically.

## #46 — Remove `Must*` panic helpers from library API

Removed: `tool.Registry.MustRegister`, `workload.FactoryRegistry.MustRegister`, `llm.DialectRegistry.MustRegister`, `auth.Registry.MustGet`, `auth/authctx.MustGet[T]`, `server/middleware.MustTenantFromContext`, `agent.MustPromptTemplate`, `agent.PromptBuilder.MustBuild`, `di.UnifiedContainer.MustResolve` method.

Kept (issue explicitly allows `Must*` for `init()` / test / CLI): `di.MustResolve[T]` free function, `regexp.MustCompile`, `tool.MustJSONResult`, `vectorstore.SearchFilter.MustMatch`, `database/testutil.MustLoadFixture`.

## #43 — Typed-key DI surface

New `di` API layered **on top of** the existing `UnifiedContainer` rather than rewriting it (the issue's reference impl would discard eager/lazy/singleton modes, retry policy, circuit breaker, lifecycle `Close`, and introspection — all current production features):

- `Key[T any]`, `NameKey[T](name)` — opaque, type-parameterised keys.
- `Provide[T](c, key, ctor)` / `ProvideSingleton[T](c, key, value)`.
- `ResolveKey[T](c, key)` / `MustResolveKey[T](c, key)`.
- Constructor signatures validated up front (must return `T` or `(T, error)`).
- Internal full-key embeds `reflect.Type` of `T`, so two `Key[T]` of different concrete types with the same `name` cannot collide.

## Behavior changes (see CHANGELOG)

- `auth.Registry.Register` — errors on duplicate (was silent overwrite).
- `storage.FactoryRegistry.Register` — returns error (was panic).
- `discovery.ProviderRegistry.Register` — returns error (was panic).
- `discovery.NewComponent` — returns `(*Component, error)` (was panic).
- `storage/{local,s3,supabase}.Register`, `discovery/{static,consul}.Register` — return error.

## Verification

`go test ./... -count=1` passes in every module of the repo (root + all 33 sub-modules).
