### PR TITLE
test(tool): add runnable examples for FromFunc and Registry (#73)

### DIFF
--- a/tool/example_test.go
+++ b/tool/example_test.go
@@ -1,0 +1,59 @@
+package tool_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kbukum/gokit/tool"
+)
+
+// AddInput is a tiny demo input type used by the example.
+type AddInput struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+// AddOutput is the matching output type.
+type AddOutput struct {
+	Sum int `json:"sum"`
+}
+
+// ExampleFromFunc shows the most common way to build a typed tool from a plain
+// Go function. Schema generation and JSON (de)serialisation are handled by
+// FromFunc — your function works in real Go types.
+func ExampleFromFunc() {
+	add := tool.FromFunc("add", "Add two integers",
+		func(_ context.Context, in AddInput) (AddOutput, error) {
+			return AddOutput{Sum: in.A + in.B}, nil
+		},
+	)
+
+	out, err := add.Execute(context.Background(), AddInput{A: 2, B: 3})
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(out.Sum)
+	// Output: 5
+}
+
+// ExampleNewRegistry shows how to register tools into a registry, then look
+// them up by name (the typical pattern for agent / MCP integration).
+func ExampleNewRegistry() {
+	add := tool.FromFunc("add", "Add two integers",
+		func(_ context.Context, in AddInput) (AddOutput, error) {
+			return AddOutput{Sum: in.A + in.B}, nil
+		},
+	)
+
+	reg := tool.NewRegistry()
+	if err := reg.Register(add.AsCallable()); err != nil {
+		fmt.Println("register:", err)
+		return
+	}
+
+	// Retrieve by name and execute through the Callable interface.
+	got, ok := reg.Get("add")
+	fmt.Println("registered:", ok, "name:", got.Definition().Name, "tools:", reg.Len())
+	// Output: registered: true name: add tools: 1
+}


### PR DESCRIPTION
## Summary

Closes part of #73 (test coverage — runnable examples).

Adds `tool/example_test.go` with two package-level example tests that document the most common entry points of the `tool` package:

- **`ExampleFromFunc`** — build a typed `Tool[I, O]` from a plain Go function and execute it against typed input/output. Verifies the schema generation + JSON (de)serialisation round-trip is invisible to callers.
- **`ExampleNewRegistry`** — wrap a typed tool with `AsCallable()`, register it, look it up by name through the type-erased `Callable` interface (the pattern agent / MCP integrations use).

Both examples include `// Output:` directives, so `go test` validates them on every run; they also render in `pkg.go.dev`.

## Why `AsCallable()`?

`Registry.Register(t Callable)` takes the type-erased `Callable` interface (which adds JSON marshal/unmarshal around the typed handler). `*Tool[I, O]` is the *typed* handle and intentionally does not satisfy `Callable` directly — `Tool.AsCallable()` is the documented bridge.

## Verification

```
$ cd tool && go test -run Example -v
=== RUN   ExampleFromFunc
--- PASS: ExampleFromFunc (0.00s)
=== RUN   ExampleNewRegistry
--- PASS: ExampleNewRegistry (0.00s)
PASS
ok  	github.com/kbukum/gokit/tool	0.474s
```

## Follow-ups

Issue #73 also calls out thin example coverage for `agent`, `dag`, `worker`, `mcp`, `llm`. Those will follow in subsequent PRs to keep this one focused and reviewable.

## Depends on

Best reviewed/merged after #105 (`fix/ci-secrets-context`) so CI actually runs on this PR. (Currently CI is broken at the workflow-startup level for every commit.)
