### PR TITLE
fix(security): strip query token after extraction, add codecov thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 85%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -185,6 +185,10 @@ func extractToken(c *gin.Context, o *authOptions) (string, bool) {
 			if o.queryTokenWarningLogger != nil {
 				o.queryTokenWarningLogger(c, o.queryTokenParam)
 			}
+			// Strip the token from the URL so it is not logged, cached, or forwarded.
+			q := c.Request.URL.Query()
+			q.Del(o.queryTokenParam)
+			c.Request.URL.RawQuery = q.Encode()
 			return token, true
 		}
 	}


### PR DESCRIPTION
## Description

OSS engineering review fixes for gokit: security hardening for auth query token handling and CI coverage threshold enforcement.

## Motivation

Part of cross-sibling OSS engineering review. After extracting an auth token from a URL query parameter, the token remained in the URL and could be logged, cached, or forwarded to upstream services. Additionally, no coverage thresholds were enforced in CI.

Sibling PRs: rskit and pykit `refactor/oss-review` branches.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Module(s) Affected

- `server/middleware` (auth.go — query token stripping)
- CI (`codecov.yml` — coverage thresholds)

## Changes Made

- **Security**: After extracting auth token from query params, strip it from the URL via `q.Del()` + URL rewrite to prevent logging/caching/forwarding of credentials
- **CI**: Add `codecov.yml` with 80% project target / 85% patch target coverage thresholds

## Testing

- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `go vet ./server/middleware/...` passes

### Test Evidence

```
$ go vet ./server/middleware/...
# no output (clean)
```

## Breaking Changes

None — the token is still extracted and used; it is simply removed from the URL after extraction.

## Checklist

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [x] I have run `make tidy` to ensure go.mod/go.sum are clean
- [x] I have added godoc comments for exported types/functions
- [x] I have considered backward compatibility
- [x] New dependencies (if any) are justified and minimal

## Additional Notes

This is part of a cross-sibling OSS engineering review across gokit, rskit, and pykit. The `codecov.yml` configuration is identical across all three repos to maintain parity.