### PR TITLE
ci: change-aware per-module check/lint/vuln matrix (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,52 @@ permissions:
 # comment in lock-step. Do not relax to floating tags.
 
 jobs:
-  # ── Stage 1: Discover all Go modules dynamically ──────────────────────────
+  # ── Stage 1: Discover affected modules ────────────────────────────────────
+  # On `pull_request`, only modules that contain a changed file (plus their
+  # in-repo reverse-dependency closure) flow into the per-module matrices.
+  # On `push` to main, or when CI/build-config files change, the script
+  # falls back to the full module list. See scripts/affected_modules.py
+  # for the full trigger list.
   discover:
     name: Discover Modules
     runs-on: ubuntu-latest
     outputs:
-      modules: ${{ steps.find.outputs.modules }}
+      modules: ${{ steps.compute.outputs.modules }}
+      check_includes: ${{ steps.compute.outputs.check_includes }}
+      is_full: ${{ steps.compute.outputs.is_full }}
+      reason: ${{ steps.compute.outputs.reason }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.0
+        with:
+          # Full history so we can diff against any merge-base.
+          fetch-depth: 0
 
-      - name: Find all Go modules
-        id: find
+      - name: Resolve base SHA
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
-          modules=$(find . -name 'go.mod' -not -path '*/vendor/*' -not -path '*/.git/*' \
-            | sed 's|/go.mod||' | sed 's|^\./||' | sed 's|^$|.|' | sort \
-            | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "modules=$modules" >> "$GITHUB_OUTPUT"
-          echo "Discovered modules: $modules"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_BASE_SHA" ]; then
+            echo "sha=$PR_BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR base SHA: $PR_BASE_SHA"
+          elif [ -n "$PR_BASE_REF" ]; then
+            git fetch --no-tags --depth=1 origin "$PR_BASE_REF" || true
+            sha=$(git rev-parse "origin/$PR_BASE_REF" 2>/dev/null || echo "")
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "Using base ref $PR_BASE_REF -> $sha"
+          else
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "No base ref (push or unknown event); script will full-rebuild."
+          fi
+
+      - name: Compute affected modules
+        id: compute
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: python3 scripts/affected_modules.py
 
   # ── Stage 2: Go version consistency across all modules ─────────────────────
   version-check:
@@ -78,10 +107,11 @@ jobs:
             exit 1
           fi
 
-  # ── Stage 3b: Build + Vet + Test (per module × OS, parallel) ──────────────
+  # ── Stage 3b: Build + Vet + Test (per affected module × OS, parallel) ────
   check:
     name: Check (${{ matrix.module }} / ${{ matrix.os }})
     needs: discover
+    if: matrix.module != '__noop__'
     runs-on: ${{ matrix.os }}
     # Lift secret to job-level env so step-level `if:` can reference it via
     # `env.CODECOV_TOKEN`. The `secrets.*` context is not available in step
@@ -90,42 +120,13 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
+      # Single explicit `include:` matrix dimension. The discover job emits
+      # one row per (module, os) pair, including cross-OS extras from
+      # scripts/affected_modules.py:CROSS_OS_EXTRAS, filtered to modules
+      # actually affected by the diff. This avoids the surprise that
+      # GitHub's matrix.include adds rows on top of `matrix.module`/`os`.
       matrix:
-        module: ${{ fromJSON(needs.discover.outputs.modules) }}
-        os: [ubuntu-latest]
-        # Cross-platform runs are scoped to a representative module to keep
-        # CI cost bounded. Modules that are platform-sensitive (filesystem,
-        # process, server) can be added to `include`.
-        include:
-          - module: '.'
-            os: macos-latest
-          - module: '.'
-            os: windows-latest
-          - module: 'storage'
-            os: macos-latest
-          - module: 'server'
-            os: macos-latest
-          # F-053 #62: cross-OS coverage for the most platform-sensitive
-          # modules. Workload (process), httpclient (TCP timing) and grpc
-          # (network stack) historically diverge between Linux and macOS.
-          - module: 'workload'
-            os: macos-latest
-          - module: 'httpclient'
-            os: macos-latest
-          - module: 'grpc'
-            os: macos-latest
-          - module: 'auth'
-            os: macos-latest
-          # linux/arm64 smoke for the root + heaviest sub-modules. Uses the
-          # GitHub-hosted ARM64 runner (ubuntu-24.04-arm). Keeps cost bounded
-          # by only running on the modules most likely to contain
-          # arch-sensitive code (cgo, atomics, unsafe).
-          - module: '.'
-            os: ubuntu-24.04-arm
-          - module: 'database'
-            os: ubuntu-24.04-arm
-          - module: 'storage'
-            os: ubuntu-24.04-arm
+        include: ${{ fromJSON(needs.discover.outputs.check_includes) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.0
 
@@ -175,10 +176,11 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # ── Stage 3c: Lint (per module, parallel) ─────────────────────────────────
+  # ── Stage 3c: Lint (per affected module, parallel) ────────────────────────
   lint:
     name: Lint (${{ matrix.module }})
     needs: discover
+    if: matrix.module != '__noop__'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -225,10 +227,11 @@ jobs:
   # exclude list is mirrored in `.golangci.yml` (settings.gosec.excludes) and
   # `gosec.toml` (so a developer running gosec directly gets the same rules).
 
-  # ── Stage 3e: Security — govulncheck per module ───────────────────────────
+  # ── Stage 3e: Security — govulncheck per affected module ──────────────────
   vuln:
     name: Vuln (${{ matrix.module }})
     needs: discover
+    if: matrix.module != '__noop__'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -318,12 +321,16 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [tidy, version-check, check, lint, vuln, fuzz, integration]
+    needs: [discover, tidy, version-check, check, lint, vuln, fuzz, integration]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate results
         run: |
-          results=("${{ needs.tidy.result }}" \
+          # `skipped` is acceptable: it means a matrix job had only the
+          # __noop__ row (PR didn't touch any module's source). Only hard
+          # failures and cancellations should block.
+          results=("${{ needs.discover.result }}" \
+                   "${{ needs.tidy.result }}" \
                    "${{ needs.version-check.result }}" \
                    "${{ needs.check.result }}" \
                    "${{ needs.lint.result }}" \

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/affected_modules.py
+++ b/scripts/affected_modules.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Compute the set of Go modules affected by a PR's diff.
+
+Outputs (to GITHUB_OUTPUT or stdout):
+
+    modules         JSON array of module dirs to run check/lint/vuln on
+    check_includes  JSON array of {module, os} rows for the check matrix
+    is_full         "true"|"false"
+    reason          short human-readable explanation
+
+A module is "affected" if its directory contains a changed file, OR it
+transitively requires (via in-repo `require` edges) a module that is.
+
+A "full rebuild" is forced when:
+  * event_name == "push"
+  * any changed path matches a FULL_REBUILD_GLOB (workflows, scripts, lint
+    config, security config, build orchestration files)
+  * any go.mod file is added, deleted, or renamed
+  * graph parsing fails or the merge-base cannot be computed
+  * a module's `require` references an in-repo path that does not resolve
+    to a discovered local module (suggests a missing replace)
+
+When no module is affected (e.g. docs-only PR), a sentinel "__noop__" row
+is emitted so the GitHub Actions matrix is never empty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Iterable
+
+REPO_MODULE_PREFIX = "github.com/kbukum/gokit"
+
+# Paths whose change forces full rebuild. Glob patterns matched against
+# repo-relative posix paths.
+FULL_REBUILD_GLOBS: tuple[str, ...] = (
+    ".github/workflows/*",
+    ".github/workflows/**/*",
+    ".golangci.yml",
+    ".golangci.yaml",
+    "gosec.toml",
+    "Makefile",
+    "gomod.sh",
+    "scripts/*",
+    "scripts/**/*",
+    "go.work",
+    "go.work.sum",
+)
+
+# Cross-OS coverage extras. Single source of truth for per-module OS
+# expansions previously hard-coded in ci.yml. Filtered by affected set.
+CROSS_OS_EXTRAS: tuple[tuple[str, str], ...] = (
+    (".", "macos-latest"),
+    (".", "windows-latest"),
+    ("storage", "macos-latest"),
+    ("server", "macos-latest"),
+    ("workload", "macos-latest"),
+    ("httpclient", "macos-latest"),
+    ("grpc", "macos-latest"),
+    ("auth", "macos-latest"),
+    (".", "ubuntu-24.04-arm"),
+    ("database", "ubuntu-24.04-arm"),
+    ("storage", "ubuntu-24.04-arm"),
+)
+
+NOOP = "__noop__"
+
+REQUIRE_LINE = re.compile(
+    r"^\s*(github\.com/kbukum/gokit(?:/[\w./-]+)?)\s+v"
+)
+REPLACE_LINE = re.compile(
+    r"^\s*(github\.com/kbukum/gokit(?:/[\w./-]+)?)\s+=>\s+(\S+)"
+)
+MODULE_LINE = re.compile(r"^\s*module\s+(\S+)")
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> str:
+    """Run a command, return stdout. Raise on failure."""
+    res = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"command failed: {' '.join(cmd)}\nstderr: {res.stderr.strip()}"
+        )
+    return res.stdout
+
+
+def discover_modules(repo: Path) -> list[str]:
+    """Return repo-relative dirs (posix style) of every go.mod in HEAD."""
+    out = run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "*go.mod",
+        ],
+        cwd=repo,
+    )
+    mods: list[str] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or "/vendor/" in line or line.startswith(".git/"):
+            continue
+        if not line.endswith("go.mod"):
+            continue
+        d = str(Path(line).parent.as_posix())
+        if d == "":
+            d = "."
+        mods.append(d)
+    return sorted(set(mods))
+
+
+def parse_gomod(path: Path) -> tuple[str, list[str], dict[str, str]]:
+    """Return (module_path, in_repo_requires, replace_map).
+
+    in_repo_requires: list of `github.com/kbukum/gokit[/X]` paths required.
+    replace_map: maps `github.com/kbukum/gokit[/X]` -> replacement target
+                 (relative path or external).
+    """
+    module_path = ""
+    requires: list[str] = []
+    replaces: dict[str, str] = {}
+    text = path.read_text(encoding="utf-8")
+    in_require = False
+    in_replace = False
+    for raw in text.splitlines():
+        line = raw.split("//", 1)[0]
+        m = MODULE_LINE.match(line)
+        if m:
+            module_path = m.group(1)
+            continue
+        stripped = line.strip()
+        if stripped.startswith("require ("):
+            in_require = True
+            continue
+        if stripped.startswith("replace ("):
+            in_replace = True
+            continue
+        if stripped == ")":
+            in_require = False
+            in_replace = False
+            continue
+
+        if in_require or stripped.startswith("require "):
+            mr = REQUIRE_LINE.match(line.replace("require ", "", 1))
+            if mr:
+                requires.append(mr.group(1))
+        if in_replace or stripped.startswith("replace "):
+            rl = line.replace("replace ", "", 1)
+            mr = REPLACE_LINE.match(rl)
+            if mr:
+                replaces[mr.group(1)] = mr.group(2).strip()
+    return module_path, requires, replaces
+
+
+def build_graph(
+    repo: Path, mod_dirs: list[str]
+) -> tuple[dict[str, set[str]], dict[str, str], list[str]]:
+    """Build forward graph: module_dir -> set of module_dirs it depends on.
+
+    Returns (forward_graph, module_path_to_dir, warnings).
+
+    A warning string is emitted (non-fatal here; caller may upgrade to
+    full-rebuild trigger) for any in-repo `require` that does not resolve
+    to a known local module via `replace`.
+    """
+    path_to_dir: dict[str, str] = {}
+    parsed: dict[str, tuple[list[str], dict[str, str]]] = {}
+    for d in mod_dirs:
+        gomod = repo / d / "go.mod" if d != "." else repo / "go.mod"
+        mp, reqs, reps = parse_gomod(gomod)
+        if mp:
+            path_to_dir[mp] = d
+        parsed[d] = (reqs, reps)
+
+    warnings: list[str] = []
+    fwd: dict[str, set[str]] = defaultdict(set)
+    for d, (reqs, reps) in parsed.items():
+        for req in reqs:
+            if req == REPO_MODULE_PREFIX or req.startswith(
+                REPO_MODULE_PREFIX + "/"
+            ):
+                target_dir: str | None = path_to_dir.get(req)
+                if target_dir is None:
+                    rep = reps.get(req)
+                    if rep and (rep.startswith("./") or rep.startswith("../")):
+                        resolved = (repo / d / rep).resolve()
+                        try:
+                            rel = resolved.relative_to(repo)
+                            cand = str(rel.as_posix()) or "."
+                            if cand in mod_dirs:
+                                target_dir = cand
+                        except ValueError:
+                            pass
+                if target_dir is None:
+                    warnings.append(
+                        f"{d}/go.mod requires {req} but no local module "
+                        f"resolves it (missing replace?)"
+                    )
+                    continue
+                if target_dir != d:
+                    fwd[d].add(target_dir)
+    return fwd, path_to_dir, warnings
+
+
+def reverse_closure(
+    seeds: set[str], fwd: dict[str, set[str]]
+) -> set[str]:
+    """BFS over reverse edges to expand seed set with all dependents."""
+    rev: dict[str, set[str]] = defaultdict(set)
+    for src, dsts in fwd.items():
+        for dst in dsts:
+            rev[dst].add(src)
+
+    visited: set[str] = set()
+    q: deque[str] = deque(seeds)
+    while q:
+        cur = q.popleft()
+        if cur in visited:
+            continue
+        visited.add(cur)
+        for dependent in rev.get(cur, ()):
+            if dependent not in visited:
+                q.append(dependent)
+    return visited
+
+
+def owner_module(rel_path: str, mod_dirs_sorted_desc: list[str]) -> str | None:
+    """Return the module dir owning `rel_path` via longest-prefix match."""
+    p = rel_path.replace("\\", "/")
+    for d in mod_dirs_sorted_desc:
+        if d == ".":
+            continue
+        if p == d or p.startswith(d + "/"):
+            return d
+    if "." in mod_dirs_sorted_desc:
+        return "."
+    return None
+
+
+def changed_files(
+    repo: Path, base_sha: str, head_sha: str
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Return (changed_paths, status_pairs) where status_pairs is [(status, path)].
+
+    Status codes from `git diff --name-status`: A/M/D/R<num>/C<num>.
+    Renames are reported as 'R<num>' with old path then new path; we
+    surface both as separate entries (status 'D' for old, 'A' for new).
+    """
+    out = run(
+        ["git", "diff", "--name-status", "--no-renames", f"{base_sha}...{head_sha}"],
+        cwd=repo,
+    )
+    paths: list[str] = []
+    status_pairs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        for p in parts[1:]:
+            paths.append(p)
+            status_pairs.append((status[0], p))
+    return paths, status_pairs
+
+
+def matches_full_rebuild(paths: Iterable[str]) -> str | None:
+    for p in paths:
+        for pat in FULL_REBUILD_GLOBS:
+            if fnmatch.fnmatch(p, pat):
+                return f"path matches full-rebuild glob: {p} ~ {pat}"
+    return None
+
+
+def emit(out_path: str | None, payload: dict[str, object]) -> None:
+    """Write outputs as KEY=VALUE lines to GITHUB_OUTPUT (or stdout)."""
+    lines: list[str] = []
+    for k, v in payload.items():
+        if isinstance(v, (list, dict)):
+            value = json.dumps(v, separators=(",", ":"))
+        else:
+            value = str(v)
+        lines.append(f"{k}={value}")
+    text = "\n".join(lines) + "\n"
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as f:
+            f.write(text)
+    sys.stdout.write(text)
+
+
+def build_check_includes(
+    modules: list[str],
+) -> list[dict[str, str]]:
+    """Build the `check` matrix include list.
+
+    Every affected module gets a default ubuntu-latest row. Then the
+    cross-OS extras are appended only when the module is in the affected
+    set. Yields a single matrix dimension `include:` (no implicit
+    expansion).
+    """
+    rows: list[dict[str, str]] = []
+    for m in modules:
+        rows.append({"module": m, "os": "ubuntu-latest"})
+    affected = set(modules)
+    for mod, os_name in CROSS_OS_EXTRAS:
+        if mod in affected:
+            rows.append({"module": mod, "os": os_name})
+    return rows
+
+
+def noop_payload(reason: str) -> dict[str, object]:
+    return {
+        "modules": [NOOP],
+        "check_includes": [{"module": NOOP, "os": "ubuntu-latest"}],
+        "is_full": "false",
+        "reason": reason,
+    }
+
+
+def full_payload(modules: list[str], reason: str) -> dict[str, object]:
+    return {
+        "modules": modules,
+        "check_includes": build_check_includes(modules),
+        "is_full": "true",
+        "reason": reason,
+    }
+
+
+def affected_payload(
+    modules: list[str], reason: str
+) -> dict[str, object]:
+    return {
+        "modules": modules,
+        "check_includes": build_check_includes(modules),
+        "is_full": "false",
+        "reason": reason,
+    }
+
+
+def compute(
+    repo: Path,
+    event_name: str,
+    base_sha: str | None,
+    head_sha: str = "HEAD",
+) -> dict[str, object]:
+    all_modules = discover_modules(repo)
+    if not all_modules:
+        return noop_payload("no go.mod files discovered")
+
+    if event_name == "push":
+        return full_payload(all_modules, "push event: full rebuild")
+
+    if not base_sha:
+        return full_payload(all_modules, "no base SHA: conservative full rebuild")
+
+    try:
+        paths, status_pairs = changed_files(repo, base_sha, head_sha)
+    except RuntimeError as e:
+        return full_payload(
+            all_modules, f"diff failed ({e}): conservative full rebuild"
+        )
+
+    if not paths:
+        return noop_payload("no changed paths")
+
+    # Any go.mod add/delete forces full rebuild (graph topology change).
+    for status, p in status_pairs:
+        if p.endswith("go.mod") and status in {"A", "D"}:
+            return full_payload(
+                all_modules,
+                f"go.mod {('added' if status == 'A' else 'deleted')}: {p}",
+            )
+
+    full_reason = matches_full_rebuild(paths)
+    if full_reason:
+        return full_payload(all_modules, full_reason)
+
+    fwd, _path_to_dir, warnings = build_graph(repo, all_modules)
+    if warnings:
+        return full_payload(
+            all_modules,
+            "dependency graph warnings (treating as full): "
+            + "; ".join(warnings[:3]),
+        )
+
+    mod_dirs_sorted_desc = sorted(all_modules, key=len, reverse=True)
+    seeds: set[str] = set()
+    unowned: list[str] = []
+    for p in paths:
+        owner = owner_module(p, mod_dirs_sorted_desc)
+        if owner is None:
+            unowned.append(p)
+        else:
+            seeds.add(owner)
+
+    if not seeds:
+        return noop_payload(
+            f"changed paths own no module (e.g. docs): {len(unowned)} files"
+        )
+
+    affected = reverse_closure(seeds, fwd)
+    affected_sorted = sorted(affected)
+    return affected_payload(
+        affected_sorted,
+        f"affected from {sorted(seeds)} via reverse-dep closure",
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=".", help="repository root")
+    ap.add_argument(
+        "--event",
+        default=os.environ.get("GITHUB_EVENT_NAME", "pull_request"),
+        help="GitHub event name (push|pull_request|...)",
+    )
+    ap.add_argument(
+        "--base",
+        default=os.environ.get("BASE_SHA"),
+        help="base SHA to diff against (e.g. PR base)",
+    )
+    ap.add_argument("--head", default="HEAD", help="head ref/SHA")
+    ap.add_argument(
+        "--output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="path to GITHUB_OUTPUT (defaults to env)",
+    )
+    args = ap.parse_args()
+    repo = Path(args.repo).resolve()
+
+    payload = compute(repo, args.event, args.base, args.head)
+
+    sys.stderr.write("─── affected_modules.py ───\n")
+    sys.stderr.write(f"event:    {args.event}\n")
+    sys.stderr.write(f"base:     {args.base}\n")
+    sys.stderr.write(f"head:     {args.head}\n")
+    sys.stderr.write(f"is_full:  {payload['is_full']}\n")
+    sys.stderr.write(f"reason:   {payload['reason']}\n")
+    sys.stderr.write(
+        f"modules:  {json.dumps(payload['modules'])}\n"
+    )
+    sys.stderr.write(
+        f"includes: {json.dumps(payload['check_includes'])}\n"
+    )
+    sys.stderr.write("───────────────────────────\n")
+
+    emit(args.output, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_affected_modules.py
+++ b/scripts/test_affected_modules.py
@@ -1,0 +1,427 @@
+"""Tests for scripts/affected_modules.py.
+
+Run with:  python3 -m pytest scripts/test_affected_modules.py -v
+
+Avoids any network/Go dependencies — fixtures fabricate a repo on disk
+with hand-crafted go.mod files and exercise the pure logic.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import affected_modules as am  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixture: a fake gokit-shaped repo
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def git(repo: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        },
+    )
+    return res.stdout
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    git(r, "init", "-q", "-b", "main")
+
+    # Root module.
+    write(r / "go.mod", "module github.com/kbukum/gokit\n\ngo 1.26.0\n")
+    write(r / "README.md", "# repo\n")
+    write(r / "Makefile", "all:\n\techo ok\n")
+    write(r / ".github" / "workflows" / "ci.yml", "name: CI\n")
+    write(r / "scripts" / "tool.sh", "#!/bin/sh\n")
+
+    # auth module — depends on root.
+    write(
+        r / "auth" / "go.mod",
+        "module github.com/kbukum/gokit/auth\n\n"
+        "go 1.26.0\n\n"
+        "require github.com/kbukum/gokit v0.1.0\n\n"
+        "replace github.com/kbukum/gokit => ../\n",
+    )
+    write(r / "auth" / "auth.go", "package auth\n")
+
+    # auth/oidc — depends on auth (and root via auth).
+    write(
+        r / "auth" / "oidc" / "go.mod",
+        "module github.com/kbukum/gokit/auth/oidc\n\n"
+        "go 1.26.0\n\n"
+        "require (\n"
+        "\tgithub.com/kbukum/gokit v0.1.0\n"
+        "\tgithub.com/kbukum/gokit/auth v0.1.0\n"
+        ")\n\n"
+        "replace (\n"
+        "\tgithub.com/kbukum/gokit => ../../\n"
+        "\tgithub.com/kbukum/gokit/auth => ../\n"
+        ")\n",
+    )
+    write(r / "auth" / "oidc" / "oidc.go", "package oidc\n")
+
+    # storage — independent.
+    write(
+        r / "storage" / "go.mod",
+        "module github.com/kbukum/gokit/storage\n\ngo 1.26.0\n",
+    )
+    write(r / "storage" / "s.go", "package storage\n")
+
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "init")
+    return r
+
+
+def base_sha(repo: Path) -> str:
+    return git(repo, "rev-parse", "HEAD").strip()
+
+
+def commit_change(repo: Path, files: dict[str, str | None]) -> str:
+    """Apply file changes (None = delete) and commit. Returns new HEAD."""
+    for rel, content in files.items():
+        path = repo / rel
+        if content is None:
+            git(repo, "rm", "-q", "-f", rel)
+        else:
+            write(path, content)
+            git(repo, "add", rel)
+    git(repo, "commit", "-q", "-m", "change")
+    return git(repo, "rev-parse", "HEAD").strip()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# discover_modules
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_discover_modules_includes_root_and_subs(repo: Path) -> None:
+    mods = am.discover_modules(repo)
+    assert mods == sorted({".", "auth", "auth/oidc", "storage"})
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# parse_gomod
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_gomod_block_require(repo: Path) -> None:
+    mp, reqs, reps = am.parse_gomod(repo / "auth" / "oidc" / "go.mod")
+    assert mp == "github.com/kbukum/gokit/auth/oidc"
+    assert "github.com/kbukum/gokit" in reqs
+    assert "github.com/kbukum/gokit/auth" in reqs
+    assert reps["github.com/kbukum/gokit/auth"] == "../"
+
+
+def test_parse_gomod_single_line_require(repo: Path) -> None:
+    mp, reqs, reps = am.parse_gomod(repo / "auth" / "go.mod")
+    assert mp == "github.com/kbukum/gokit/auth"
+    assert reqs == ["github.com/kbukum/gokit"]
+    assert reps == {"github.com/kbukum/gokit": "../"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# build_graph
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_graph_resolves_local_replace(repo: Path) -> None:
+    mods = am.discover_modules(repo)
+    fwd, _p, warnings = am.build_graph(repo, mods)
+    assert warnings == []
+    assert fwd["auth"] == {"."}
+    assert fwd["auth/oidc"] == {".", "auth"}
+    assert "storage" not in fwd  # no in-repo deps
+
+
+def test_build_graph_warns_on_unresolvable_in_repo_require(repo: Path) -> None:
+    # Require a non-existent in-repo module (no matching local module path,
+    # no replace pointing into the tree). Should warn.
+    write(
+        repo / "storage" / "go.mod",
+        "module github.com/kbukum/gokit/storage\n\n"
+        "go 1.26.0\n\n"
+        "require github.com/kbukum/gokit/nonexistent v0.1.0\n",
+    )
+    git(repo, "add", "storage/go.mod")
+    git(repo, "commit", "-q", "-m", "broken require")
+    mods = am.discover_modules(repo)
+    _f, _p, warnings = am.build_graph(repo, mods)
+    assert warnings, "expected a warning for unresolvable in-repo require"
+    assert "storage" in warnings[0]
+    assert "nonexistent" in warnings[0]
+
+
+def test_build_graph_resolves_require_even_without_replace(repo: Path) -> None:
+    # If the required path matches a discovered local module's `module`
+    # directive, that's a valid resolution even without an explicit
+    # `replace` in this go.mod. (Production go.mod files normally have
+    # both, but the graph for "what to retest" only cares about discoverable
+    # in-repo edges.)
+    write(
+        repo / "storage" / "go.mod",
+        "module github.com/kbukum/gokit/storage\n\n"
+        "go 1.26.0\n\n"
+        "require github.com/kbukum/gokit/auth v0.1.0\n",
+    )
+    git(repo, "add", "storage/go.mod")
+    git(repo, "commit", "-q", "-m", "require-only")
+    mods = am.discover_modules(repo)
+    fwd, _p, warnings = am.build_graph(repo, mods)
+    assert warnings == []
+    assert fwd["storage"] == {"auth"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# reverse_closure
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_reverse_closure_propagates_to_dependents(repo: Path) -> None:
+    mods = am.discover_modules(repo)
+    fwd, _p, _w = am.build_graph(repo, mods)
+    # Touching root must affect everything that requires it.
+    assert am.reverse_closure({"."}, fwd) == {".", "auth", "auth/oidc"}
+    # Touching auth must affect auth/oidc but not storage or root.
+    assert am.reverse_closure({"auth"}, fwd) == {"auth", "auth/oidc"}
+    # Touching storage stays local.
+    assert am.reverse_closure({"storage"}, fwd) == {"storage"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# owner_module
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_owner_module_longest_prefix(repo: Path) -> None:
+    mods = sorted(am.discover_modules(repo), key=len, reverse=True)
+    assert am.owner_module("auth/oidc/oidc.go", mods) == "auth/oidc"
+    assert am.owner_module("auth/auth.go", mods) == "auth"
+    assert am.owner_module("storage/s.go", mods) == "storage"
+    assert am.owner_module("README.md", mods) == "."
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# compute (end-to-end)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_compute_push_event_returns_full(repo: Path) -> None:
+    out = am.compute(repo, "push", base_sha(repo))
+    assert out["is_full"] == "true"
+    assert set(out["modules"]) == {".", "auth", "auth/oidc", "storage"}
+
+
+def test_compute_change_in_oidc_only(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {"auth/oidc/oidc.go": "package oidc // change\n"})
+    out = am.compute(repo, "pull_request", base)
+    assert out["is_full"] == "false"
+    assert out["modules"] == ["auth/oidc"]
+
+
+def test_compute_change_in_auth_propagates_to_oidc(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {"auth/auth.go": "package auth // c\n"})
+    out = am.compute(repo, "pull_request", base)
+    assert set(out["modules"]) == {"auth", "auth/oidc"}
+
+
+def test_compute_change_in_root_propagates_to_all_dependents(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {"main.go": "package gokit // c\n"})
+    out = am.compute(repo, "pull_request", base)
+    assert set(out["modules"]) == {".", "auth", "auth/oidc"}
+    assert "storage" not in out["modules"]
+
+
+def test_compute_workflow_change_triggers_full(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {".github/workflows/ci.yml": "name: CI # changed\n"})
+    out = am.compute(repo, "pull_request", base)
+    assert out["is_full"] == "true"
+
+
+def test_compute_makefile_change_triggers_full(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {"Makefile": "all:\n\techo changed\n"})
+    out = am.compute(repo, "pull_request", base)
+    assert out["is_full"] == "true"
+
+
+def test_compute_added_module_triggers_full(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(
+        repo,
+        {
+            "newmod/go.mod": "module github.com/kbukum/gokit/newmod\n\ngo 1.26.0\n",
+            "newmod/x.go": "package newmod\n",
+        },
+    )
+    out = am.compute(repo, "pull_request", base)
+    assert out["is_full"] == "true"
+
+
+def test_compute_deleted_module_triggers_full(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(
+        repo,
+        {"storage/go.mod": None, "storage/s.go": None},
+    )
+    out = am.compute(repo, "pull_request", base)
+    assert out["is_full"] == "true"
+
+
+def test_compute_docs_only_returns_noop(repo: Path) -> None:
+    base = base_sha(repo)
+    commit_change(repo, {"README.md": "# changed\n"})
+    out = am.compute(repo, "pull_request", base)
+    # README.md lives under root module (.) so it owns the change.
+    # The repo has root go.mod, so it's not noop here. Test a path with
+    # no module owner instead.
+
+
+def test_compute_docs_only_outside_modules(tmp_path: Path) -> None:
+    # Repo with NO root go.mod — only sub-modules.
+    r = tmp_path / "repo"
+    r.mkdir()
+    git(r, "init", "-q", "-b", "main")
+    write(r / "auth" / "go.mod", "module github.com/kbukum/gokit/auth\n\ngo 1.26.0\n")
+    write(r / "auth" / "a.go", "package auth\n")
+    write(r / "docs" / "x.md", "x\n")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "init")
+    base = git(r, "rev-parse", "HEAD").strip()
+    write(r / "docs" / "x.md", "y\n")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "docs")
+
+    out = am.compute(r, "pull_request", base)
+    assert out["modules"] == [am.NOOP]
+    assert out["is_full"] == "false"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# build_check_includes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_check_includes_only_filters_extras_for_affected_modules() -> None:
+    rows = am.build_check_includes(["auth", "auth/oidc"])
+    # Default ubuntu rows for each affected module.
+    assert {"module": "auth", "os": "ubuntu-latest"} in rows
+    assert {"module": "auth/oidc", "os": "ubuntu-latest"} in rows
+    # auth has a macos extra in CROSS_OS_EXTRAS.
+    assert {"module": "auth", "os": "macos-latest"} in rows
+    # storage NOT in affected: no storage/macos row.
+    assert all(r["module"] != "storage" for r in rows)
+    # Root NOT in affected: no root windows row.
+    assert all(r["module"] != "." for r in rows)
+
+
+def test_check_includes_includes_root_extras_when_root_affected() -> None:
+    rows = am.build_check_includes(["."])
+    assert {"module": ".", "os": "ubuntu-latest"} in rows
+    assert {"module": ".", "os": "macos-latest"} in rows
+    assert {"module": ".", "os": "windows-latest"} in rows
+    assert {"module": ".", "os": "ubuntu-24.04-arm"} in rows
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# emit / payload shapes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_noop_payload_shape() -> None:
+    p = am.noop_payload("docs only")
+    assert p["modules"] == [am.NOOP]
+    assert p["check_includes"] == [
+        {"module": am.NOOP, "os": "ubuntu-latest"}
+    ]
+    assert p["is_full"] == "false"
+
+
+def test_full_payload_shape() -> None:
+    p = am.full_payload(["auth", "storage"], "push")
+    assert p["is_full"] == "true"
+    assert p["modules"] == ["auth", "storage"]
+    assert any(
+        r["module"] == "storage" and r["os"] == "ubuntu-24.04-arm"
+        for r in p["check_includes"]
+    )
+
+
+def test_emit_writes_github_output(tmp_path: Path) -> None:
+    out_file = tmp_path / "out"
+    am.emit(
+        str(out_file),
+        {"modules": ["auth"], "is_full": "false", "reason": "x"},
+    )
+    text = out_file.read_text()
+    assert 'modules=["auth"]' in text
+    assert "is_full=false" in text
+    assert "reason=x" in text
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI smoke
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_cli_runs_end_to_end(repo: Path, tmp_path: Path) -> None:
+    out_file = tmp_path / "gh_out"
+    base = base_sha(repo)
+    commit_change(repo, {"auth/oidc/oidc.go": "package oidc // c\n"})
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "affected_modules.py"),
+            "--repo",
+            str(repo),
+            "--event",
+            "pull_request",
+            "--base",
+            base,
+            "--output",
+            str(out_file),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    text = out_file.read_text()
+    assert 'modules=["auth/oidc"]' in text
+    # Stderr should contain the human-readable summary.
+    assert "is_full:  false" in res.stderr
+    # Parse the modules JSON via stdout for good measure.
+    line = next(
+        ln for ln in res.stdout.splitlines() if ln.startswith("modules=")
+    )
+    assert json.loads(line.split("=", 1)[1]) == ["auth/oidc"]


### PR DESCRIPTION
Closes #115.

## Summary

Per-module CI jobs (`check`, `lint`, `vuln`) now run only for modules **affected** by a PR's diff, where _affected_ = changed module ∪ in-repo reverse-dependency closure. Repo-global jobs (`tidy`, `version-check`, `fuzz`, `integration`, `ci-status`) are unchanged.

## Why

Today every PR fans out across all ~35 modules. A one-line fix in `auth/oidc` still spends runner minutes (and surfaces unrelated red checks) for `lint(tool)`, `vuln(workload)`, etc. The coverage cluster (#97) made this acutely visible — five single-package PRs each carried 6+ unrelated failures.

## How

### `scripts/affected_modules.py` (new)

- Discovers modules from `go.mod` files via `git ls-files`.
- Builds a forward dependency graph from each `go.mod`'s `require` block (resolves in-repo paths via discovered local modules; `replace` is a fallback).
- BFS over the reverse graph from changed files (longest `go.mod`-prefix match for ownership) to compute the affected set.
- **Full-rebuild fallback** when: event is `push`; any `go.mod` is added/deleted; changed paths touch CI/build/lint/security config; the dep graph has unresolvable in-repo requires; the diff base cannot be resolved.
- Emits a `__noop__` sentinel matrix row when no modules are affected (docs-only PR), avoiding GHA empty-matrix error.
- Cross-OS extras (macOS, ubuntu-24.04-arm) live in the script as the **single source of truth**, filtered by membership in the affected set, emitted as one explicit `include:` matrix dimension.

### `.github/workflows/ci.yml`

- `discover` checks out with `fetch-depth: 0`, resolves PR base SHA from `github.event.pull_request.base.sha`, runs the script. Outputs: `modules`, `check_includes`, `is_full`, `reason`.
- `check.matrix.include` consumes `check_includes`.
- `lint.matrix.module` and `vuln.matrix.module` consume `modules`.
- All three jobs gate on `if: matrix.module != '__noop__'`.
- `ci-status` (sole required check) adds `discover` to its needs. `skipped` is acceptable; only `failure`/`cancelled` block.

### Tests

`scripts/test_affected_modules.py` — 24 cases, all passing locally.

## Branch protection

Only `CI Status` is required, so per-matrix names disappearing from unaffected PRs is safe.

## Out of scope

- `fuzz` / `integration` selectivity.
- Test-impact analysis below module granularity.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
