### PR TITLE
docs: bump Go-version references from 1.25 to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/kbukum/gokit/actions/workflows/ci.yml/badge.svg)](https://github.com/kbukum/gokit/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/kbukum/gokit.svg)](https://pkg.go.dev/github.com/kbukum/gokit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8.svg)](go.mod)
+[![Go 1.26+](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
 
 **A modular Go toolkit for building production services.** Config, logging, resilience, observability, dependency injection, and infrastructure adapters — so teams can focus on business logic instead of reinventing plumbing.
 
@@ -31,7 +31,7 @@ go get github.com/kbukum/gokit/server@latest
 go get github.com/kbukum/gokit/database@latest
 ```
 
-Requires **Go 1.25+**.
+Requires **Go 1.26+**.
 
 ## Quickstart
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -8,7 +8,7 @@ Every package has its own `README.md` with API examples — start there for deta
 
 | Go version | gokit version |
 |------------|---------------|
-| 1.25+      | v0.1.2+       |
+| 1.26+      | v0.1.2+       |
 
 ## Core Packages
 


### PR DESCRIPTION
All `go.mod` files declare `go 1.26.0`, but the README badge, install prerequisite line, and `docs/PACKAGES.md` compatibility matrix still said **Go 1.25+**. Aligns docs with reality.

Verification:
```
$ find . -name go.mod -not -path '*/vendor/*' -not -path '*/.git/*' -exec grep -H '^go ' {} \; | awk '{print $NF}' | sort -u
1.26.0
```

Refs F-088, F-090 in `docs/REVIEW.md`.