### PR TITLE
refactor: align core foundation modules (errors, config, logging, validation, encryption, util, version)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -11,39 +11,71 @@ go get github.com/kbukum/gokit
 ## Quick Start
 
 ```go
-package main
+package config
 
 import (
-    "fmt"
-    "github.com/kbukum/gokit/config"
+    gkconfig "github.com/kbukum/gokit/config"
+    "github.com/kbukum/gokit/database"
+    "github.com/kbukum/gokit/redis"
+    "github.com/kbukum/gokit/server"
+    "github.com/kbukum/gokit/messaging/kafka"
+    "github.com/kbukum/gokit/discovery"
 )
 
-type AppConfig struct {
-    config.ServiceConfig `yaml:",inline" mapstructure:",squash"`
-    Port                 int    `yaml:"port" mapstructure:"port"`
-    DatabaseURL          string `yaml:"database_url" mapstructure:"database_url"`
-}
+// ServiceConfig embeds the base gokit config and adds infrastructure modules.
+type ServiceConfig struct {
+    gkconfig.ServiceConfig `yaml:",inline" mapstructure:",squash"`
 
-func main() {
-    var cfg AppConfig
-    if err := config.LoadConfig("my-service", &cfg); err != nil {
-        panic(err)
-    }
-    fmt.Printf("Running %s in %s mode\n", cfg.Name, cfg.Environment)
+    HTTP      server.Config    `yaml:"server" mapstructure:"server"`
+    Database  database.Config  `yaml:"database" mapstructure:"database"`
+    Redis     redis.Config     `yaml:"redis" mapstructure:"redis"`
+    Kafka     kafka.Config     `yaml:"kafka" mapstructure:"kafka"`
+    Discovery discovery.Config `yaml:"discovery" mapstructure:"discovery"`
 }
+```
+
+Then load it in your bootstrap:
+
+```go
+var cfg config.ServiceConfig
+if err := gkconfig.LoadConfig("my-service", &cfg); err != nil {
+    panic(err)
+}
+fmt.Printf("Running %s on %s:%d in %s mode\n",
+    cfg.Name, cfg.Address, cfg.Port, cfg.Environment)
 ```
 
 ## Key Types & Functions
 
 | Name | Description |
 |------|-------------|
-| `ServiceConfig` | Common fields: Name, Environment, Version, Debug, Logging |
+| `ServiceConfig` | Common fields: Name, Environment, Version, Address, Port, Debug, Logging |
 | `LoadConfig()` | Load config from YAML + env with auto-resolution |
-| `ConfigResolver` | Resolves config and .env file paths |
+| `Resolver` | Resolves config and .env file paths |
 | `WithConfigFile()` | Option to specify config file path |
 | `WithEnvFile()` | Option to specify .env file path |
+| `WithProfile()` | Option to load profile-specific env file |
 | `WithFileSystem()` | Option to inject custom filesystem |
 | `FileSystem` | Interface for file existence and env loading |
+
+### Loading Order (lowest → highest priority)
+
+1. YAML config file (`config.yml`)
+2. Profile env file (`config/profiles/{profile}.env`)
+3. `.env` file
+4. Environment variables
+
+### ServiceConfig Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Name` | `string` | `""` | Service name |
+| `Environment` | `string` | `"development"` | Deployment environment |
+| `Version` | `string` | `""` | Service version |
+| `Address` | `string` | `"0.0.0.0"` | Service bind address |
+| `Port` | `int` | `50051` | Service port |
+| `Debug` | `bool` | `false` | Debug mode (auto-enabled in development) |
+| `Logging` | `logger.Config` | | Logging configuration (level, format, etc.) |
 
 ### Environment Type
 
@@ -68,6 +100,10 @@ if env.IsDevelopment() {
 	// enable debug features
 }
 ```
+
+### Validation
+
+`ServiceConfig.Validate()` returns `errors.AppError` (from `github.com/kbukum/gokit/errors`) for validation failures.
 
 ---
 

--- a/config/loader.go
+++ b/config/loader.go
@@ -317,8 +317,8 @@ func pathsByPrefix(path, fileName string) []string {
 	}
 }
 
-// autoBindEnvVars binds environment variables to Viper using BindEnv (correct precedence)
-// instead of Set (which has the highest precedence and would override config file values).
+// autoBindEnvVars binds environment variables to Viper using BindEnv so config
+// file values still take precedence over environment variables when expected.
 // Only binds variables that match known config key patterns.
 func autoBindEnvVars(v *viper.Viper) {
 	for _, env := range os.Environ() {

--- a/config/service.go
+++ b/config/service.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/kbukum/gokit/errors"
 	"github.com/kbukum/gokit/logger"
 )
 
@@ -46,6 +47,8 @@ type ServiceConfig struct {
 	Name        string        `yaml:"name" mapstructure:"name"`
 	Environment string        `yaml:"environment" mapstructure:"environment"`
 	Version     string        `yaml:"version" mapstructure:"version"`
+	Address     string        `yaml:"address" mapstructure:"address"`
+	Port        int           `yaml:"port" mapstructure:"port"`
 	Debug       bool          `yaml:"debug" mapstructure:"debug"`
 	Logging     logger.Config `yaml:"logging" mapstructure:"logging"`
 }
@@ -68,6 +71,12 @@ func (c *ServiceConfig) ApplyDefaults() {
 	if c.Environment == "" {
 		c.Environment = "development"
 	}
+	if c.Address == "" {
+		c.Address = "0.0.0.0"
+	}
+	if c.Port == 0 {
+		c.Port = 50051
+	}
 	if c.Environment == "development" {
 		c.Debug = true
 	}
@@ -89,7 +98,7 @@ func (c *ServiceConfig) ApplyDefaults() {
 // Override this in embedding structs and call c.ServiceConfig.Validate() first.
 func (c *ServiceConfig) Validate() error {
 	if c.Name == "" {
-		return fmt.Errorf("config.name is required")
+		return errors.Validation("config.name is required")
 	}
 	validEnvs := []string{"development", "staging", "production"}
 	found := false
@@ -100,10 +109,10 @@ func (c *ServiceConfig) Validate() error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("config.environment must be one of [development, staging, production] (got: %s)", c.Environment)
+		return errors.Validation(fmt.Sprintf("config.environment must be one of [development, staging, production] (got: %s)", c.Environment))
 	}
 	if err := c.Logging.Validate(); err != nil {
-		return fmt.Errorf("config.logging: %w", err)
+		return errors.Validation(fmt.Sprintf("config.logging: %v", err))
 	}
 	return nil
 }

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -1,6 +1,6 @@
 # encryption
 
-AES-256-GCM encryption and decryption service for sensitive data.
+Symmetric encryption for gokit applications with AES-256-GCM and ChaCha20-Poly1305.
 
 ## Install
 
@@ -19,20 +19,19 @@ import (
 )
 
 func main() {
-    svc, err := encryption.NewService("my-secret-key")
+    // Default: AES-256-GCM
+    enc, err := encryption.New("my-secret-passphrase")
     if err != nil {
         panic(err)
     }
 
-    // Encrypt
-    ciphertext, err := svc.Encrypt("sensitive data")
+    ciphertext, err := enc.Encrypt("sensitive data")
     if err != nil {
         panic(err)
     }
     fmt.Println(ciphertext) // base64-encoded
 
-    // Decrypt
-    plaintext, err := svc.Decrypt(ciphertext)
+    plaintext, err := enc.Decrypt(ciphertext)
     if err != nil {
         panic(err)
     }
@@ -40,14 +39,48 @@ func main() {
 }
 ```
 
+## Algorithms
+
+| Algorithm | Constant | Best For |
+|-----------|----------|----------|
+| AES-256-GCM (default) | `AlgorithmAESGCM` | CPUs with AES-NI hardware acceleration |
+| ChaCha20-Poly1305 | `AlgorithmChaCha20` | CPUs without AES-NI (ARM, older x86) |
+
+```go
+// Explicit algorithm selection
+enc, err := encryption.New("key", encryption.WithAlgorithm(encryption.AlgorithmChaCha20))
+```
+
+## Key Derivation
+
+Keys are derived from passphrases using **PBKDF2-SHA256** with:
+- **600,000 iterations** (OWASP 2023 recommendation)
+- **Random 16-byte salt** per encryption operation
+
+## Ciphertext Format
+
+```
+base64(salt[16] || nonce[12] || ciphertext)
+```
+
+The salt is prepended to the ciphertext so decryption can extract it and re-derive the key.
+
 ## Key Types & Functions
 
 | Name | Description |
 |------|-------------|
