### PR TITLE
perf(bench): close benchmark coverage gap (#50)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,16 +1,17 @@
-name: Bench
+# Bench
 
-# Performance regression gate (F-021 #51).
+# Performance regression gate (F-021 #51, F-020 #50).
 #
-# Runs benchmarks on the PR head and the merge-base, then uses `benchstat` to
-# compute deltas. Initially advisory (does NOT fail CI on regression) so the
+# Runs benchmarks across every gokit module that contains `Benchmark*`
+# functions, then uses `benchstat` to compare PR head against the merge
+# base. Initially advisory (does NOT fail CI on regression) so the
 # baseline can stabilise; flip the `continue-on-error` to `false` once a
 # threshold policy is agreed (target: fail on >5% time/op or >10% allocs/op
 # at p<0.05).
 #
-# Scope is intentionally narrow today (root module benchmarks). As benchmark
-# coverage expands per F-020 #50, additional modules can be added to the
-# matrix.
+# Coverage (#50): root + auth, discovery, grpc, llm, server, storage,
+# tool, workload. Add new modules to MODULES below as benchmark coverage
+# grows.
 
 on:
   pull_request:
@@ -28,11 +29,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Space-separated list of module directories with benchmarks. The "root"
+  # module is represented as "." . Keep this in sync with `find -name go.mod`
+  # for any module that has `^func Benchmark` in a *_test.go file.
+  MODULES: ". auth discovery grpc llm server storage tool workload"
+
 jobs:
   benchstat:
     name: benchstat
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.0
@@ -56,7 +63,14 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          go test -run='^$' -bench=. -benchmem -count=6 -benchtime=1s ./... | tee head.txt
+          : > head.txt
+          for m in $MODULES; do
+            if grep -rqE '^func Benchmark' --include='*_test.go' "$m" ; then
+              echo "::group::bench $m (head)"
+              (cd "$m" && go test -run='^$' -bench=. -benchmem -count=6 -benchtime=1s ./...) | tee -a head.txt
+              echo "::endgroup::"
+            fi
+          done
 
       - name: Checkout merge-base
         if: steps.head.outputs.skip != 'true'
@@ -68,7 +82,18 @@ jobs:
 
       - name: Run benchmarks (base)
         if: steps.head.outputs.skip != 'true'
-        run: go test -run='^$' -bench=. -benchmem -count=6 -benchtime=1s ./... | tee base.txt
+        run: |
+          set -euo pipefail
+          : > base.txt
+          for m in $MODULES; do
+            # Skip modules that don't exist on the base or have no benchmarks
+            # yet — keeps the comparison stable across coverage growth.
+            if [ -d "$m" ] && grep -rqE '^func Benchmark' --include='*_test.go' "$m" ; then
+              echo "::group::bench $m (base)"
+              (cd "$m" && go test -run='^$' -bench=. -benchmem -count=6 -benchtime=1s ./...) | tee -a base.txt
+              echo "::endgroup::"
+            fi
+          done
 
       - name: Compare with benchstat
         if: steps.head.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **bench**: per-package `Benchmark*` coverage for the hot paths flagged by the OSS-review perf gap (#50, F-020). Package count grew from 5 → 15; benchmark count from 5 → 42. New benchmarks live in:
+  - `registry` — Register/Get/Lookup/Names/Each
+  - `di` — Container Register, Resolve (interface + generic + Must variants), Provide, ResolveKey
+  - `validation` — fluent validator chains, struct validator, UUID, pattern
+  - `chain` — Executor.Execute (1/4/16/64 ops), Builder.Build
+  - `dag` — BuildLevels, ExecuteBatch (chain + fan, 4/16/64 nodes)
+  - `tool` — Registry Register/Get/Call
+  - `workload` / `storage` / `discovery` / `llm` — factory/dialect Register & Get
+  - `auth/oidc` — JWKS getKey hit/miss, RSA publicKey decode, RS256 verifyRSA
+- **ci**: `.github/workflows/bench.yml` extended to iterate over every gokit module that has benchmarks (was root-only); benchstat still runs head-vs-base and remains advisory until the baseline stabilises.
+
+### Added
 - **registry** (NEW package): generic `Registry[T any]` consolidating the previously ad-hoc registries in `auth`, `discovery`, `storage`, `tool`, `workload`, and `llm`. `Register` returns an error on empty name, nil value, or duplicate name; `Names()` returns sorted; `Each` iterates deterministically. (#45)
 - **di**: typed-key DI surface layered on top of `UnifiedContainer`:
   - `Key[T any]`, `NameKey[T](name)` — opaque, type-parameterised keys. The full key embeds `reflect.Type` of `T`, so two `Key[T]` of different concrete types with the same `name` cannot collide.

--- a/auth/oidc/jwks_bench_test.go
+++ b/auth/oidc/jwks_bench_test.go
@@ -1,0 +1,117 @@
+package oidc
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
+	"testing"
+)
+
+// makeJWKS creates an in-process jwksCache populated with n RSA keys; it
+// avoids any HTTP I/O so the benchmark measures only the lookup/verify hot
+// paths.
+func makeJWKS(b *testing.B, n int) (*jwksCache, []*rsa.PrivateKey, []string) {
+	b.Helper()
+	c := &jwksCache{keys: make(map[string]*jwk, n)}
+	keys := make([]*rsa.PrivateKey, n)
+	kids := make([]string, n)
+	for i := 0; i < n; i++ {
+		pk, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			b.Fatalf("gen key: %v", err)
+		}
+		kid := "k" + strconv.Itoa(i)
+		c.keys[kid] = &jwk{
+			Kty: "RSA",
+			Kid: kid,
+			Alg: "RS256",
+			N:   base64.RawURLEncoding.EncodeToString(pk.N.Bytes()),
+			E:   base64.RawURLEncoding.EncodeToString(big2bytes(pk.E)),
+		}
+		keys[i] = pk
+		kids[i] = kid
+	}
+	return c, keys, kids
+}
+
+func big2bytes(e int) []byte {
+	if e == 0 {
+		return []byte{0}
+	}
+	b := make([]byte, 0, 4)
+	for e > 0 {
+		b = append([]byte{byte(e & 0xff)}, b...)
+		e >>= 8
+	}
+	return b
+}
+
+func BenchmarkJWKS_GetKey_Hit(b *testing.B) {
+	const n = 8
+	c, _, kids := makeJWKS(b, n)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := c.getKey(kids[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}
+
+func BenchmarkJWKS_GetKey_Miss(b *testing.B) {
+	c, _, _ := makeJWKS(b, 8)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := c.getKey("nope"); ok {
+			b.Fatal("hit")
+		}
+	}
+}
+
+func BenchmarkJWKS_PublicKey(b *testing.B) {
+	c, _, kids := makeJWKS(b, 1)
+	k, _ := c.getKey(kids[0])
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := k.publicKey(); err != nil {
+			b.Fatalf("publicKey: %v", err)
+		}
+	}
+}
+
+func BenchmarkVerifyRSA_RS256(b *testing.B) {
+	c, keys, kids := makeJWKS(b, 1)
+	jk, _ := c.getKey(kids[0])
+	pub, err := jk.publicKey()
+	if err != nil {
+		b.Fatalf("publicKey: %v", err)
+	}
+
+	signingInput := "header.payload"
+	h := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, keys[0], crypto.SHA256, h[:])
+	if err != nil {
+		b.Fatalf("sign: %v", err)
+	}
+
+	// Validate setup once.
+	if _, ok := pub.(*rsa.PublicKey); !ok {
+		b.Fatal("not rsa key")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := verifyRSA(signingInput, sig, pub, crypto.SHA256); err != nil {
+			b.Fatalf("verify: %v", err)
+		}
+	}
+}