-| `Service` | AES-256-GCM encryption/decryption service |
-| `NewService(key string)` | Create service (key is SHA-256 hashed to 32 bytes) |
-| `Encrypt(plaintext string)` | Encrypt to base64-encoded ciphertext |
-| `Decrypt(ciphertext string)` | Decrypt from base64-encoded ciphertext |
+| `Encryptor` | Interface: `Encrypt(string) (string, error)` and `Decrypt(string) (string, error)` |
+| `New(key, ...Option)` | Factory: creates an `Encryptor` for the chosen algorithm |
+| `WithAlgorithm(alg)` | Option: selects encryption algorithm |
+| `Service` | AES-256-GCM implementation |
+| `ChaCha20Service` | ChaCha20-Poly1305 implementation |
+
+## Security Considerations
+
+- Each encryption generates a unique random salt and nonce
+- PBKDF2 with 600k iterations resists brute-force and rainbow table attacks
+- Both algorithms provide authenticated encryption (AEAD)
+- The same plaintext encrypted twice produces different ciphertext
 
 ---
 

--- a/encryption/chacha20.go
+++ b/encryption/chacha20.go
@@ -8,61 +8,89 @@ import (
 	"io"
 
 	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 // ChaCha20Service handles encryption/decryption using ChaCha20-Poly1305.
 // This is a modern AEAD cipher that performs well on CPUs without AES hardware
 // acceleration (e.g., ARM devices, older processors).
 type ChaCha20Service struct {
-	aead interface {
-		Seal(dst, nonce, plaintext, additionalData []byte) []byte
-		Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error)
-		NonceSize() int
-	}
+	passphrase []byte
 }
 
 // NewChaCha20 creates a new ChaCha20-Poly1305 encryption service.
-// The key is hashed with SHA-256 to produce a consistent 32-byte key.
+// The key is derived using PBKDF2-SHA256 with a random salt per operation.
 func NewChaCha20(key string) (*ChaCha20Service, error) {
-	hasher := sha256.New()
-	hasher.Write([]byte(key))
-	keyBytes := hasher.Sum(nil)
+	return &ChaCha20Service{passphrase: []byte(key)}, nil
+}
 
-	aead, err := chacha20poly1305.New(keyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("create chacha20: %w", err)
-	}
-
-	return &ChaCha20Service{aead: aead}, nil
+func (s *ChaCha20Service) deriveKey(salt []byte) []byte {
+	return pbkdf2.Key(s.passphrase, salt, pbkdf2Iter, pbkdf2KeyLen, sha256.New)
 }
 
 // Encrypt encrypts plaintext and returns a base64-encoded result.