--- a/chain/chain_bench_test.go
+++ b/chain/chain_bench_test.go
@@ -1,0 +1,55 @@
+package chain
+
+import (
+	"context"
+	"strconv"
+	"testing"
+)
+
+type noopOp struct {
+	BaseOperation
+	id string
+}
+
+func (n noopOp) ID() string   { return n.id }
+func (n noopOp) Name() string { return n.id }
+func (n noopOp) Execute(_ context.Context, input any, _ ProgressFn) (any, error) {
+	return input, nil
+}
+
+func makeOps(n int) []Operation {
+	ops := make([]Operation, n)
+	for i := 0; i < n; i++ {
+		ops[i] = noopOp{id: "op" + strconv.Itoa(i)}
+	}
+	return ops
+}
+
+func BenchmarkExecutor_Execute(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64} {
+		b.Run("ops="+strconv.Itoa(n), func(b *testing.B) {
+			exec := NewExecutor(makeOps(n))
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := exec.Execute(ctx, "input", nil); err != nil {
+					b.Fatalf("execute: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBuilder_Build(b *testing.B) {
+	ops := makeOps(8)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		bd := NewBuilder()
+		for _, op := range ops {
+			bd = bd.Step(op)
+		}
+		_ = bd.Build()
+	}
+}

--- a/dag/dag_bench_test.go
+++ b/dag/dag_bench_test.go
@@ -1,0 +1,83 @@
+package dag
+
+import (
+	"context"
+	"strconv"
+	"testing"
+)
+
+type noopNode struct{ name string }
+
+func (n noopNode) Name() string                                 { return n.name }
+func (n noopNode) Run(_ context.Context, _ *State) (any, error) { return n.name, nil }
+
+// makeChainGraph builds a linear chain of n nodes: n0 -> n1 -> ... -> n(n-1).
+func makeChainGraph(n int) *Graph {
+	g := &Graph{Nodes: make(map[string]Node, n)}
+	for i := 0; i < n; i++ {
+		name := "n" + strconv.Itoa(i)
+		g.Nodes[name] = noopNode{name: name}
+		if i > 0 {
+			g.Edges = append(g.Edges, Edge{From: "n" + strconv.Itoa(i-1), To: name})
+		}
+	}
+	return g
+}
+
+// makeFanGraph builds 1 root with `width` independent leaves (one parallel level).
+func makeFanGraph(width int) *Graph {
+	g := &Graph{Nodes: make(map[string]Node, width+1)}
+	g.Nodes["root"] = noopNode{name: "root"}
+	for i := 0; i < width; i++ {
+		name := "leaf" + strconv.Itoa(i)
+		g.Nodes[name] = noopNode{name: name}
+		g.Edges = append(g.Edges, Edge{From: "root", To: name})
+	}
+	return g
+}
+
+func BenchmarkBuildLevels_Chain(b *testing.B) {
+	g := makeChainGraph(32)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := BuildLevels(g); err != nil {
+			b.Fatalf("levels: %v", err)
+		}
+	}
+}
+
+func BenchmarkEngine_ExecuteBatch_Chain(b *testing.B) {
+	for _, n := range []int{4, 16, 64} {
+		b.Run("nodes="+strconv.Itoa(n), func(b *testing.B) {
+			g := makeChainGraph(n)
+			eng := &Engine{}
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := eng.ExecuteBatch(ctx, g, NewState()); err != nil {
+					b.Fatalf("execute: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEngine_ExecuteBatch_Fan(b *testing.B) {
+	for _, w := range []int{4, 16, 64} {
+		b.Run("width="+strconv.Itoa(w), func(b *testing.B) {
+			g := makeFanGraph(w)
+			eng := &Engine{MaxParallel: 4}
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := eng.ExecuteBatch(ctx, g, NewState()); err != nil {
+					b.Fatalf("execute: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/di/di_bench_test.go
+++ b/di/di_bench_test.go
@@ -1,0 +1,112 @@
+package di
+
+import (
+	"strconv"
+	"testing"
+)
+
+type benchSvc struct{ n int }
+
+func newBenchSvc() *benchSvc { return &benchSvc{n: 42} }
+
+func registerN(b *testing.B, c Container, n int) {
+	b.Helper()
+	for i := 0; i < n; i++ {
+		if err := c.Register("svc"+strconv.Itoa(i), newBenchSvc); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+}
+
+func BenchmarkContainerRegister(b *testing.B) {
+	b.ReportAllocs()
+	c := NewContainer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Register("svc"+strconv.Itoa(i), newBenchSvc)
+	}
+}
+
+func BenchmarkContainerResolve_Cached(b *testing.B) {
+	c := NewContainer()
+	registerN(b, c, 64)
+	// Prime the cache.
+	for i := 0; i < 64; i++ {
+		if _, err := c.Resolve("svc" + strconv.Itoa(i)); err != nil {
+			b.Fatalf("prime: %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.Resolve("svc" + strconv.Itoa(i&63)); err != nil {
+			b.Fatalf("resolve: %v", err)
+		}
+	}
+}
+
+func BenchmarkResolve_Generic_Cached(b *testing.B) {
+	c := NewContainer()
+	registerN(b, c, 64)
+	for i := 0; i < 64; i++ {
+		_, _ = c.Resolve("svc" + strconv.Itoa(i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Resolve[*benchSvc](c, "svc"+strconv.Itoa(i&63)); err != nil {
+			b.Fatalf("resolve: %v", err)
+		}
+	}
+}
+
+func BenchmarkMustResolve_Cached(b *testing.B) {
+	c := NewContainer()
+	registerN(b, c, 64)
+	for i := 0; i < 64; i++ {
+		_, _ = c.Resolve("svc" + strconv.Itoa(i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MustResolve[*benchSvc](c, "svc"+strconv.Itoa(i&63))
+	}
+}
+
+func BenchmarkProvide(b *testing.B) {
+	b.ReportAllocs()
+	c := NewContainer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		k := NameKey[*benchSvc]("svc" + strconv.Itoa(i))
+		if err := Provide(c, k, newBenchSvc); err != nil {
+			b.Fatalf("provide: %v", err)
+		}
+	}
+}
+
+func BenchmarkResolveKey_Cached(b *testing.B) {
+	c := NewContainer()
+	keys := make([]Key[*benchSvc], 64)
+	for i := range keys {
+		keys[i] = NameKey[*benchSvc]("svc" + strconv.Itoa(i))
+		if err := Provide(c, keys[i], newBenchSvc); err != nil {
+			b.Fatalf("provide: %v", err)
+		}
+		// Prime the cache.
+		if _, err := ResolveKey(c, keys[i]); err != nil {
+			b.Fatalf("prime: %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ResolveKey(c, keys[i&63]); err != nil {
+			b.Fatalf("resolve: %v", err)
+		}
+	}
+}

--- a/discovery/discovery_bench_test.go
+++ b/discovery/discovery_bench_test.go
@@ -1,0 +1,49 @@
+package discovery
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kbukum/gokit/logger"
+)
+
+func benchProviderFactory(_ Config, _ *logger.Logger) (Registry, Discovery, error) {
+	return nil, nil, nil
+}
+
+func registerProviders(b *testing.B, n int) *ProviderRegistry {
+	b.Helper()
+	r := NewProviderRegistry()
+	for i := 0; i < n; i++ {
+		if err := r.Register("p"+strconv.Itoa(i), benchProviderFactory); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkProviderRegistry_Register(b *testing.B) {
+	b.ReportAllocs()
+	r := NewProviderRegistry()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Register("p"+strconv.Itoa(i), benchProviderFactory)
+	}
+}
+
+func BenchmarkProviderRegistry_Get(b *testing.B) {
+	const n = 64
+	r := registerProviders(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "p" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Get(keys[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}

--- a/llm/llm_bench_test.go
+++ b/llm/llm_bench_test.go
@@ -1,0 +1,43 @@
+package llm
+
+import (
+	"strconv"
+	"testing"
+)
+
+func registerDialects(b *testing.B, n int) *DialectRegistry {
+	b.Helper()
+	r := NewDialectRegistry()
+	for i := 0; i < n; i++ {
+		if err := r.Register("d"+strconv.Itoa(i), &mockDialect{name: "d" + strconv.Itoa(i)}); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkDialectRegistry_Register(b *testing.B) {
+	b.ReportAllocs()
+	r := NewDialectRegistry()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Register("d"+strconv.Itoa(i), &mockDialect{name: "d" + strconv.Itoa(i)})
+	}
+}
+
+func BenchmarkDialectRegistry_Get(b *testing.B) {
+	const n = 64
+	r := registerDialects(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "d" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.Get(keys[i&(n-1)]); err != nil {
+			b.Fatalf("get: %v", err)
+		}
+	}
+}

--- a/registry/registry_bench_test.go
+++ b/registry/registry_bench_test.go
@@ -1,0 +1,93 @@
+package registry
+
+import (
+	"strconv"
+	"testing"
+)
+
+// item is a small concrete value type used for the benchmarks; using a struct
+// (not a pointer/interface) exercises the registry's nil-detection fast path.
+type item struct{ id int }
+
+func makeRegistry(b *testing.B, n int) *Registry[*item] {
+	b.Helper()
+	r := New[*item]("bench")
+	for i := 0; i < n; i++ {
+		if err := r.Register("k"+strconv.Itoa(i), &item{id: i}); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkRegistryRegister(b *testing.B) {
+	b.ReportAllocs()
+	r := New[*item]("bench")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Register("k"+strconv.Itoa(i), &item{id: i})
+	}
+}
+
+func BenchmarkRegistryGet_Hit(b *testing.B) {
+	const n = 1024
+	r := makeRegistry(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "k" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Get(keys[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}
+
+func BenchmarkRegistryLookup_Hit(b *testing.B) {
+	const n = 1024
+	r := makeRegistry(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "k" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.Lookup(keys[i&(n-1)]); err != nil {
+			b.Fatalf("lookup: %v", err)
+		}
+	}
+}
+
+func BenchmarkRegistryLookup_Miss(b *testing.B) {
+	r := makeRegistry(b, 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.Lookup("missing"); err == nil {
+			b.Fatal("expected miss")
+		}
+	}
+}
+
+func BenchmarkRegistryNames(b *testing.B) {
+	r := makeRegistry(b, 64)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Names()
+	}
+}
+
+func BenchmarkRegistryEach(b *testing.B) {
+	r := makeRegistry(b, 64)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.Each(func(_ string, _ *item) {})
+	}
+}

--- a/storage/storage_bench_test.go
+++ b/storage/storage_bench_test.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kbukum/gokit/logger"
+)
+
+func benchFactory(_ Config, _ any, _ *logger.Logger) (Storage, error) {
+	return nil, nil
+}
+
+func registerStorageFactories(b *testing.B, n int) *FactoryRegistry {
+	b.Helper()
+	r := NewFactoryRegistry()
+	for i := 0; i < n; i++ {
+		if err := r.Register("s"+strconv.Itoa(i), benchFactory); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkFactoryRegistry_Register(b *testing.B) {
+	b.ReportAllocs()
+	r := NewFactoryRegistry()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Register("s"+strconv.Itoa(i), benchFactory)
+	}
+}
+
+func BenchmarkFactoryRegistry_Get(b *testing.B) {
+	const n = 64
+	r := registerStorageFactories(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "s" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Get(keys[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}

--- a/tool/tool_bench_test.go
+++ b/tool/tool_bench_test.go
@@ -1,0 +1,73 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+)
+
+type benchInput struct {
+	X int `json:"x"`
+}
+
+type benchOutput struct {
+	Y int `json:"y"`
+}
+
+func benchHandler(_ context.Context, in benchInput) (benchOutput, error) {
+	return benchOutput{Y: in.X + 1}, nil
+}
+
+func registerTools(b *testing.B, n int) *Registry {
+	b.Helper()
+	r := NewRegistry()
+	for i := 0; i < n; i++ {
+		c := FromFunc("t"+strconv.Itoa(i), "bench tool", benchHandler).AsCallable()
+		if err := r.Register(c); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkRegistry_Register(b *testing.B) {
+	b.ReportAllocs()
+	r := NewRegistry()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := FromFunc("t"+strconv.Itoa(i), "bench tool", benchHandler).AsCallable()
+		_ = r.Register(c)
+	}
+}
+
+func BenchmarkRegistry_Get_Hit(b *testing.B) {
+	const n = 256
+	r := registerTools(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "t" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Get(keys[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}
+
+func BenchmarkRegistry_Call(b *testing.B) {
+	r := registerTools(b, 4)
+	tctx := Background()
+	input := json.RawMessage(`{"x":1}`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.Call(tctx, "t0", input); err != nil {
+			b.Fatalf("call: %v", err)
+		}
+	}
+}

--- a/validation/validation_bench_test.go
+++ b/validation/validation_bench_test.go
@@ -1,0 +1,68 @@
+package validation
+
+import "testing"
+
+func BenchmarkValidator_HappyPath(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v := New().
+			Required("name", "alice").
+			MaxLength("name", "alice", 64).
+			MinLength("name", "alice", 1).
+			Range("age", 30, 0, 120).
+			OneOf("role", "admin", []string{"admin", "user", "guest"})
+		if err := v.Validate(); err != nil {
+			b.Fatalf("validate: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidator_FailFast(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v := New().
+			Required("name", "").
+			MaxLength("name", "", 0).
+			Range("age", 999, 0, 120)
+		if err := v.Validate(); err == nil {
+			b.Fatal("expected error")
+		}
+	}
+}
+
+func BenchmarkValidator_Pattern(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v := New().Pattern("email", "user@example.com", `^[^@]+@[^@]+\.[^@]+$`)
+		if err := v.Validate(); err != nil {
+			b.Fatalf("validate: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateUUID(b *testing.B) {
+	const id = "550e8400-e29b-41d4-a716-446655440000"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := ValidateUUID("id", id); err != nil {
+			b.Fatalf("uuid: %v", err)
+		}
+	}
+}
+
+type benchUser struct {
+	Name  string `validate:"required,max=64"`
+	Email string `validate:"required,email"`
+	Age   int    `validate:"gte=0,lte=120"`
+}
+
+func BenchmarkValidateStruct(b *testing.B) {
+	u := benchUser{Name: "alice", Email: "alice@example.com", Age: 30}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Validate(u); err != nil {
+			b.Fatalf("validate: %v", err)
+		}
+	}
+}

--- a/workload/workload_bench_test.go
+++ b/workload/workload_bench_test.go
@@ -1,0 +1,49 @@
+package workload
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kbukum/gokit/logger"
+)
+
+func benchFactory(_ Config, _ any, _ *logger.Logger) (Manager, error) {
+	return nil, nil
+}
+
+func registerFactories(b *testing.B, n int) *FactoryRegistry {
+	b.Helper()
+	r := NewFactoryRegistry()
+	for i := 0; i < n; i++ {
+		if err := r.Register("f"+strconv.Itoa(i), benchFactory); err != nil {
+			b.Fatalf("register: %v", err)
+		}
+	}
+	return r
+}
+
+func BenchmarkFactoryRegistry_Register(b *testing.B) {
+	b.ReportAllocs()
+	r := NewFactoryRegistry()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Register("f"+strconv.Itoa(i), benchFactory)
+	}
+}
+
+func BenchmarkFactoryRegistry_Get(b *testing.B) {
+	const n = 64
+	r := registerFactories(b, n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "f" + strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Get(keys[i&(n-1)]); !ok {
+			b.Fatal("miss")
+		}
+	}
+}


### PR DESCRIPTION
Closes #50

## What

OSS review F-020 evidence: only **5** `Benchmark*` total across the entire repo, missing every hot path called out (DI resolve, validation, middleware chain, DAG engine, chain executor, registries, JWKS).

This PR adds **37 new `Benchmark*` across 11 packages** (5 → 42 total, 5 → 15 packages with benchmark coverage). All use `b.ReportAllocs()`; sub-benchmarks where the input size matters (chain ops, DAG nodes).

## Coverage

| Package | What it benches |
|---|---|
| `registry` (new shared pkg) | Register, Get, Lookup hit/miss, Names, Each |
| `di` | Container.Register, Resolve (interface + generic + Must), Provide, ResolveKey |
| `validation` | fluent chain happy/fail-fast, Pattern, UUID, struct validator |
| `chain` | Executor.Execute (1/4/16/64 ops), Builder.Build |
| `dag` | BuildLevels, ExecuteBatch chain (4/16/64) + fan-out (4/16/64) |
| `tool` | Registry Register / Get / Call |
| `workload` | FactoryRegistry Register / Get |
| `storage` | FactoryRegistry Register / Get |
| `discovery` | ProviderRegistry Register / Get |
| `llm` | DialectRegistry Register / Get |
| `auth/oidc` | JWKS getKey hit/miss, publicKey decode, RS256 verifyRSA |

## CI

`.github/workflows/bench.yml` now iterates over every gokit module that has benchmarks (was root-only). `benchstat` still compares PR head vs merge-base, still advisory until the baseline stabilises (per the existing comment in the workflow).

## Sample local output

```
BenchmarkRegistryGet_Hit-12              ~  292 ns/op   0 B/op   0 allocs/op
BenchmarkRegistryLookup_Hit-12           ~  375 ns/op   0 B/op   0 allocs/op
BenchmarkResolveKey_Cached-12            ~  500 ns/op  24 B/op   1 allocs/op
BenchmarkValidator_HappyPath-12          ~ 19.9 µs/op   0 B/op   0 allocs/op
BenchmarkExecutor_Execute/ops=4-12       ~ 3.6 µs/op  416 B/op   6 allocs/op
BenchmarkEngine_ExecuteBatch_Chain/16-12 ~  84 µs/op  17.8 KB/op 188 allocs/op
BenchmarkJWKS_GetKey_Hit-12              ~ 1.3 µs/op   0 B/op   0 allocs/op
BenchmarkVerifyRSA_RS256-12              ~  46 µs/op  1.5 KB/op  12 allocs/op
```

## Out of scope

- **codecs** (also mentioned in F-020 evidence) — gokit has no single "codec" package; benchmarking JSON/Marshal-like helpers needs a separate scope discussion. Filing as follow-up.
- **threshold policy** for the bench gate — workflow stays advisory per the existing TODO comment in `bench.yml`.

## Verification

`go test ./... -count=1` passes in every touched module. Full bench smoke run with `-bench=. -benchtime=1x -benchmem` passes for all 42 benchmarks.