+// Format: base64(salt[16] || nonce[12] || ciphertext)
 func (s *ChaCha20Service) Encrypt(plaintext string) (string, error) {
-	nonce := make([]byte, s.aead.NonceSize())
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+
+	keyBytes := s.deriveKey(salt)
+
+	aead, err := chacha20poly1305.New(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("create chacha20: %w", err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("generate nonce: %w", err)
 	}
-	ciphertext := s.aead.Seal(nonce, nonce, []byte(plaintext), nil)
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
+
+	ciphertext := aead.Seal(nil, nonce, []byte(plaintext), nil)
+
+	// Format: salt || nonce || ciphertext
+	result := make([]byte, 0, len(salt)+len(nonce)+len(ciphertext))
+	result = append(result, salt...)
+	result = append(result, nonce...)
+	result = append(result, ciphertext...)
+
+	return base64.StdEncoding.EncodeToString(result), nil
 }
 
 // Decrypt decrypts a base64-encoded ciphertext.
+// Expects format: base64(salt[16] || nonce[12] || ciphertext)
 func (s *ChaCha20Service) Decrypt(ciphertext string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
 		return "", fmt.Errorf("decode base64: %w", err)
 	}
 
-	nonceSize := s.aead.NonceSize()
-	if len(data) < nonceSize {
+	if len(data) < saltSize {
 		return "", fmt.Errorf("ciphertext too short")
 	}
 
-	nonce, ciphertextData := data[:nonceSize], data[nonceSize:]
-	plaintext, err := s.aead.Open(nil, nonce, ciphertextData, nil)
+	salt := data[:saltSize]
+	remaining := data[saltSize:]
+
+	keyBytes := s.deriveKey(salt)
+
+	aead, err := chacha20poly1305.New(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("create chacha20: %w", err)
+	}
+
+	nonceSize := aead.NonceSize()
+	if len(remaining) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertextData := remaining[:nonceSize], remaining[nonceSize:]
+	plainBytes, err := aead.Open(nil, nonce, ciphertextData, nil)
 	if err != nil {
 		return "", fmt.Errorf("decrypt: %w", err)
 	}
 
-	return string(plaintext), nil
+	return string(plainBytes), nil
 }

--- a/encryption/doc.go
+++ b/encryption/doc.go
@@ -1,8 +1,10 @@
-// Package encryption provides AES-GCM encryption and decryption for
+// Package encryption provides symmetric encryption and decryption for
 // sensitive data in gokit applications.
 //
-// It supports automatic key derivation from passphrases using SHA-256
-// hashing, producing 256-bit keys for AES-GCM authenticated encryption.
+// It supports AES-256-GCM (default) and ChaCha20-Poly1305 algorithms with
+// PBKDF2-SHA256 key derivation (600,000 iterations, random 16-byte salt).
+//
+// Ciphertext format: base64(salt[16] || nonce[12] || ciphertext)
 //
 // # Usage
 //

--- a/encryption/encryption_test.go
+++ b/encryption/encryption_test.go
@@ -121,8 +121,10 @@ func TestDifferentKeysProduceDifferentCiphertexts(t *testing.T) {
 func TestNewServiceDifferentKeysNotEqual(t *testing.T) {
 	svc1, _ := NewService("key1")
 	svc2, _ := NewService("key2")
-	if svc1.gcm == svc2.gcm {
-		t.Error("different keys should produce different GCM instances")
+	ct, _ := svc1.Encrypt("test")
+	_, err := svc2.Decrypt(ct)
+	if err == nil {
+		t.Error("different keys should not decrypt each other's ciphertext")
 	}
 }
 

--- a/encryption/encryptor.go
+++ b/encryption/encryptor.go
@@ -33,7 +33,7 @@ func WithAlgorithm(alg Algorithm) Option {
 // New creates an Encryptor with the given key and options.
 // Default algorithm is AES-256-GCM. Use WithAlgorithm to select ChaCha20-Poly1305.
 //
-// The key is hashed to the required length for the chosen algorithm.
+// The key is derived using PBKDF2-SHA256 for the chosen algorithm.
 func New(key string, opts ...Option) (Encryptor, error) {
 	o := &options{algorithm: AlgorithmAESGCM}
 	for _, opt := range opts {

--- a/encryption/service.go
+++ b/encryption/service.go
@@ -8,60 +8,104 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const (
+	saltSize     = 16
+	pbkdf2Iter   = 600_000
+	pbkdf2KeyLen = 32
 )
 
 // Service handles encryption/decryption of sensitive data using AES-256-GCM.
 type Service struct {
-	gcm cipher.AEAD
+	passphrase []byte
 }
 
 // NewService creates a new encryption service with the given key.
-// The key is hashed with SHA-256 to produce a consistent 32-byte AES key.
+// The key is derived using PBKDF2-SHA256 with a random salt per operation.
 func NewService(key string) (*Service, error) {
-	hasher := sha256.New()
-	hasher.Write([]byte(key))
-	keyBytes := hasher.Sum(nil)
+	return &Service{passphrase: []byte(key)}, nil
+}
+
+func (s *Service) deriveKey(salt []byte) []byte {
+	return pbkdf2.Key(s.passphrase, salt, pbkdf2Iter, pbkdf2KeyLen, sha256.New)
+}
+
+// Encrypt encrypts plaintext and returns a base64-encoded result.
+// Format: base64(salt[16] || nonce[12] || ciphertext)
+func (s *Service) Encrypt(plaintext string) (string, error) {
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+
+	keyBytes := s.deriveKey(salt)
 
 	block, err := aes.NewCipher(keyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("create cipher: %w", err)
+		return "", fmt.Errorf("create cipher: %w", err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, fmt.Errorf("create GCM: %w", err)
+		return "", fmt.Errorf("create GCM: %w", err)
 	}
 
-	return &Service{gcm: gcm}, nil
-}
-
-// Encrypt encrypts plaintext and returns a base64-encoded result.
-func (s *Service) Encrypt(plaintext string) (string, error) {
-	nonce := make([]byte, s.gcm.NonceSize())
+	nonce := make([]byte, gcm.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("generate nonce: %w", err)
 	}
-	ciphertext := s.gcm.Seal(nonce, nonce, []byte(plaintext), nil)
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
+
+	ciphertext := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+
+	// Format: salt || nonce || ciphertext
+	result := make([]byte, 0, len(salt)+len(nonce)+len(ciphertext))
+	result = append(result, salt...)
+	result = append(result, nonce...)
+	result = append(result, ciphertext...)
+
+	return base64.StdEncoding.EncodeToString(result), nil
 }
 
 // Decrypt decrypts a base64-encoded ciphertext.
+// Expects format: base64(salt[16] || nonce[12] || ciphertext)
 func (s *Service) Decrypt(ciphertext string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
 		return "", fmt.Errorf("decode base64: %w", err)
 	}
 
-	nonceSize := s.gcm.NonceSize()
-	if len(data) < nonceSize {
+	if len(data) < saltSize {
 		return "", fmt.Errorf("ciphertext too short")
 	}
 
-	nonce, ciphertextData := data[:nonceSize], data[nonceSize:]
-	plaintext, err := s.gcm.Open(nil, nonce, ciphertextData, nil)
+	salt := data[:saltSize]
+	remaining := data[saltSize:]
+
+	keyBytes := s.deriveKey(salt)
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(remaining) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertextData := remaining[:nonceSize], remaining[nonceSize:]
+	plainBytes, err := gcm.Open(nil, nonce, ciphertextData, nil)
 	if err != nil {
 		return "", fmt.Errorf("decrypt: %w", err)
 	}
 
-	return string(plaintext), nil
+	return string(plainBytes), nil
 }

--- a/errors/README.md
+++ b/errors/README.md
@@ -6,7 +6,7 @@ Unified application error handling with HTTP status codes, error codes, and retr
 
 The `errors` module provides a structured approach to error handling across Go microservices. It moves away from simple string-based errors towards a machine-readable `AppError` type that includes semantic error codes, HTTP status mappings, and metadata.
 
-This design follows best practices such as RFC 7807 (Problem Details for HTTP APIs) and Google AIP-193. It allows services to communicate clearly about what went wrong, whether the client should retry, and provides structured details that can be easily parsed by frontend applications or observability tools.
+This design follows best practices such as RFC 9457 (Problem Details for HTTP APIs) and Google AIP-193. It allows services to communicate clearly about what went wrong, whether the client should retry, and provides structured details that can be easily parsed by frontend applications or observability tools.
 
 ## Installation
 
@@ -36,7 +36,7 @@ func main() {
 
 	// Check if it's an AppError and convert to response
 	if appErr, ok := errors.AsAppError(err); ok {
-		resp := appErr.ToResponse()
+		resp := appErr.ToProblemDetail()
 		// Send resp as JSON to the client
 		fmt.Printf("Response: %+v\n", resp)
 	}
@@ -55,7 +55,7 @@ This module does not require external configuration. It uses a predefined set of
 |-------|------|-------------|
 | `AppError` | `struct` | The core error type implementing the `error` interface. |
 | `ErrorCode` | `string` | A machine-readable string representing the error category. |
-| `ErrorResponse` | `struct` | The JSON-serializable structure for API responses. |
+| `ProblemDetail` | `struct` | RFC 9457 Problem Details response type for JSON serialization. |
 
 ### Common Constructors
 
@@ -75,18 +75,22 @@ The `ErrorCode` type defines all machine-readable error categories:
 |------|-------------|-----------|
 | `NOT_FOUND` | 404 | No |
 | `ALREADY_EXISTS` | 409 | No |
+| `CONFLICT` | 409 | No |
 | `INVALID_INPUT` | 422 | No |
 | `MISSING_FIELD` | 422 | No |
 | `INVALID_FORMAT` | 422 | No |
 | `UNAUTHORIZED` | 401 | No |
 | `FORBIDDEN` | 403 | No |
-| `INTERNAL` | 500 | No |
+| `TOKEN_EXPIRED` | 401 | No |
+| `INVALID_TOKEN` | 401 | No |
+| `INTERNAL_ERROR` | 500 | No |
 | `DATABASE_ERROR` | 500 | No |
+| `EXTERNAL_SERVICE_ERROR` | 500 | Yes |
 | `SERVICE_UNAVAILABLE` | 503 | Yes |
-| `CONNECTION_FAILED` | 503 | Yes |
+| `CONNECTION_FAILED` | 502 | Yes |
 | `TIMEOUT` | 504 | Yes |
 | `RATE_LIMITED` | 429 | Yes |
-| `EXTERNAL_SERVICE_ERROR` | 502 | Yes |
+| `CANCELED` | 499 | No |
 
 ### Builder Methods
 
@@ -94,17 +98,17 @@ The `ErrorCode` type defines all machine-readable error categories:
 - `WithDetail(key string, value any)`: Adds a single piece of metadata.
 - `WithDetails(map[string]any)`: Merges multiple pieces of metadata.
 
-### RFC 7807 Support
+### RFC 9457 Support
 
-Convert any `AppError` to an [RFC 7807 Problem Details](https://www.rfc-editor.org/rfc/rfc7807) response:
+Convert any `AppError` to an [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) response:
 
 ```go
 appErr := errors.NotFound("user", "abc-123")
-rfc := appErr.ToRFC7807()
-// RFC7807Response{Type, Title, Status, Detail, Instance}
+rfc := appErr.ToProblemDetail()
+// ProblemDetail{Type, Title, Status, Detail, Instance, Code, Retryable, Details}
 ```
 
-The `RFC7807Response` struct includes `Type`, `Title`, `Status`, `Detail`, and `Instance` fields suitable for direct JSON serialization in HTTP APIs.
+The `ProblemDetail` struct includes `Type`, `Title`, `Status`, `Detail`, `Instance`, `Code`, `Retryable`, and `Details` fields suitable for direct JSON serialization in HTTP APIs.
 
 ## Advanced Usage
 

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -59,6 +59,13 @@ const (
 	ErrCodeExternalService ErrorCode = "EXTERNAL_SERVICE_ERROR"
 )
 
+// Lifecycle errors (not retryable, not a server fault)
+const (
+	// ErrCodeCanceled indicates the operation was canceled by the caller or system
+	// before completion (e.g., context cancellation, client disconnect).
+	ErrCodeCanceled ErrorCode = "CANCELED"
+)
+
 var retryableCodes = map[ErrorCode]bool{
 	ErrCodeServiceUnavailable: true,
 	ErrCodeConnectionFailed:   true,
@@ -66,6 +73,7 @@ var retryableCodes = map[ErrorCode]bool{
 	ErrCodeRateLimited:        true,
 	ErrCodeExternalService:    true,
 	ErrCodeInternal:           false,
+	ErrCodeCanceled:           false,
 }
 
 // IsRetryableCode returns true if the error code indicates a retryable error.
@@ -91,7 +99,7 @@ var grpcCodeMap = map[ErrorCode]codes.Code{
 	ErrCodeTokenExpired:       codes.Unauthenticated,
 	ErrCodeInvalidToken:       codes.Unauthenticated,
 	ErrCodeForbidden:          codes.PermissionDenied,
-	ErrCodeConflict:           codes.FailedPrecondition,
+	ErrCodeConflict:           codes.Aborted,
 	ErrCodeTimeout:            codes.DeadlineExceeded,
 	ErrCodeRateLimited:        codes.ResourceExhausted,
 	ErrCodeServiceUnavailable: codes.Unavailable,
@@ -99,4 +107,5 @@ var grpcCodeMap = map[ErrorCode]codes.Code{
 	ErrCodeInternal:           codes.Internal,
 	ErrCodeDatabaseError:      codes.Internal,
 	ErrCodeExternalService:    codes.Internal,
+	ErrCodeCanceled:           codes.Canceled,
 }

--- a/errors/codes_test.go
+++ b/errors/codes_test.go
@@ -23,7 +23,7 @@ func TestErrorCode_GRPCCode(t *testing.T) {
 		{"TokenExpired", ErrCodeTokenExpired, codes.Unauthenticated},
 		{"InvalidToken", ErrCodeInvalidToken, codes.Unauthenticated},
 		{"Forbidden", ErrCodeForbidden, codes.PermissionDenied},
-		{"Conflict", ErrCodeConflict, codes.FailedPrecondition},
+		{"Conflict", ErrCodeConflict, codes.Aborted},
 		{"Timeout", ErrCodeTimeout, codes.DeadlineExceeded},
 		{"RateLimited", ErrCodeRateLimited, codes.ResourceExhausted},
 		{"ServiceUnavailable", ErrCodeServiceUnavailable, codes.Unavailable},
@@ -31,6 +31,7 @@ func TestErrorCode_GRPCCode(t *testing.T) {
 		{"Internal", ErrCodeInternal, codes.Internal},
 		{"DatabaseError", ErrCodeDatabaseError, codes.Internal},
 		{"ExternalService", ErrCodeExternalService, codes.Internal},
+		{"Canceled", ErrCodeCanceled, codes.Canceled},
 		{"Unknown code defaults to Internal", ErrorCode("UNKNOWN"), codes.Internal},
 	}
 

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,4 +1,4 @@
 // Package errors provides unified error handling for Go services.
 // It implements structured error types with error codes, HTTP status mapping,
-// and retryable detection following RFC 7807 and Google AIP-193.
+// and retryable detection following RFC 9457 and Google AIP-193.
 package errors

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -86,7 +86,7 @@ func ServiceUnavailable(service string) *AppError {
 func ConnectionFailed(service string) *AppError {
 	return &AppError{
 		Code: ErrCodeConnectionFailed, Message: fmt.Sprintf("Unable to connect to %s. Please verify the service is running.", service),
-		HTTPStatus: http.StatusServiceUnavailable, Retryable: true,
+		HTTPStatus: http.StatusBadGateway, Retryable: true,
 		Details: map[string]any{"service": service},
 	}
 }
@@ -233,8 +233,17 @@ func DatabaseError(cause error) *AppError {
 func ExternalServiceError(service string, cause error) *AppError {
 	return &AppError{
 		Code: ErrCodeExternalService, Message: fmt.Sprintf("The %s service encountered an error. Please try again.", service),
-		HTTPStatus: http.StatusBadGateway, Retryable: true,
+		HTTPStatus: http.StatusInternalServerError, Retryable: true,
 		Details: map[string]any{"service": service}, Cause: cause,
+	}
+}
+
+// Canceled creates a new AppError for an operation that was canceled.
+func Canceled(operation string) *AppError {
+	return &AppError{
+		Code: ErrCodeCanceled, Message: fmt.Sprintf("The %s operation was canceled.", operation),
+		HTTPStatus: 499, Retryable: false,
+		Details: map[string]any{"operation": operation},
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -218,7 +218,7 @@ func TestAppError_Constructors_Table(t *testing.T) {
 		retryable bool
 	}{
 		{"ServiceUnavailable", ServiceUnavailable("api"), ErrCodeServiceUnavailable, http.StatusServiceUnavailable, true},
-		{"ConnectionFailed", ConnectionFailed("db"), ErrCodeConnectionFailed, http.StatusServiceUnavailable, true},
+		{"ConnectionFailed", ConnectionFailed("db"), ErrCodeConnectionFailed, http.StatusBadGateway, true},
 		{"Timeout", Timeout("query"), ErrCodeTimeout, http.StatusGatewayTimeout, true},
 		{"RateLimited", RateLimited(), ErrCodeRateLimited, http.StatusTooManyRequests, true},
 		{"AlreadyExists", AlreadyExists("user"), ErrCodeAlreadyExists, http.StatusConflict, false},
@@ -227,7 +227,7 @@ func TestAppError_Constructors_Table(t *testing.T) {
 		{"InvalidFormat", InvalidFormat("date", "RFC3339"), ErrCodeInvalidFormat, http.StatusUnprocessableEntity, false},
 		{"InvalidToken", InvalidToken(), ErrCodeInvalidToken, http.StatusUnauthorized, false},
 		{"DatabaseError", DatabaseError(nil), ErrCodeDatabaseError, http.StatusInternalServerError, false},
-		{"ExternalServiceError", ExternalServiceError("stripe", nil), ErrCodeExternalService, http.StatusBadGateway, true},
+		{"ExternalServiceError", ExternalServiceError("stripe", nil), ErrCodeExternalService, http.StatusInternalServerError, true},
 		{"Validation", Validation("bad input"), ErrCodeInvalidInput, http.StatusUnprocessableEntity, false},
 	}
 
@@ -389,7 +389,7 @@ func TestErrorCode_HTTPStatusMapping_All(t *testing.T) {
 	}{
 		// Connection/Availability (retryable)
 		{ErrCodeServiceUnavailable, http.StatusServiceUnavailable},
-		{ErrCodeConnectionFailed, http.StatusServiceUnavailable},
+		{ErrCodeConnectionFailed, http.StatusBadGateway},
 		{ErrCodeTimeout, http.StatusGatewayTimeout},
 		{ErrCodeRateLimited, http.StatusTooManyRequests},
 		// Resource
@@ -408,7 +408,7 @@ func TestErrorCode_HTTPStatusMapping_All(t *testing.T) {
 		// Internal
 		{ErrCodeInternal, http.StatusInternalServerError},
 		{ErrCodeDatabaseError, http.StatusInternalServerError},
-		{ErrCodeExternalService, http.StatusBadGateway},
+		{ErrCodeExternalService, http.StatusInternalServerError},
 	}
 
 	constructorForCode := map[ErrorCode]func() *AppError{
@@ -505,7 +505,7 @@ func TestToProblemDetail_AllCodes(t *testing.T) {
 		status      int
 	}{
 		{ErrCodeServiceUnavailable, "https://gokit.dev/errors/service-unavailable", http.StatusServiceUnavailable},
-		{ErrCodeConnectionFailed, "https://gokit.dev/errors/connection-failed", http.StatusServiceUnavailable},
+		{ErrCodeConnectionFailed, "https://gokit.dev/errors/connection-failed", http.StatusBadGateway},
 		{ErrCodeTimeout, "https://gokit.dev/errors/timeout", http.StatusGatewayTimeout},
 		{ErrCodeRateLimited, "https://gokit.dev/errors/rate-limited", http.StatusTooManyRequests},
 		{ErrCodeNotFound, "https://gokit.dev/errors/not-found", http.StatusNotFound},
@@ -520,7 +520,7 @@ func TestToProblemDetail_AllCodes(t *testing.T) {
 		{ErrCodeInvalidToken, "https://gokit.dev/errors/invalid-token", http.StatusUnauthorized},
 		{ErrCodeInternal, "https://gokit.dev/errors/internal-error", http.StatusInternalServerError},
 		{ErrCodeDatabaseError, "https://gokit.dev/errors/database-error", http.StatusInternalServerError},
-		{ErrCodeExternalService, "https://gokit.dev/errors/external-service-error", http.StatusBadGateway},
+		{ErrCodeExternalService, "https://gokit.dev/errors/external-service-error", http.StatusInternalServerError},
 	}
 
 	constructorForCode := map[ErrorCode]func() *AppError{

--- a/errors/response.go
+++ b/errors/response.go
@@ -8,11 +8,8 @@ import (
 )
 
 // typeBaseURI holds the configurable base URI for problem type URIs.
-//
-// Default: "https://gokit.dev/errors/". The default is materialized on first
-// read (lazy) rather than at package init() to avoid registering side effects
-// in the package import graph (F-066). Callers that need a different base
-// must call SetTypeBaseURI before any error response is rendered.
+// Callers that need a different base must call SetTypeBaseURI before
+// any error response is rendered.
 const defaultTypeBaseURI = "https://gokit.dev/errors/"
 
 var typeBaseURI atomic.Value

--- a/logger/component_registry.go
+++ b/logger/component_registry.go
@@ -8,7 +8,7 @@ import (
 
 // ComponentRegistry tracks components during bootstrap for summary display.
 type ComponentRegistry struct {
-	mu             sync.Mutex
+	mu             sync.RWMutex
 	startTime      time.Time
 	infrastructure []InfraComponent
 	services       []ServiceComponent
@@ -81,8 +81,7 @@ func NewComponentRegistry() *ComponentRegistry {
 	}
 }
 
-// SetAPIPrefix sets the API prefix (for example "/api/v1") so route grouping
-// can be done using the configured prefix instead of hard-coded values.
+// SetAPIPrefix sets the API prefix (for example "/api/v1") for route grouping.
 func (r *ComponentRegistry) SetAPIPrefix(prefix string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -91,8 +90,8 @@ func (r *ComponentRegistry) SetAPIPrefix(prefix string) {
 
 // APIPrefix returns the configured API prefix.
 func (r *ComponentRegistry) APIPrefix() string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.apiPrefix
 }
 
@@ -172,36 +171,36 @@ func (r *ComponentRegistry) RegisterConsumer(name, groupID, topic string, partit
 
 // Infrastructure returns all registered infrastructure components.
 func (r *ComponentRegistry) Infrastructure() []InfraComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]InfraComponent(nil), r.infrastructure...)
 }
 
 // Services returns all registered service components.
 func (r *ComponentRegistry) Services() []ServiceComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]ServiceComponent(nil), r.services...)
 }
 
 // Repositories returns all registered repository components.
 func (r *ComponentRegistry) Repositories() []RepositoryComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]RepositoryComponent(nil), r.repositories...)
 }
 
 // Clients returns all registered client components.
 func (r *ComponentRegistry) Clients() []ClientComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]ClientComponent(nil), r.clients...)
 }
 
 // Handlers returns all registered handler components.
 func (r *ComponentRegistry) Handlers() []HandlerComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]HandlerComponent(nil), r.handlers...)
 }
 
@@ -214,7 +213,7 @@ func (r *ComponentRegistry) SetHandlers(handlers []HandlerComponent) {
 
 // Consumers returns all registered consumer components.
 func (r *ComponentRegistry) Consumers() []ConsumerComponent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return append([]ConsumerComponent(nil), r.consumers...)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,6 +69,9 @@ func New(cfg *Config, serviceName string) *Logger {
 	if cfg.Caller {
 		zl = zl.With().Caller().Logger()
 	}
+	if cfg.Stacktrace {
+		zl = zl.With().Stack().Logger()
+	}
 
 	zl = zl.Level(level)
 

--- a/util/clock.go
+++ b/util/clock.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock abstracts time so that production code can use SystemClock while tests
+// inject a FakeClock with a controllable instant.
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock is a real clock backed by time.Now().UTC().
+type SystemClock struct{}
+
+// Now returns the current UTC time.
+func (SystemClock) Now() time.Time { return time.Now().UTC() }
+
+// FakeClock is a deterministic clock for tests. Advance or set the time
+// manually to exercise time-dependent logic without real delays.
+type FakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFakeClock creates a FakeClock starting at initial. If initial is the zero
+// value, it defaults to 2024-01-01T00:00:00Z.
+func NewFakeClock(initial time.Time) *FakeClock {
+	if initial.IsZero() {
+		initial = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+	return &FakeClock{now: initial}
+}
+
+// Now returns the current fake time.
+func (c *FakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Advance moves the clock forward by d.
+func (c *FakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// Set sets an absolute time.
+func (c *FakeClock) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = t
+}

--- a/util/clock_test.go
+++ b/util/clock_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSystemClock_Now(t *testing.T) {
+	c := SystemClock{}
+	now := c.Now()
+	diff := time.Since(now)
+	if diff < 0 || diff > 2*time.Second {
+		t.Errorf("SystemClock.Now() returned %v, expected close to now", now)
+	}
+}
+
+func TestFakeClock_Default(t *testing.T) {
+	c := NewFakeClock(time.Time{})
+	expected := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	if got := c.Now(); !got.Equal(expected) {
+		t.Errorf("default FakeClock = %v, want %v", got, expected)
+	}
+}
+
+func TestFakeClock_Advance(t *testing.T) {
+	c := NewFakeClock(time.Time{})
+	c.Advance(30 * time.Second)
+	expected := time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC)
+	if got := c.Now(); !got.Equal(expected) {
+		t.Errorf("after advance = %v, want %v", got, expected)
+	}
+}
+
+func TestFakeClock_Set(t *testing.T) {
+	c := NewFakeClock(time.Time{})
+	target := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	c.Set(target)
+	if got := c.Now(); !got.Equal(target) {
+		t.Errorf("after set = %v, want %v", got, target)
+	}
+}
+
+func TestFakeClock_CustomInitial(t *testing.T) {
+	initial := time.Date(2020, 5, 1, 8, 30, 0, 0, time.UTC)
+	c := NewFakeClock(initial)
+	if got := c.Now(); !got.Equal(initial) {
+		t.Errorf("custom initial = %v, want %v", got, initial)
+	}
+}

--- a/util/merge.go
+++ b/util/merge.go
@@ -1,0 +1,25 @@
+package util
+
+// DeepMerge recursively merges override into base (override wins).
+// Returns a new map — neither input is mutated.
+// When both values for a key are map[string]any they are merged recursively;
+// otherwise the override value replaces the base.
+func DeepMerge(base, override map[string]any) map[string]any {
+	result := make(map[string]any, len(base))
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, overVal := range override {
+		baseVal, exists := result[k]
+		if exists {
+			baseMap, baseOk := baseVal.(map[string]any)
+			overMap, overOk := overVal.(map[string]any)
+			if baseOk && overOk {
+				result[k] = DeepMerge(baseMap, overMap)
+				continue
+			}
+		}
+		result[k] = overVal
+	}
+	return result
+}

--- a/util/merge_test.go
+++ b/util/merge_test.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeepMerge_Shallow(t *testing.T) {
+	base := map[string]any{"a": 1, "b": 2}
+	over := map[string]any{"b": 3, "c": 4}
+	got := DeepMerge(base, over)
+	want := map[string]any{"a": 1, "b": 3, "c": 4}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("shallow merge = %v, want %v", got, want)
+	}
+}
+
+func TestDeepMerge_Nested(t *testing.T) {
+	base := map[string]any{
+		"db": map[string]any{"host": "localhost", "port": 5432},
+	}
+	over := map[string]any{
+		"db": map[string]any{"port": 3306, "name": "mydb"},
+	}
+	got := DeepMerge(base, over)
+	want := map[string]any{
+		"db": map[string]any{"host": "localhost", "port": 3306, "name": "mydb"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("nested merge = %v, want %v", got, want)
+	}
+}
+
+func TestDeepMerge_OverrideNonMap(t *testing.T) {
+	base := map[string]any{"a": 1}
+	over := map[string]any{"a": []int{1, 2, 3}}
+	got := DeepMerge(base, over)
+	if !reflect.DeepEqual(got["a"], []int{1, 2, 3}) {
+		t.Errorf("override non-map = %v, want [1,2,3]", got["a"])
+	}
+}
+
+func TestDeepMerge_EmptyBase(t *testing.T) {
+	got := DeepMerge(map[string]any{}, map[string]any{"a": 1})
+	want := map[string]any{"a": 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty base = %v, want %v", got, want)
+	}
+}
+
+func TestDeepMerge_EmptyOverride(t *testing.T) {
+	base := map[string]any{"a": 1}
+	got := DeepMerge(base, map[string]any{})
+	if !reflect.DeepEqual(got, base) {
+		t.Errorf("empty override = %v, want %v", got, base)
+	}
+}
+
+func TestDeepMerge_DoesNotMutate(t *testing.T) {
+	base := map[string]any{"a": 1}
+	over := map[string]any{"b": 2}
+	_ = DeepMerge(base, over)
+	if len(base) != 1 {
+		t.Error("base was mutated")
+	}
+	if len(over) != 1 {
+		t.Error("override was mutated")
+	}
+}
+
+func TestDeepMerge_DeeplyNested(t *testing.T) {
+	base := map[string]any{
+		"l1": map[string]any{
+			"l2": map[string]any{
+				"l3": map[string]any{"a": 1},
+			},
+		},
+	}
+	over := map[string]any{
+		"l1": map[string]any{
+			"l2": map[string]any{
+				"l3": map[string]any{"b": 2},
+			},
+		},
+	}
+	got := DeepMerge(base, over)
+	want := map[string]any{
+		"l1": map[string]any{
+			"l2": map[string]any{
+				"l3": map[string]any{"a": 1, "b": 2},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deeply nested = %v, want %v", got, want)
+	}
+}

--- a/validation/README.md
+++ b/validation/README.md
@@ -48,7 +48,8 @@ func main() {
 | `FieldError` | Individual field validation error |
 | `New()` | Create a new Validator |
 | `Required()` / `RequiredUUID()` / `OptionalUUID()` | Presence checks |
-| `MinLength()` / `MaxLength()` / `Range()` / `Min()` / `Max()` | Size/range rules |
+| `MinLength()` / `MaxLength()` / `InRange()` / `MinValue()` / `MaxValue()` | Size/range rules |
+| `Email()` / `URL()` | Email and URL format checks |
 | `Pattern()` / `OneOf()` / `Custom()` | Pattern, enum, and custom rules |
 | `Validate(s any)` | Struct tag validation using `validate` tags |
 | `ValidateUUID()` | Parse and validate UUID string |

--- a/validation/doc.go
+++ b/validation/doc.go
@@ -10,11 +10,11 @@
 //	    Name  string `validate:"required,min=2"`
 //	    Email string `validate:"required,email"`
 //	}
-//	err := validation.ValidateStruct(cmd)
+//	err := validation.Validate(cmd)
 //
 // # Programmatic Validation
 //
 //	v := validation.New()
-//	v.Check(name != "", "name", "name is required")
-//	err := v.Error()
+//	v.Custom(name != "", "name", "name is required")
+//	appErr := v.Validate()
 package validation

--- a/validation/validation_bench_test.go
+++ b/validation/validation_bench_test.go
@@ -9,7 +9,7 @@ func BenchmarkValidator_HappyPath(b *testing.B) {
 			Required("name", "alice").
 			MaxLength("name", "alice", 64).
 			MinLength("name", "alice", 1).
-			Range("age", 30, 0, 120).
+			InRange("age", 30, 0, 120).
 			OneOf("role", "admin", []string{"admin", "user", "guest"})
 		if err := v.Validate(); err != nil {
 			b.Fatalf("validate: %v", err)
@@ -23,7 +23,7 @@ func BenchmarkValidator_FailFast(b *testing.B) {
 		v := New().
 			Required("name", "").
 			MaxLength("name", "", 0).
-			Range("age", 999, 0, 120)
+			InRange("age", 999, 0, 120)
 		if err := v.Validate(); err == nil {
 			b.Fatal("expected error")
 		}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -109,19 +109,19 @@ func TestValidatorMinLength(t *testing.T) {
 
 func TestValidatorRange(t *testing.T) {
 	v := New()
-	v.Range("age", 25, 18, 100)
+	v.InRange("age", 25, 18, 100)
 	if v.HasErrors() {
 		t.Error("expected no error for value in range")
 	}
 
 	v2 := New()
-	v2.Range("age", 5, 18, 100)
+	v2.InRange("age", 5, 18, 100)
 	if !v2.HasErrors() {
 		t.Error("expected error for value below range")
 	}
 
 	v3 := New()
-	v3.Range("age", 101, 18, 100)
+	v3.InRange("age", 101, 18, 100)
 	if !v3.HasErrors() {
 		t.Error("expected error for value above range")
 	}
@@ -129,20 +129,20 @@ func TestValidatorRange(t *testing.T) {
 
 func TestValidatorMinMax(t *testing.T) {
 	v := New()
-	v.Min("count", 5, 1)
-	v.Max("count", 5, 10)
+	v.MinValue("count", 5, 1)
+	v.MaxValue("count", 5, 10)
 	if v.HasErrors() {
 		t.Error("expected no errors")
 	}
 
 	v2 := New()
-	v2.Min("count", 0, 1)
+	v2.MinValue("count", 0, 1)
 	if !v2.HasErrors() {
 		t.Error("expected error for value below min")
 	}
 
 	v3 := New()
-	v3.Max("count", 11, 10)
+	v3.MaxValue("count", 11, 10)
 	if !v3.HasErrors() {
 		t.Error("expected error for value above max")
 	}
@@ -232,7 +232,7 @@ func TestValidatorValidate(t *testing.T) {
 
 func TestValidatorChaining(t *testing.T) {
 	v := New()
-	result := v.Required("name", "John").MaxLength("name", "John", 100).Min("age", 25, 18)
+	result := v.Required("name", "John").MaxLength("name", "John", 100).MinValue("age", 25, 18)
 	if result != v {
 		t.Error("expected chaining to return same validator")
 	}
@@ -452,7 +452,7 @@ func TestMin_TableDriven(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			v := New()
-			v.Min("f", tt.value, tt.minVal)
+			v.MinValue("f", tt.value, tt.minVal)
 			if got := v.HasErrors(); got != tt.wantErr {
 				t.Errorf("Min(%d, %d): HasErrors() = %v, want %v",
 					tt.value, tt.minVal, got, tt.wantErr)
@@ -480,7 +480,7 @@ func TestMax_TableDriven(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			v := New()
-			v.Max("f", tt.value, tt.maxVal)
+			v.MaxValue("f", tt.value, tt.maxVal)
 			if got := v.HasErrors(); got != tt.wantErr {
 				t.Errorf("Max(%d, %d): HasErrors() = %v, want %v",
 					tt.value, tt.maxVal, got, tt.wantErr)
@@ -512,7 +512,7 @@ func TestRange_TableDriven(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			v := New()
-			v.Range("f", tt.value, tt.minVal, tt.maxVal)
+			v.InRange("f", tt.value, tt.minVal, tt.maxVal)
 			if got := v.HasErrors(); got != tt.wantErr {
 				t.Errorf("Range(%d, %d, %d): HasErrors() = %v, want %v",
 					tt.value, tt.minVal, tt.maxVal, got, tt.wantErr)
@@ -534,7 +534,6 @@ func TestPattern_TableDriven(t *testing.T) {
 		{"empty value skips", "", `^[a-z]+$`, false},
 		{"email-like pattern", "a@b.com", `^.+@.+\..+$`, false},
 		{"partial match rejected", "123abc", `^[a-z]+$`, true},
-		{"invalid regex reports error", "test", `[invalid`, true},
 		{"unicode pattern", "日本語", `^[\p{Han}\p{Hiragana}\p{Katakana}]+$`, false},
 		{"dot matches char", "a", `.`, false},
 	}
@@ -702,9 +701,9 @@ func TestChainingReturnsSameInstance(t *testing.T) {
 		Required("a", "val").
 		MinLength("b", "val", 1).
 		MaxLength("c", "val", 100).
-		Min("d", 5, 0).
-		Max("e", 5, 10).
-		Range("f", 5, 0, 10).
+		MinValue("d", 5, 0).
+		MaxValue("e", 5, 10).
+		InRange("f", 5, 0, 10).
 		Pattern("g", "abc", `^[a-z]+$`).
 		OneOf("h", "x", []string{"x", "y"}).
 		RequiredUUID("i", uuid.New().String()).
@@ -742,7 +741,7 @@ func TestMultipleErrors_Collected(t *testing.T) {
 	v := New()
 	v.Required("name", "")
 	v.Required("email", "")
-	v.Min("age", -1, 0)
+	v.MinValue("age", -1, 0)
 	v.MaxLength("bio", strings.Repeat("x", 300), 255)
 
 	errs := v.Errors()
@@ -765,7 +764,7 @@ func TestValidate_MultipleErrors_AppErrorContainsAll(t *testing.T) {
 	v := New()
 	v.Required("first_name", "")
 	v.Required("last_name", "")
-	v.Min("score", -10, 0)
+	v.MinValue("score", -10, 0)
 
 	appErr := v.Validate()
 	if appErr == nil {
@@ -1175,9 +1174,9 @@ func TestEdge_ExtremelyLargeStringInput(t *testing.T) {
 func TestEdge_ZeroIntValues(t *testing.T) {
 	t.Parallel()
 	v := New()
-	v.Min("f", 0, 0)
-	v.Max("f", 0, 0)
-	v.Range("f", 0, 0, 0)
+	v.MinValue("f", 0, 0)
+	v.MaxValue("f", 0, 0)
+	v.InRange("f", 0, 0, 0)
 	if v.HasErrors() {
 		t.Error("zero should pass min=0, max=0, range(0,0)")
 	}
@@ -1439,5 +1438,118 @@ func TestValidator_ConcurrentStructValidation(t *testing.T) {
 	}
 	for i := 0; i < 50; i++ {
 		<-done
+	}
+}
+
+func TestValidatorEmail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid email", "user@example.com", false},
+		{"valid with plus", "user+tag@example.com", false},
+		{"valid subdomain", "user@sub.example.com", false},
+		{"missing @", "userexample.com", true},
+		{"missing domain", "user@", true},
+		{"missing local", "@example.com", true},
+		{"no tld", "user@example", true},
+		{"empty skipped", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := New()
+			v.Email("email", tt.value)
+			if got := v.HasErrors(); got != tt.wantErr {
+				t.Errorf("Email(%q): HasErrors() = %v, want %v", tt.value, got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatorURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid http", "http://example.com", false},
+		{"valid https", "https://example.com", false},
+		{"no scheme", "example.com", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"empty skipped", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := New()
+			v.URL("url", tt.value)
+			if got := v.HasErrors(); got != tt.wantErr {
+				t.Errorf("URL(%q): HasErrors() = %v, want %v", tt.value, got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPatternPanicsOnInvalidRegex(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for invalid regex pattern")
+		}
+		msg := fmt.Sprintf("%v", r)
+		if !strings.Contains(msg, "invalid regex pattern") {
+			t.Errorf("unexpected panic message: %s", msg)
+		}
+	}()
+	New().Pattern("field", "value", "[invalid")
+}
+
+func TestValidatorBefore(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		deadline  string
+		wantError bool
+	}{
+		{"before_passes", "2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", false},
+		{"equal_fails", "2025-01-01T00:00:00Z", "2025-01-01T00:00:00Z", true},
+		{"after_fails", "2026-01-01T00:00:00Z", "2025-01-01T00:00:00Z", true},
+		{"empty_skipped", "", "2025-01-01T00:00:00Z", false},
+		{"invalid_value_fails", "not-a-date", "2025-01-01T00:00:00Z", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := New().Before("t", tt.value, tt.deadline)
+			if v.HasErrors() != tt.wantError {
+				t.Errorf("HasErrors=%v, want %v", v.HasErrors(), tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidatorAfter(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		floor     string
+		wantError bool
+	}{
+		{"after_passes", "2026-01-01T00:00:00Z", "2025-01-01T00:00:00Z", false},
+		{"equal_fails", "2025-01-01T00:00:00Z", "2025-01-01T00:00:00Z", true},
+		{"before_fails", "2024-01-01T00:00:00Z", "2025-01-01T00:00:00Z", true},
+		{"empty_skipped", "", "2025-01-01T00:00:00Z", false},
+		{"invalid_value_fails", "garbage", "2025-01-01T00:00:00Z", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := New().After("t", tt.value, tt.floor)
+			if v.HasErrors() != tt.wantError {
+				t.Errorf("HasErrors=%v, want %v", v.HasErrors(), tt.wantError)
+			}
+		})
 	}
 }

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -121,24 +122,24 @@ func (v *Validator) MinLength(field, value string, minLen int) *Validator {
 	return v
 }
 
-// Range checks if a number is within a range.
-func (v *Validator) Range(field string, value, minVal, maxVal int) *Validator {
+// InRange checks if a number is within an inclusive range.
+func (v *Validator) InRange(field string, value, minVal, maxVal int) *Validator {
 	if value < minVal || value > maxVal {
 		v.AddError(field, fmt.Sprintf("must be between %d and %d", minVal, maxVal))
 	}
 	return v
 }
 
-// Min checks if a number meets minimum value.
-func (v *Validator) Min(field string, value, minVal int) *Validator {
+// MinValue checks if a number meets the minimum value.
+func (v *Validator) MinValue(field string, value, minVal int) *Validator {
 	if value < minVal {
 		v.AddError(field, fmt.Sprintf("must be at least %d", minVal))
 	}
 	return v
 }
 
-// Max checks if a number is within max value.
-func (v *Validator) Max(field string, value, maxVal int) *Validator {
+// MaxValue checks if a number does not exceed the maximum value.
+func (v *Validator) MaxValue(field string, value, maxVal int) *Validator {
 	if value > maxVal {
 		v.AddError(field, fmt.Sprintf("must be %d or less", maxVal))
 	}
@@ -150,9 +151,36 @@ func (v *Validator) Pattern(field, value, pattern string) *Validator {
 	if value == "" {
 		return v
 	}
-	matched, err := regexp.MatchString(pattern, value)
-	if err != nil || !matched {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		panic(fmt.Sprintf("validation: invalid regex pattern %q: %v", pattern, err))
+	}
+	if !re.MatchString(value) {
 		v.AddError(field, "does not match required format")
+	}
+	return v
+}
+
+// Email checks if a string is a valid email address.
+func (v *Validator) Email(field, value string) *Validator {
+	if value == "" {
+		return v
+	}
+	// Simple email validation: local@domain.tld
+	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+	if !emailRegex.MatchString(value) {
+		v.AddError(field, "must be a valid email address")
+	}
+	return v
+}
+
+// URL checks if a string is a valid HTTP or HTTPS URL.
+func (v *Validator) URL(field, value string) *Validator {
+	if value == "" {
+		return v
+	}
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		v.AddError(field, "must be a valid URL")
 	}
 	return v
 }
@@ -175,6 +203,48 @@ func (v *Validator) OneOf(field, value string, allowed []string) *Validator {
 func (v *Validator) Custom(condition bool, field, message string) *Validator {
 	if !condition {
 		v.AddError(field, message)
+	}
+	return v
+}
+
+// Before checks that value (RFC 3339 datetime string) is strictly before deadline.
+// Empty values are skipped (use Required first).
+func (v *Validator) Before(field, value, deadline string) *Validator {
+	if value == "" {
+		return v
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		v.AddError(field, "must be a valid datetime")
+		return v
+	}
+	d, err := time.Parse(time.RFC3339, deadline)
+	if err != nil {
+		return v
+	}
+	if !t.Before(d) {
+		v.AddError(field, fmt.Sprintf("must be before %s", deadline))
+	}
+	return v
+}
+
+// After checks that value (RFC 3339 datetime string) is strictly after floor.
+// Empty values are skipped (use Required first).
+func (v *Validator) After(field, value, floor string) *Validator {
+	if value == "" {
+		return v
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		v.AddError(field, "must be a valid datetime")
+		return v
+	}
+	f, err := time.Parse(time.RFC3339, floor)
+	if err != nil {
+		return v
+	}
+	if !t.After(f) {
+		v.AddError(field, fmt.Sprintf("must be after %s", floor))
 	}
 	return v
 }

--- a/version/README.md
+++ b/version/README.md
@@ -42,8 +42,8 @@ go build -ldflags "-X github.com/kbukum/gokit/version.Version=1.2.3 \
 
 | Name | Description |
 |------|-------------|
-| `Info` | Struct with Version, GitCommit, GitBranch, BuildTime, GoVersion |
-| `GetVersionInfo()` | Returns full `*Info` struct |
+| `VersionInfo` | Struct with Version, GitCommit, GitBranch, BuildTime, GoVersion |
+| `GetVersionInfo()` | Returns full `*VersionInfo` struct |
 | `GetShortVersion()` | Returns `version-commit` string |
 | `GetFullVersion()` | Returns detailed version string |
 | `Version` / `GitCommit` / `GitBranch` / `BuildTime` | Linker-injected variables |

--- a/version/version.go
+++ b/version/version.go
@@ -16,8 +16,8 @@ var (
 	GoVersion = ""    // Go version used for build
 )
 
-// Info represents version information
-type Info struct {
+// VersionInfo represents version information
+type VersionInfo struct {
 	Version   string    `json:"version"`
 	GitCommit string    `json:"git_commit"`
 	GitBranch string    `json:"git_branch"`
@@ -29,8 +29,8 @@ type Info struct {
 }
 
 // GetVersionInfo returns comprehensive version information
-func GetVersionInfo() *Info {
-	info := &Info{
+func GetVersionInfo() *VersionInfo {
+	info := &VersionInfo{
 		Version:   Version,
 		GitCommit: GitCommit,
 		GitBranch: GitBranch,
@@ -73,12 +73,6 @@ func GetVersionInfo() *Info {
 				}
 			}
 		}
-	}
-
-	// If we still don't have build time, use current time for dev builds
-	if info.BuildDate.IsZero() {
-		info.BuildDate = time.Now().UTC()
-		info.BuildTime = info.BuildDate.Format(time.RFC3339)
 	}
 
 	return info

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -28,7 +28,7 @@ func TestGetVersionInfoDefaults(t *testing.T) {
 
 	info := GetVersionInfo()
 	if info == nil {
-		t.Fatal("expected non-nil Info")
+		t.Fatal("expected non-nil VersionInfo")
 	}
 	if info.Version != "dev" {
 		t.Errorf("expected version 'dev', got %q", info.Version)
@@ -36,9 +36,7 @@ func TestGetVersionInfoDefaults(t *testing.T) {
 	if info.IsRelease {
 		t.Error("dev should not be a release")
 	}
-	if info.BuildDate.IsZero() {
-		t.Error("BuildDate should not be zero")
-	}
+	// BuildDate may be populated from VCS info or may be zero for dev builds.
 }
 
 func TestGetVersionInfoWithBuildTime(t *testing.T) {
@@ -452,10 +450,10 @@ func TestGetVersionInfoBuildTimeEdgeCases(t *testing.T) {
 	tests := []struct {
 		name      string
 		buildTime string
-		wantZero  bool // true if BuildDate should fall back (not parsed from buildTime)
+		wantZero  bool // true if BuildDate should fall back to VCS or stay zero
 	}{
 		{"empty", "", true},
-		{"zero_time", "0001-01-01T00:00:00Z", true}, // parses to Go zero time, overwritten by now()
+		{"zero_time", "0001-01-01T00:00:00Z", true}, // parses to Go zero time
 		{"far_future", "2099-12-31T23:59:59Z", false},
 	}
 
@@ -470,10 +468,9 @@ func TestGetVersionInfoBuildTimeEdgeCases(t *testing.T) {
 
 			info := GetVersionInfo()
 			if tc.wantZero {
-				// When BuildTime is empty, BuildDate is populated from VCS or now()
-				if info.BuildDate.IsZero() {
-					t.Error("BuildDate should not be zero even with empty BuildTime")
-				}
+				// When BuildTime is empty or zero, BuildDate may be populated from
+				// VCS info (if running in a git repo) or may remain zero. We no
+				// longer fall back to time.Now() for deterministic dev builds.
 			} else {
 				parsed, err := time.Parse(time.RFC3339, tc.buildTime)
 				if err != nil {
@@ -495,14 +492,8 @@ func TestGetFullVersionAllEmpty(t *testing.T) {
 	BuildTime = ""
 	GoVersion = ""
 
-	fv := GetFullVersion()
-	// Should not panic and should produce some output with "(built ...)"
-	if fv == "" {
-		t.Error("full version should not be empty even with all empty fields")
-	}
-	if !strings.Contains(fv, "built") {
-		t.Errorf("expected 'built' in full version, got %q", fv)
-	}
+	// Should not panic; output depends on VCS info from debug.ReadBuildInfo
+	_ = GetFullVersion()
 }
 
 // JSON round-trip
@@ -519,12 +510,12 @@ func TestInfoJSON_RoundTrip(t *testing.T) {
 
 	data, err := json.Marshal(original)
 	if err != nil {
-		t.Fatalf("failed to marshal Info: %v", err)
+		t.Fatalf("failed to marshal VersionInfo: %v", err)
 	}
 
-	var restored Info
+	var restored VersionInfo
 	if err := json.Unmarshal(data, &restored); err != nil {
-		t.Fatalf("failed to unmarshal Info: %v", err)
+		t.Fatalf("failed to unmarshal VersionInfo: %v", err)
 	}
 
 	if restored.Version != original.Version {


### PR DESCRIPTION
## Description

Align the 7 core foundation modules across gokit, rskit, and pykit for consistent API surfaces, naming, and behavior. This is Group 01 of the cross-kit alignment initiative.

## Motivation

The three kits (gokit, rskit, pykit) mirror each other but had diverged in naming, API surface, and behavior across core modules. This PR brings gokit into alignment with the agreed cross-kit conventions.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Module(s) Affected

- errors
- config
- logging (logger)
- validation
- encryption
- util
- version

## Changes Made

- **validation**: Rename `Range`→`InRange`, `Min`→`MinValue`, `Max`→`MaxValue`; add `Before`/`After` datetime validators
- **errors**: Rename `Cancelled`→`Canceled`, `ErrCodeCancelled`→`ErrCodeCanceled`, `CANCELLED`→`CANCELED` (US spelling, matches gRPC `codes.Canceled`)
- **config**: Fix README to show real-world SSM-style usage pattern with module config embedding
- **util**: Add `Clock` interface (SystemClock/FakeClock) and `DeepMerge` for map merging
- **version**: Rename `Info`→`VersionInfo`, remove nondeterministic `time.Now()` fallback
- **encryption**: Verify PBKDF2-SHA256 with 600k iterations, no code changes needed
- **logging**: Fix RLock bug, wire Stacktrace config
- Clean up intermediate/changelog-style comments across all modules
- Format and lint cleanup (gofmt, gofumpt, golangci-lint clean)

## Testing

- [x] Added new tests for my changes
- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)

### Test Evidence

```
ok  github.com/kbukum/gokit/errors      0.322s
ok  github.com/kbukum/gokit/config      0.427s
ok  github.com/kbukum/gokit/logger      0.778s
ok  github.com/kbukum/gokit/validation  1.302s
ok  github.com/kbukum/gokit/util        1.022s
ok  github.com/kbukum/gokit/version     1.556s
ok  github.com/kbukum/gokit/encryption  115.049s
```

## Breaking Changes

| Before | After | Migration |
|--------|-------|-----------|
| `v.Range(field, val, min, max)` | `v.InRange(field, val, min, max)` | Rename call |
| `v.Min(field, val, min)` | `v.MinValue(field, val, min)` | Rename call |
| `v.Max(field, val, max)` | `v.MaxValue(field, val, max)` | Rename call |
| `errors.Cancelled(op)` | `errors.Canceled(op)` | Rename call |
| `errors.ErrCodeCancelled` | `errors.ErrCodeCanceled` | Rename reference |
| `version.Info` | `version.VersionInfo` | Rename type |

No backward compatibility needed — development stage, full redesign allowed.

## Checklist

- [x] My code follows the coding standards in CONTRIBUTING.md
- [x] I have run `make tidy` to ensure go.mod/go.sum are clean
- [x] I have added godoc comments for exported types/functions
- [x] I have updated relevant documentation (README.md, doc.go, etc.)
- [x] I have added tests that prove my fix/feature works
- [x] I have considered backward compatibility
- [x] New dependencies (if any) are justified and minimal

## Additional Notes

Part of cross-kit alignment initiative. Sibling PRs: rskit (refactor/oss-review), pykit (refactor/oss-review).