### PR TITLE
feat: align L2 modules (component, hook, di, provider, bootstrap)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -97,7 +97,7 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 		}
 		if len(history) > 0 {
 			msgs = append(history, msgs...)
-			a.emitHook(MemoryLoaded{SessionID: a.config.SessionID, MessageCount: len(history)})
+			a.emitHook(ctx, MemoryLoaded{SessionID: a.config.SessionID, MessageCount: len(history)})
 		}
 	}
 
@@ -105,7 +105,7 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 
 	for turn := 1; turn <= a.config.MaxTurns; turn++ {
 		// Emit TurnStart hook
-		if hr := a.emitHook(TurnStart{Turn: turn}); hr.Action == hook.ActionAbort {
+		if hr := a.emitHook(ctx, TurnStart{Turn: turn}); hr.Action == hook.ActionAbort {
 			a.saveMemory(ctx, msgs)
 			return a.buildResult(msgs, llm.AssistantMessage{}, totalUsage, turn-1, StopAborted), nil
 		}
@@ -114,7 +114,7 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 		req := a.buildRequest(msgs)
 
 		// Emit PreLLMCall hook
-		if hr := a.emitHook(PreLLMCall{Request: req}); hr.Action == hook.ActionAbort {
+		if hr := a.emitHook(ctx, PreLLMCall{Request: req}); hr.Action == hook.ActionAbort {
 			a.saveMemory(ctx, msgs)
 			return a.buildResult(msgs, llm.AssistantMessage{}, totalUsage, turn-1, StopAborted), nil
 		} else if hr.Action == hook.ActionModify {
@@ -126,12 +126,12 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 		// Call LLM
 		resp, err := a.config.Provider.Complete(ctx, req)
 		if err != nil {
-			a.emitHook(OnError{Err: err, Source: "llm_provider"})
+			a.emitHook(ctx, OnError{Err: err, Source: "llm_provider"})
 			return nil, fmt.Errorf("agent: llm call failed on turn %d: %w", turn, err)
 		}
 
 		// Emit PostLLMCall hook
-		a.emitHook(PostLLMCall{Response: *resp})
+		a.emitHook(ctx, PostLLMCall{Response: *resp})
 
 		// Accumulate usage
 		totalUsage = addUsage(totalUsage, resp.Usage)
@@ -141,7 +141,7 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 
 		// If no tool calls, we're done
 		if !resp.HasToolCalls() {
-			a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+			a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 			a.saveMemory(ctx, msgs)
 			return a.buildResult(msgs, resp.Message, totalUsage, turn, StopEndTurn), nil
 		}
@@ -154,7 +154,7 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 
 		// Check token budget
 		if a.config.MaxTokenBudget > 0 && totalTokens(totalUsage) >= a.config.MaxTokenBudget {
-			a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+			a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 			a.saveMemory(ctx, msgs)
 			return a.buildResult(msgs, resp.Message, totalUsage, turn, StopMaxBudget), nil
 		}
@@ -168,11 +168,11 @@ func (a *Agent) Run(ctx context.Context, messages []llm.Message) (*Result, error
 			}
 			msgs = compacted
 			newTokens := a.config.Provider.CountTokens(msgs)
-			a.emitHook(ContextCompacted{OldTokens: oldTokens, NewTokens: newTokens, Strategy: fmt.Sprintf("%T", a.config.ContextStrategy)})
+			a.emitHook(ctx, ContextCompacted{OldTokens: oldTokens, NewTokens: newTokens, Strategy: fmt.Sprintf("%T", a.config.ContextStrategy)})
 		}
 
 		// Emit TurnEnd hook
-		a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+		a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 	}
 
 	// Reached max turns
@@ -220,7 +220,7 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 			history, err := a.config.Memory.Load(ctx, a.config.SessionID)
 			if err == nil && len(history) > 0 {
 				msgs = append(history, msgs...)
-				a.emitHook(MemoryLoaded{SessionID: a.config.SessionID, MessageCount: len(history)})
+				a.emitHook(ctx, MemoryLoaded{SessionID: a.config.SessionID, MessageCount: len(history)})
 			}
 		}
 
@@ -235,7 +235,7 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 				return
 			}
 
-			if hr := a.emitHook(TurnStart{Turn: turn}); hr.Action == hook.ActionAbort {
+			if hr := a.emitHook(ctx, TurnStart{Turn: turn}); hr.Action == hook.ActionAbort {
 				a.saveMemory(ctx, msgs)
 				send(CompleteEvent{Result: *a.buildResult(msgs, llm.AssistantMessage{}, totalUsage, turn-1, StopAborted)})
 				return
@@ -243,7 +243,7 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 
 			req := a.buildRequest(msgs)
 
-			if hr := a.emitHook(PreLLMCall{Request: req}); hr.Action == hook.ActionAbort {
+			if hr := a.emitHook(ctx, PreLLMCall{Request: req}); hr.Action == hook.ActionAbort {
 				a.saveMemory(ctx, msgs)
 				send(CompleteEvent{Result: *a.buildResult(msgs, llm.AssistantMessage{}, totalUsage, turn-1, StopAborted)})
 				return
@@ -256,7 +256,7 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 			// Use streaming if provider supports it
 			streamCh, err := a.config.Provider.Stream(ctx, req)
 			if err != nil {
-				a.emitHook(OnError{Err: err, Source: "llm_provider"})
+				a.emitHook(ctx, OnError{Err: err, Source: "llm_provider"})
 				return
 			}
 
@@ -275,13 +275,13 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 				return
 			}
 
-			a.emitHook(PostLLMCall{Response: *resp})
+			a.emitHook(ctx, PostLLMCall{Response: *resp})
 
 			totalUsage = addUsage(totalUsage, resp.Usage)
 			msgs = append(msgs, resp.Message)
 
 			if !resp.HasToolCalls() {
-				a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+				a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 				if !send(TurnCompleteEvent{Turn: turn, Message: resp.Message, Usage: resp.Usage}) {
 					return
 				}
@@ -308,7 +308,7 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 			}
 
 			if a.config.MaxTokenBudget > 0 && totalTokens(totalUsage) >= a.config.MaxTokenBudget {
-				a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+				a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 				if !send(TurnCompleteEvent{Turn: turn, Message: resp.Message, Usage: resp.Usage}) {
 					return
 				}
@@ -325,13 +325,13 @@ func (a *Agent) Stream(ctx context.Context, messages []llm.Message) (<-chan Even
 				}
 				msgs = compacted
 				newTokens := a.config.Provider.CountTokens(msgs)
-				a.emitHook(ContextCompacted{OldTokens: oldTokens, NewTokens: newTokens, Strategy: fmt.Sprintf("%T", a.config.ContextStrategy)})
+				a.emitHook(ctx, ContextCompacted{OldTokens: oldTokens, NewTokens: newTokens, Strategy: fmt.Sprintf("%T", a.config.ContextStrategy)})
 				if !send(ContextCompactedEvent{OldTokens: oldTokens, NewTokens: newTokens}) {
 					return
 				}
 			}
 
-			a.emitHook(TurnEnd{Turn: turn, Message: resp.Message})
+			a.emitHook(ctx, TurnEnd{Turn: turn, Message: resp.Message})
 			if !send(TurnCompleteEvent{Turn: turn, Message: resp.Message, Usage: resp.Usage}) {
 				return
 			}
@@ -380,7 +380,7 @@ func (a *Agent) executeTool(ctx context.Context, tc llm.ToolCall) (*tool.Result,
 
 	// Emit PreToolCall hook
 	input := json.RawMessage(tc.Function.Arguments)
-	if hr := a.emitHook(PreToolCall{Name: tc.Function.Name, Input: input}); hr.Action == hook.ActionAbort {
+	if hr := a.emitHook(ctx, PreToolCall{Name: tc.Function.Name, Input: input}); hr.Action == hook.ActionAbort {
 		return nil, fmt.Errorf("tool %q aborted by hook: %s", tc.Function.Name, hr.Reason)
 	}
 
@@ -402,7 +402,7 @@ func (a *Agent) executeTool(ctx context.Context, tc llm.ToolCall) (*tool.Result,
 	}
 
 	// Emit PostToolCall hook
-	a.emitHook(PostToolCall{
+	a.emitHook(ctx, PostToolCall{
 		Name:   tc.Function.Name,
 		Input:  input,
 		Result: result,
@@ -446,7 +446,7 @@ func (a *Agent) executeTools(ctx context.Context, calls []llm.ToolCall) []toolRe
 		for i, tc := range calls {
 			names[i] = tc.Function.Name
 		}
-		a.emitHook(ToolsParallelized{ToolNames: names, Count: len(calls)})
+		a.emitHook(ctx, ToolsParallelized{ToolNames: names, Count: len(calls)})
 
 		var wg sync.WaitGroup
 		for i, tc := range calls {
@@ -482,11 +482,11 @@ func (a *Agent) executeTools(ctx context.Context, calls []llm.ToolCall) []toolRe
 	return results
 }
 
-func (a *Agent) emitHook(event hook.Event) hook.Result {
+func (a *Agent) emitHook(ctx context.Context, event hook.Event) hook.Result {
 	if a.config.Hooks == nil {
 		return hook.Continue()
 	}
-	return a.config.Hooks.Emit(event)
+	return a.config.Hooks.Emit(ctx, event)
 }
 
 func (a *Agent) contextTooLarge(msgs []llm.Message) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -264,7 +264,7 @@ func TestAgent_ToolError(t *testing.T) {
 func TestAgent_HookAbortOnTurnStart(t *testing.T) {
 	provider := newMockProvider(textResponse("should not reach"))
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventTurnStart, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventTurnStart, func(ctx context.Context, e hook.Event) hook.Result {
 		return hook.Abort("blocked by policy")
 	})
 
@@ -293,7 +293,7 @@ func TestAgent_HookAbortOnPreToolCall(t *testing.T) {
 	)
 	tools := makeMockTool("dangerous", "should not run")
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventPreToolCall, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventPreToolCall, func(ctx context.Context, e hook.Event) hook.Result {
 		pre := e.(agent.PreToolCall)
 		if pre.Name == "dangerous" {
 			return hook.Abort("tool blocked")
@@ -337,7 +337,7 @@ func TestAgent_HookModifyPreLLMCall(t *testing.T) {
 	wrapper := &modelCapturingProvider{inner: origProvider, captured: &capturedModel}
 
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventPreLLMCall, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventPreLLMCall, func(ctx context.Context, e hook.Event) hook.Result {
 		pre := e.(agent.PreLLMCall)
 		modified := pre.Request
 		modified.Model = "gpt-4-turbo"
@@ -678,7 +678,7 @@ func TestAgent_ParallelTools(t *testing.T) {
 
 	var parallelHookFired bool
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventToolsParallelized, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventToolsParallelized, func(ctx context.Context, e hook.Event) hook.Result {
 		parallelHookFired = true
 		tp := e.(agent.ToolsParallelized)
 		if tp.Count != 2 {
@@ -753,7 +753,7 @@ func TestAgent_MemoryHookFired(t *testing.T) {
 
 	var loaded bool
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventMemoryLoaded, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventMemoryLoaded, func(ctx context.Context, e hook.Event) hook.Result {
 		loaded = true
 		ml := e.(agent.MemoryLoaded)
 		if ml.SessionID != "sess-1" {
@@ -915,7 +915,7 @@ func TestAgent_ContextCompaction(t *testing.T) {
 
 	var compactedHookFired bool
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventContextCompacted, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventContextCompacted, func(ctx context.Context, e hook.Event) hook.Result {
 		compactedHookFired = true
 		return hook.Continue()
 	})

--- a/agent/command.go
+++ b/agent/command.go
@@ -150,7 +150,7 @@ func builtinClear(ctx context.Context, _ string, a *Agent) (string, error) {
 	return "Conversation memory cleared.", nil
 }
 
-func builtinModel(_ context.Context, args string, a *Agent) (string, error) {
+func builtinModel(ctx context.Context, args string, a *Agent) (string, error) {
 	args = strings.TrimSpace(args)
 	if args == "" {
 		current := a.GetModel()
@@ -161,7 +161,7 @@ func builtinModel(_ context.Context, args string, a *Agent) (string, error) {
 	}
 	prev := a.GetModel()
 	a.SetModel(args)
-	a.emitHook(ModelSwitched{
+	a.emitHook(ctx, ModelSwitched{
 		PreviousModel: prev,
 		NewModel:      args,
 		Reason:        "command",

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -198,7 +198,7 @@ func TestBuiltin_Model_Switch(t *testing.T) {
 
 	var switched bool
 	hooks := hook.NewRegistry()
-	hooks.On(agent.EventModelSwitched, func(e hook.Event) hook.Result {
+	hooks.On(agent.EventModelSwitched, func(ctx context.Context, e hook.Event) hook.Result {
 		ms := e.(agent.ModelSwitched)
 		if ms.NewModel == "gpt-4o" && ms.PreviousModel == "" {
 			switched = true

--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kbukum/gokit/component"
 	"github.com/kbukum/gokit/di"
+	"github.com/kbukum/gokit/hook"
 	"github.com/kbukum/gokit/logger"
 )
 
@@ -37,10 +38,7 @@ type App[C Config] struct {
 
 	gracefulTimeout time.Duration
 	onConfigure     []func(ctx context.Context, app *App[C]) error
-
-	onStart []Hook
-	onReady []Hook
-	onStop  []Hook
+	hooks           *hook.Registry
 }
 
 // NewApp creates a new application instance from a typed config.
@@ -60,6 +58,7 @@ func NewApp[C Config](cfg C, opts ...Option) (*App[C], error) {
 		Container:       di.NewContainer(),
 		Components:      component.NewRegistry(),
 		gracefulTimeout: 15 * time.Second,
+		hooks:           hook.NewRegistry(),
 	}
 
 	// Apply options (may override logger, container, timeout).
@@ -71,12 +70,11 @@ func NewApp[C Config](cfg C, opts ...Option) (*App[C], error) {
 		app.gracefulTimeout = *o.gracefulTimeout
 	}
 
-	// Logger: use custom if provided, otherwise init from config.
+	// Logger: use custom if provided, otherwise create from config (no global state).
 	if o.logger != nil {
 		app.Logger = o.logger
 	} else {
-		logger.Init(&base.Logging)
-		app.Logger = logger.GetGlobalLogger()
+		app.Logger = logger.New(&base.Logging, base.Name)
 	}
 
 	app.Summary = NewSummary(base.Name, base.Version)
@@ -191,28 +189,28 @@ func (a *App[C]) startup(ctx context.Context) error {
 		"version": a.Version,
 	})
 
-	// Phase 1: Initialize — start all registered infrastructure components.
-	if err := a.initialize(ctx); err != nil {
-		return fmt.Errorf("initialization failed: %w", err)
-	}
-
-	// Run OnStart hooks
-	if err := runHooks(ctx, a.onStart); err != nil {
-		return fmt.Errorf("onStart hook failed: %w", err)
-	}
-
-	// Phase 2: Configure — run business-layer setup callbacks.
-	// Configure callbacks may register additional components (workers,
-	// schedulers, background tasks) that depend on infrastructure.
+	// Phase 1: Configure — run business-layer setup callbacks that may register
+	// additional components. This happens before StartAll so that all components
+	// (infrastructure + application) start in a single pass.
 	if err := a.configure(ctx); err != nil {
 		return fmt.Errorf("configuration failed: %w", err)
 	}
 
-	// Phase 3: Start application components — starts any components
-	// registered during Phase 2. Already-started infrastructure
-	// components are skipped (StartAll is idempotent).
+	// Phase 2: Start — single-pass StartAll for all registered components.
 	if err := a.Components.StartAll(ctx); err != nil {
-		return fmt.Errorf("application component startup failed: %w", err)
+		// Partial rollback: run OnStop hooks for cleanup of any resources
+		// that configure callbacks may have set up.
+		if stopErr := a.emitLifecycleHooks(ctx, EventStop); stopErr != nil {
+			a.Logger.ErrorCtx(ctx, "OnStop hook error during startup rollback", map[string]interface{}{
+				"error": stopErr.Error(),
+			})
+		}
+		return fmt.Errorf("component startup failed: %w", err)
+	}
+
+	// Run OnStart hooks
+	if err := a.emitLifecycleHooks(ctx, EventStart); err != nil {
+		return fmt.Errorf("onStart hook failed: %w", err)
 	}
 
 	// Ready check — verify all components are healthy
@@ -223,7 +221,7 @@ func (a *App[C]) startup(ctx context.Context) error {
 	}
 
 	// Run OnReady hooks
-	if err := runHooks(ctx, a.onReady); err != nil {
+	if err := a.emitLifecycleHooks(ctx, EventReady); err != nil {
 		return fmt.Errorf("onReady hook failed: %w", err)
 	}
 
@@ -231,18 +229,6 @@ func (a *App[C]) startup(ctx context.Context) error {
 	a.Summary.SetStartupDuration(time.Since(start))
 	a.DisplaySummary()
 
-	return nil
-}
-
-// initialize starts all registered components (Phase 1).
-func (a *App[C]) initialize(ctx context.Context) error {
-	a.Logger.DebugCtx(ctx, "Phase 1: Starting components")
-
-	if err := a.Components.StartAll(ctx); err != nil {
-		return fmt.Errorf("failed to start components: %w", err)
-	}
-
-	a.Logger.DebugCtx(ctx, "Phase 1: All components started")
 	return nil
 }
 
@@ -332,8 +318,8 @@ func (a *App[C]) shutdownWith(parent context.Context) error {
 
 	var shutdownErrs []error
 
-	// Run OnStop hooks before stopping components
-	if err := runHooks(ctx, a.onStop); err != nil {
+	// Run OnStop hooks before stopping components — collect all errors.
+	if err := a.emitLifecycleHooks(ctx, EventStop); err != nil {
 		a.Logger.ErrorCtx(ctx, "OnStop hook error", map[string]interface{}{
 			"error": err.Error(),
 		})

--- a/bootstrap/bootstrap_comprehensive_test.go
+++ b/bootstrap/bootstrap_comprehensive_test.go
@@ -173,17 +173,19 @@ func TestPhase1PartialStartupFailure(t *testing.T) {
 // ── 3. Hook error propagation across phases ──────────────────────────────
 
 func TestHookErrorIncludesIndex(t *testing.T) {
-	hooks := []Hook{
+	cfg := newTestConfig("test", "1.0")
+	app, _ := NewApp(cfg)
+	app.OnStart(
 		func(ctx context.Context) error { return nil },
-		func(ctx context.Context) error { return nil },
+		func(_ context.Context) error { return nil },
 		func(ctx context.Context) error { return fmt.Errorf("boom") },
-	}
-	err := runHooks(context.Background(), hooks)
+	)
+	err := app.emitLifecycleHooks(context.Background(), EventStart)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "hook 2") {
-		t.Errorf("expected 'hook 2' in error, got %q", err.Error())
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected 'boom' in error, got %q", err.Error())
 	}
 }
 
@@ -587,14 +589,13 @@ func TestRunTaskFullLifecycleOrder(t *testing.T) {
 	}
 
 	expected := []string{
-		"db:start",    // Phase 1: infrastructure components start
+		"onConfigure", // Phase 1: configure (may register app components)
+		"db:start",    // Phase 2: single-pass StartAll
 		"onStart",     // OnStart hooks
-		"onConfigure", // Phase 2: configure (may register app components)
-		// Phase 3: StartAll again (no-op here since no new components)
-		"onReady", // Ready hooks
-		"task",    // Task execution
-		"onStop",  // Stop hooks
-		"db:stop", // Components stop (reverse order)
+		"onReady",     // Ready hooks
+		"task",        // Task execution
+		"onStop",      // Stop hooks
+		"db:stop",     // Components stop (reverse order)
 	}
 
 	if len(order) != len(expected) {
@@ -649,9 +650,9 @@ func TestTwoPhaseStartupComponentsRegisteredDuringConfigure(t *testing.T) {
 	}
 
 	expected := []string{
-		"db:start",              // Phase 1: infra started
-		"onConfigure",           // Phase 2: registers worker
-		"catalog-refresh:start", // Phase 3: late-registered component started
+		"onConfigure",           // Phase 1: configure — registers worker
+		"db:start",              // Phase 2: single-pass StartAll (both components)
+		"catalog-refresh:start", // Phase 2: late-registered component started in same pass
 		"onReady",               // Ready hooks
 		"task",                  // Task
 		"catalog-refresh:stop",  // Stop: reverse order (app component first)
@@ -749,13 +750,15 @@ func TestOnConfigureAccessToFullApp(t *testing.T) {
 }
 
 func TestEmptyHookSlicesAreNoop(t *testing.T) {
-	err := runHooks(context.Background(), nil)
+	cfg := newTestConfig("test", "1.0")
+	app, _ := NewApp(cfg)
+	// No hooks registered — emit should succeed with no error.
+	err := app.emitLifecycleHooks(context.Background(), EventStart)
 	if err != nil {
-		t.Errorf("nil hooks should succeed: %v", err)
+		t.Errorf("no hooks should succeed: %v", err)
 	}
-
-	err = runHooks(context.Background(), []Hook{})
+	err = app.emitLifecycleHooks(context.Background(), EventStop)
 	if err != nil {
-		t.Errorf("empty hooks should succeed: %v", err)
+		t.Errorf("no hooks should succeed: %v", err)
 	}
 }

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -153,11 +153,7 @@ func TestOnStartHook(t *testing.T) {
 		return nil
 	})
 
-	if len(app.onStart) != 1 {
-		t.Errorf("expected 1 onStart hook, got %d", len(app.onStart))
-	}
-
-	err := runHooks(context.Background(), app.onStart)
+	err := app.emitLifecycleHooks(context.Background(), EventStart)
 	if err != nil {
 		t.Fatalf("hook failed: %v", err)
 	}
@@ -175,7 +171,7 @@ func TestOnReadyHook(t *testing.T) {
 		return nil
 	})
 
-	err := runHooks(context.Background(), app.onReady)
+	err := app.emitLifecycleHooks(context.Background(), EventReady)
 	if err != nil {
 		t.Fatalf("hook failed: %v", err)
 	}
@@ -193,7 +189,7 @@ func TestOnStopHook(t *testing.T) {
 		return nil
 	})
 
-	err := runHooks(context.Background(), app.onStop)
+	err := app.emitLifecycleHooks(context.Background(), EventStop)
 	if err != nil {
 		t.Fatalf("hook failed: %v", err)
 	}
@@ -211,31 +207,33 @@ func TestMultipleHooks(t *testing.T) {
 		func(ctx context.Context) error { order = append(order, "second"); return nil },
 	)
 
-	runHooks(context.Background(), app.onStart)
+	app.emitLifecycleHooks(context.Background(), EventStart)
 	if len(order) != 2 || order[0] != "first" || order[1] != "second" {
 		t.Errorf("expected [first, second], got %v", order)
 	}
 }
 
 func TestHookError(t *testing.T) {
-	hooks := []Hook{
-		func(ctx context.Context) error { return fmt.Errorf("hook failed") },
-	}
-	err := runHooks(context.Background(), hooks)
+	cfg := newTestConfig("test", "1.0")
+	app, _ := NewApp(cfg)
+	app.OnStart(func(ctx context.Context) error { return fmt.Errorf("hook failed") })
+	err := app.emitLifecycleHooks(context.Background(), EventStart)
 	if err == nil {
 		t.Error("expected error from failing hook")
 	}
 }
 
 func TestHookErrorStopsExecution(t *testing.T) {
+	cfg := newTestConfig("test", "1.0")
+	app, _ := NewApp(cfg)
 	secondCalled := false
-	hooks := []Hook{
+	app.OnStart(
 		func(ctx context.Context) error { return fmt.Errorf("fail") },
 		func(ctx context.Context) error { secondCalled = true; return nil },
-	}
-	runHooks(context.Background(), hooks)
+	)
+	app.emitLifecycleHooks(context.Background(), EventStart)
 	if secondCalled {
-		t.Error("expected second hook not to be called after first fails")
+		t.Error("expected second hook not to be called after first fails (abort)")
 	}
 }
 
@@ -416,7 +414,7 @@ func TestRunTaskWithHooks(t *testing.T) {
 		return nil
 	})
 
-	expected := []string{"start", "configure", "ready", "task", "stop"}
+	expected := []string{"configure", "start", "ready", "task", "stop"}
 	if len(order) != len(expected) {
 		t.Fatalf("expected %v, got %v", expected, order)
 	}

--- a/bootstrap/hooks.go
+++ b/bootstrap/hooks.go
@@ -2,7 +2,9 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
+	"errors"
+
+	"github.com/kbukum/gokit/hook"
 )
 
 // Hook is a lifecycle callback that runs during application startup or shutdown.
@@ -10,31 +12,72 @@ import (
 // about specific infrastructure.
 type Hook func(ctx context.Context) error
 
-// OnStart registers a hook that runs after all components are started (Phase 1)
+// Lifecycle event types used with the hook registry.
+var (
+	EventStart = hook.EventType("bootstrap:start")
+	EventReady = hook.EventType("bootstrap:ready")
+	EventStop  = hook.EventType("bootstrap:stop")
+)
+
+// lifecycleEvent is a concrete hook.Event for bootstrap lifecycle events.
+type lifecycleEvent struct {
+	eventType hook.EventType
+}
+
+func (e lifecycleEvent) Type() hook.EventType { return e.eventType }
+
+// OnStart registers a hook that runs after all components are started
 // but before the application is marked as ready.
 func (a *App[C]) OnStart(hooks ...Hook) {
-	a.onStart = append(a.onStart, hooks...)
+	for _, h := range hooks {
+		fn := h
+		a.hooks.On(EventStart, func(ctx context.Context, _ hook.Event) hook.Result {
+			if err := fn(ctx); err != nil {
+				return hook.AbortWithError("onStart hook failed", err)
+			}
+			return hook.Continue()
+		})
+	}
 }
 
 // OnReady registers a hook that runs after the application passes its ready check
 // and is about to begin accepting traffic.
 func (a *App[C]) OnReady(hooks ...Hook) {
-	a.onReady = append(a.onReady, hooks...)
+	for _, h := range hooks {
+		fn := h
+		a.hooks.On(EventReady, func(ctx context.Context, _ hook.Event) hook.Result {
+			if err := fn(ctx); err != nil {
+				return hook.AbortWithError("onReady hook failed", err)
+			}
+			return hook.Continue()
+		})
+	}
 }
 
 // OnStop registers a hook that runs during graceful shutdown before components
 // are stopped. Use this for cleanup tasks like draining connections or
 // deregistering from service discovery.
 func (a *App[C]) OnStop(hooks ...Hook) {
-	a.onStop = append(a.onStop, hooks...)
+	for _, h := range hooks {
+		fn := h
+		a.hooks.On(EventStop, func(ctx context.Context, _ hook.Event) hook.Result {
+			if err := fn(ctx); err != nil {
+				return hook.ContinueWithError(err)
+			}
+			return hook.Continue()
+		})
+	}
 }
 
-// runHooks executes a slice of hooks sequentially, returning the first error.
-func runHooks(ctx context.Context, hooks []Hook) error {
-	for i, h := range hooks {
-		if err := h(ctx); err != nil {
-			return fmt.Errorf("hook %d failed: %w", i, err)
-		}
+// emitLifecycleHooks dispatches a lifecycle event and returns any error.
+func (a *App[C]) emitLifecycleHooks(ctx context.Context, eventType hook.EventType) error {
+	result := a.hooks.Emit(ctx, lifecycleEvent{eventType: eventType})
+	var errs []error
+	if result.Err != nil {
+		errs = append(errs, result.Err)
 	}
-	return nil
+	if result.Action == hook.ActionAbort && result.Reason != "" && result.Err == nil {
+		errs = append(errs, errors.New(result.Reason))
+	}
+	return errors.Join(errs...)
 }

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -508,8 +508,8 @@ func TestStopAllErrorAggregationFormat(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "shutdown errors") {
-		t.Errorf("expected 'shutdown errors' prefix, got: %s", msg)
+	if !strings.Contains(msg, "cache") {
+		t.Errorf("expected 'cache' in error, got: %s", msg)
 	}
 	if !strings.Contains(msg, "db timeout") {
 		t.Errorf("expected 'db timeout' in error, got: %s", msg)
@@ -1249,5 +1249,180 @@ func TestRouteStruct(t *testing.T) {
 	r := Route{Method: "POST", Path: "/api/v1/users", Handler: "CreateUser"}
 	if r.Method != "POST" || r.Path != "/api/v1/users" || r.Handler != "CreateUser" {
 		t.Errorf("unexpected route: %+v", r)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle state machine tests
+// ---------------------------------------------------------------------------
+
+func TestStateString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state State
+		want  string
+	}{
+		{StateCreated, "created"},
+		{StateStarting, "starting"},
+		{StateRunning, "running"},
+		{StateStopping, "stopping"},
+		{StateStopped, "stopped"},
+		{StateFailed, "failed"},
+		{State(99), "unknown"},
+	}
+	for _, tc := range tests {
+		if got := tc.state.String(); got != tc.want {
+			t.Errorf("State(%d).String() = %q, want %q", tc.state, got, tc.want)
+		}
+	}
+}
+
+func TestStateTransitions_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	c := &mockComponent{
+		name:   "svc",
+		health: Health{Name: "svc", Status: StatusHealthy},
+	}
+	r.Register(c)
+
+	// After registration: Created
+	state, ok := r.State("svc")
+	if !ok || state != StateCreated {
+		t.Fatalf("expected Created, got %v", state)
+	}
+
+	// After StartAll: Running
+	r.StartAll(context.Background())
+	state, _ = r.State("svc")
+	if state != StateRunning {
+		t.Fatalf("expected Running, got %v", state)
+	}
+
+	// After StopAll: Stopped
+	r.StopAll(context.Background())
+	state, _ = r.State("svc")
+	if state != StateStopped {
+		t.Fatalf("expected Stopped, got %v", state)
+	}
+}
+
+func TestStateTransitions_StartFailure(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	c := &mockComponent{
+		name:     "fail",
+		startErr: fmt.Errorf("boom"),
+		health:   Health{Name: "fail", Status: StatusUnhealthy},
+	}
+	r.Register(c)
+
+	err := r.StartAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	state, _ := r.State("fail")
+	if state != StateFailed {
+		t.Fatalf("expected Failed after start error, got %v", state)
+	}
+}
+
+func TestStateTransitions_RollbackOnPartialFailure(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(&mockComponent{
+		name:   "a",
+		health: Health{Name: "a", Status: StatusHealthy},
+	})
+	r.Register(&mockComponent{
+		name:     "b",
+		startErr: fmt.Errorf("b failed"),
+		health:   Health{Name: "b", Status: StatusUnhealthy},
+	})
+
+	r.StartAll(context.Background())
+
+	// 'a' was started then rolled back → Stopped
+	stateA, _ := r.State("a")
+	if stateA != StateStopped {
+		t.Errorf("expected 'a' Stopped after rollback, got %v", stateA)
+	}
+
+	// 'b' failed → Failed
+	stateB, _ := r.State("b")
+	if stateB != StateFailed {
+		t.Errorf("expected 'b' Failed, got %v", stateB)
+	}
+}
+
+func TestState_UnknownComponent(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	_, ok := r.State("nonexistent")
+	if ok {
+		t.Error("expected ok=false for unknown component")
+	}
+}
+
+func TestStopAllDetailed(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(&mockComponent{
+		name:   "ok",
+		health: Health{Name: "ok", Status: StatusHealthy},
+	})
+	r.Register(&mockComponent{
+		name:    "fail",
+		stopErr: fmt.Errorf("stop error"),
+		health:  Health{Name: "fail", Status: StatusHealthy},
+	})
+	r.StartAll(context.Background())
+
+	results := r.StopAllDetailed(context.Background())
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// Results are in reverse order (fail first, then ok)
+	var okResult, failResult StopResult
+	for _, sr := range results {
+		switch sr.Name {
+		case "ok":
+			okResult = sr
+		case "fail":
+			failResult = sr
+		}
+	}
+
+	if okResult.Err != nil {
+		t.Errorf("expected nil error for 'ok', got %v", okResult.Err)
+	}
+	if failResult.Err == nil {
+		t.Error("expected error for 'fail'")
+	}
+}
+
+func TestRestartAfterStop(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	c := &mockComponent{
+		name:   "restartable",
+		health: Health{Name: "restartable", Status: StatusHealthy},
+	}
+	r.Register(c)
+
+	r.StartAll(context.Background())
+	r.StopAll(context.Background())
+
+	// Should be able to start again after stop
+	err := r.StartAll(context.Background())
+	if err != nil {
+		t.Fatalf("expected restart to succeed, got: %v", err)
+	}
+
+	state, _ := r.State("restartable")
+	if state != StateRunning {
+		t.Errorf("expected Running after restart, got %v", state)
 	}
 }

--- a/component/interfaces.go
+++ b/component/interfaces.go
@@ -2,6 +2,44 @@ package component
 
 import "context"
 
+// State represents the lifecycle state of a component.
+type State int
+
+const (
+	// StateCreated is the initial state after registration.
+	StateCreated State = iota
+	// StateStarting indicates the component is currently starting.
+	StateStarting
+	// StateRunning indicates the component started successfully and is operational.
+	StateRunning
+	// StateStopping indicates the component is currently shutting down.
+	StateStopping
+	// StateStopped indicates the component has been shut down.
+	StateStopped
+	// StateFailed indicates the component failed to start or encountered a fatal error.
+	StateFailed
+)
+
+// String returns the human-readable name of a lifecycle state.
+func (s State) String() string {
+	switch s {
+	case StateCreated:
+		return "created"
+	case StateStarting:
+		return "starting"
+	case StateRunning:
+		return "running"
+	case StateStopping:
+		return "stopping"
+	case StateStopped:
+		return "stopped"
+	case StateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
 // HealthStatus represents the health state of a component.
 type HealthStatus string
 
@@ -20,6 +58,14 @@ type Health struct {
 
 // Component represents a lifecycle-managed infrastructure component.
 // Each infrastructure module (database, redis, kafka, etc.) implements this interface.
+//
+// The canonical lifecycle state machine is:
+//
+//	Created → Starting → Running → Stopping → Stopped
+//	                ↘ Failed
+//
+// Stop() is responsible for draining any inflight work before releasing
+// resources. The framework enforces a per-component timeout via the context.
 type Component interface {
 	// Name returns the unique name of the component for registration.
 	Name() string
@@ -28,10 +74,19 @@ type Component interface {
 	Start(ctx context.Context) error
 
 	// Stop gracefully shuts down the component and releases resources.
+	// Implementations must drain inflight work within the context deadline.
 	Stop(ctx context.Context) error
 
 	// Health returns the current health status of the component.
 	Health(ctx context.Context) Health
+}
+
+// StopResult holds the outcome of stopping a single component.
+type StopResult struct {
+	// Name of the component.
+	Name string
+	// Err is nil on success, non-nil on failure.
+	Err error
 }
 
 // Description holds summary information for the bootstrap display.

--- a/component/registry.go
+++ b/component/registry.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -15,14 +16,16 @@ import (
 // pass a tighter deadline by attaching one to ctx.
 const DefaultStopTimeout = 10 * time.Second
 
-// componentEntry holds a component and its started state.
+// componentEntry holds a component and its lifecycle state.
 type componentEntry struct {
 	component Component
-	started   bool
+	state     State
 }
 
 // Registry manages component lifecycle with deterministic ordering.
 // Components are started in registration order and stopped in reverse order.
+// Each component tracks a formal lifecycle state (Created → Starting →
+// Running → Stopping → Stopped | Failed).
 type Registry struct {
 	entries []*componentEntry
 	lookup  map[string]*componentEntry
@@ -53,7 +56,7 @@ func (r *Registry) Register(c Component) error {
 		return fmt.Errorf("component %s already registered", name)
 	}
 
-	entry := &componentEntry{component: c}
+	entry := &componentEntry{component: c, state: StateCreated}
 	r.entries = append(r.entries, entry)
 	r.lookup[name] = entry
 
@@ -63,9 +66,20 @@ func (r *Registry) Register(c Component) error {
 	return nil
 }
 
+// State returns the lifecycle state of a named component.
+// Returns StateCreated and false if the component is not registered.
+func (r *Registry) State(name string) (State, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if entry, exists := r.lookup[name]; exists {
+		return entry.state, true
+	}
+	return StateCreated, false
+}
+
 // StartAll starts all not-yet-started components in registration order.
 //
-// It is safe to call multiple times — already-started components are
+// It is safe to call multiple times — already-running components are
 // skipped. This supports two-phase startup where infrastructure
 // components are started first and application-layer components
 // (registered during configure) are started in a second pass.
@@ -85,7 +99,7 @@ func (r *Registry) StartAll(ctx context.Context) error {
 	r.mu.RLock()
 	pending := make([]*componentEntry, 0, len(r.entries))
 	for _, entry := range r.entries {
-		if !entry.started {
+		if entry.state == StateCreated || entry.state == StateStopped || entry.state == StateFailed {
 			pending = append(pending, entry)
 		}
 	}
@@ -107,8 +121,16 @@ func (r *Registry) StartAll(ctx context.Context) error {
 	for _, entry := range pending {
 		name := entry.component.Name()
 
+		r.mu.Lock()
+		entry.state = StateStarting
+		r.mu.Unlock()
+
 		logger.DebugCtx(ctx, "Starting component", map[string]interface{}{"component": name})
 		if err := entry.component.Start(ctx); err != nil {
+			r.mu.Lock()
+			entry.state = StateFailed
+			r.mu.Unlock()
+
 			logger.ErrorCtx(ctx, "Component start failed", map[string]interface{}{
 				"component": name,
 				"error":     err.Error(),
@@ -118,7 +140,7 @@ func (r *Registry) StartAll(ctx context.Context) error {
 		}
 
 		r.mu.Lock()
-		entry.started = true
+		entry.state = StateRunning
 		r.mu.Unlock()
 		startedThisCall = append(startedThisCall, entry)
 
@@ -135,6 +157,11 @@ func (r *Registry) rollback(ctx context.Context, entries []*componentEntry) {
 	for i := len(entries) - 1; i >= 0; i-- {
 		entry := entries[i]
 		name := entry.component.Name()
+
+		r.mu.Lock()
+		entry.state = StateStopping
+		r.mu.Unlock()
+
 		stopCtx, cancel := stopContext(ctx)
 		if err := entry.component.Stop(stopCtx); err != nil {
 			logger.ErrorCtx(ctx, "Rollback stop failed", map[string]interface{}{
@@ -143,18 +170,19 @@ func (r *Registry) rollback(ctx context.Context, entries []*componentEntry) {
 			})
 		}
 		cancel()
+
 		r.mu.Lock()
-		entry.started = false
+		entry.state = StateStopped
 		r.mu.Unlock()
 	}
 }
 
-// StopAll gracefully stops all components in reverse registration order.
+// StopAll gracefully stops all running components in reverse registration order.
 //
 // Each Component.Stop runs with the caller's ctx; if ctx has no deadline,
-// DefaultStopTimeout is applied per-component as a safety net (closes
-// F-075: hardcoded shutdown deadlines no longer clobber a caller-supplied
-// deadline).
+// DefaultStopTimeout is applied per-component as a safety net.
+// Errors are aggregated via errors.Join so callers can inspect individual
+// failures with errors.Is/errors.As.
 func (r *Registry) StopAll(ctx context.Context) error {
 	r.lifecycleMu.Lock()
 	defer r.lifecycleMu.Unlock()
@@ -163,7 +191,7 @@ func (r *Registry) StopAll(ctx context.Context) error {
 	r.mu.RLock()
 	toStop := make([]*componentEntry, 0, len(r.entries))
 	for i := len(r.entries) - 1; i >= 0; i-- {
-		if r.entries[i].started {
+		if r.entries[i].state == StateRunning {
 			toStop = append(toStop, r.entries[i])
 		}
 	}
@@ -174,6 +202,11 @@ func (r *Registry) StopAll(ctx context.Context) error {
 	var errs []error
 	for _, entry := range toStop {
 		name := entry.component.Name()
+
+		r.mu.Lock()
+		entry.state = StateStopping
+		r.mu.Unlock()
+
 		logger.DebugCtx(ctx, "Stopping component", map[string]interface{}{"component": name})
 
 		stopCtx, cancel := stopContext(ctx)
@@ -189,16 +222,53 @@ func (r *Registry) StopAll(ctx context.Context) error {
 		cancel()
 
 		r.mu.Lock()
-		entry.started = false
+		entry.state = StateStopped
 		r.mu.Unlock()
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("shutdown errors: %v", errs)
+		return errors.Join(errs...)
 	}
 
 	logger.InfoCtx(ctx, "All components stopped successfully")
 	return nil
+}
+
+// StopAllDetailed gracefully stops all running components and returns
+// per-component results. This provides structured error information for
+// callers that need to know which specific components failed.
+func (r *Registry) StopAllDetailed(ctx context.Context) []StopResult {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+
+	r.mu.RLock()
+	toStop := make([]*componentEntry, 0, len(r.entries))
+	for i := len(r.entries) - 1; i >= 0; i-- {
+		if r.entries[i].state == StateRunning {
+			toStop = append(toStop, r.entries[i])
+		}
+	}
+	r.mu.RUnlock()
+
+	results := make([]StopResult, 0, len(toStop))
+	for _, entry := range toStop {
+		name := entry.component.Name()
+
+		r.mu.Lock()
+		entry.state = StateStopping
+		r.mu.Unlock()
+
+		stopCtx, cancel := stopContext(ctx)
+		err := entry.component.Stop(stopCtx)
+		cancel()
+
+		r.mu.Lock()
+		entry.state = StateStopped
+		r.mu.Unlock()
+
+		results = append(results, StopResult{Name: name, Err: err})
+	}
+	return results
 }
 
 // stopContext returns a context for an individual Component.Stop call. If
@@ -212,13 +282,19 @@ func stopContext(parent context.Context) (context.Context, context.CancelFunc) {
 }
 
 // HealthAll returns health status for all registered components.
+// The snapshot is taken under the read lock, but Health() calls are made
+// without holding the lock to avoid blocking registration or lifecycle ops.
 func (r *Registry) HealthAll(ctx context.Context) []Health {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	snapshot := make([]Component, len(r.entries))
+	for i, entry := range r.entries {
+		snapshot[i] = entry.component
+	}
+	r.mu.RUnlock()
 
-	results := make([]Health, 0, len(r.entries))
-	for _, entry := range r.entries {
-		results = append(results, entry.component.Health(ctx))
+	results := make([]Health, 0, len(snapshot))
+	for _, c := range snapshot {
+		results = append(results, c.Health(ctx))
 	}
 	return results
 }

--- a/di/container.go
+++ b/di/container.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,8 +17,9 @@ type RegistrationMode int
 
 const (
 	Eager     RegistrationMode = iota // Initialize immediately on registration
-	Lazy                              // Initialize on first resolve
+	Lazy                              // Initialize on first resolve (cached)
 	Singleton                         // Pre-created instance
+	Transient                         // New instance per resolve (never cached)
 )
 
 // Container defines the interface for a dependency injection container.
@@ -30,6 +33,7 @@ type Container interface {
 	Register(key string, constructor interface{}) error
 	RegisterLazy(key string, constructor interface{}, options ...LazyOption) error
 	RegisterEager(key string, constructor interface{}) error
+	RegisterTransient(key string, constructor interface{}) error
 	Resolve(key string) (interface{}, error)
 	RegisterSingleton(key string, instance interface{}) error
 	Close() error
@@ -60,6 +64,10 @@ type UnifiedContainer struct {
 	components map[string]*ComponentRegistration
 	singletons map[string]interface{}
 	mutex      sync.RWMutex
+	// resolving tracks keys currently being resolved to detect circular dependencies.
+	// Each goroutine gets its own set via goroutine-local tracking.
+	resolvingMu sync.Mutex
+	resolving   map[uint64]map[string]bool
 }
 
 type ComponentRegistration struct {
@@ -110,6 +118,7 @@ func NewContainer() Container {
 	return &UnifiedContainer{
 		components: make(map[string]*ComponentRegistration),
 		singletons: make(map[string]interface{}),
+		resolving:  make(map[uint64]map[string]bool),
 	}
 }
 
@@ -173,6 +182,22 @@ func (c *UnifiedContainer) RegisterSingleton(key string, instance interface{}) e
 	return nil
 }
 
+// RegisterTransient registers a constructor that creates a new instance on every Resolve call.
+// The result is never cached.
+func (c *UnifiedContainer) RegisterTransient(key string, constructor interface{}) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	registration := &ComponentRegistration{
+		key:         key,
+		constructor: constructor,
+		mode:        Transient,
+	}
+
+	c.components[key] = registration
+	return nil
+}
+
 // Resolve gets a component instance
 func (c *UnifiedContainer) Resolve(key string) (interface{}, error) {
 	// Check singletons first
@@ -189,7 +214,62 @@ func (c *UnifiedContainer) Resolve(key string) (interface{}, error) {
 		return nil, fmt.Errorf("component not registered: %s", key)
 	}
 
+	// Circular dependency detection
+	gid := goroutineID()
+	if err := c.pushResolving(gid, key); err != nil {
+		return nil, err
+	}
+	defer c.popResolving(gid, key)
+
 	return c.resolveComponent(registration)
+}
+
+// goroutineID extracts the goroutine ID from the runtime stack.
+func goroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	// Stack starts with "goroutine NNN [..."
+	s := string(buf[:n])
+	s = strings.TrimPrefix(s, "goroutine ")
+	var id uint64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		id = id*10 + uint64(c-'0')
+	}
+	return id
+}
+
+// pushResolving marks key as being resolved on this goroutine. Returns an error
+// if a cycle is detected.
+func (c *UnifiedContainer) pushResolving(gid uint64, key string) error {
+	c.resolvingMu.Lock()
+	defer c.resolvingMu.Unlock()
+
+	set, ok := c.resolving[gid]
+	if !ok {
+		set = make(map[string]bool)
+		c.resolving[gid] = set
+	}
+	if set[key] {
+		return fmt.Errorf("circular dependency detected: resolving %q is already in progress on this goroutine", key)
+	}
+	set[key] = true
+	return nil
+}
+
+// popResolving removes the key from the goroutine's resolving set.
+func (c *UnifiedContainer) popResolving(gid uint64, key string) {
+	c.resolvingMu.Lock()
+	defer c.resolvingMu.Unlock()
+
+	if set, ok := c.resolving[gid]; ok {
+		delete(set, key)
+		if len(set) == 0 {
+			delete(c.resolving, gid)
+		}
+	}
 }
 
 func (c *UnifiedContainer) resolveComponent(registration *ComponentRegistration) (interface{}, error) {
@@ -198,6 +278,8 @@ func (c *UnifiedContainer) resolveComponent(registration *ComponentRegistration)
 		return c.resolveEager(registration)
 	case Lazy:
 		return c.resolveLazy(registration)
+	case Transient:
+		return c.resolveTransient(registration)
 	default:
 		return nil, fmt.Errorf("unknown registration mode for component: %s", registration.key)
 	}
@@ -234,6 +316,11 @@ func (c *UnifiedContainer) resolveLazy(registration *ComponentRegistration) (int
 	return c.initializeWithRetry(registration)
 }
 
+// resolveTransient creates a new instance every time. No caching.
+func (c *UnifiedContainer) resolveTransient(registration *ComponentRegistration) (interface{}, error) {
+	return c.callConstructor(registration.constructor)
+}
+
 func (c *UnifiedContainer) initializeWithRetry(registration *ComponentRegistration) (interface{}, error) {
 	var lastError error
 	backoffMs := registration.retryPolicy.InitialBackoffMs
@@ -262,6 +349,11 @@ func (c *UnifiedContainer) initializeWithRetry(registration *ComponentRegistrati
 		instance, err := c.callConstructor(registration.constructor)
 		if err != nil {
 			lastError = err
+			// Circular dependency errors are deterministic — retrying won't help.
+			if strings.Contains(err.Error(), "circular dependency detected") {
+				return nil, fmt.Errorf("failed to initialize component '%s': %w",
+					registration.key, err)
+			}
 			registration.circuitBreaker.RecordFailure()
 			logger.Debug("Lazy component initialization failed", map[string]interface{}{
 				"component": registration.key,

--- a/di/doc.go
+++ b/di/doc.go
@@ -1,16 +1,19 @@
 // Package di provides a dependency injection container for gokit applications.
 //
-// It supports eager, lazy, and singleton registration modes with type-safe
-// resolution using Go generics. The container enables decoupled architecture
-// by managing service dependencies and their lifecycle.
+// The primary API uses type-safe keys ([Key]) with generics:
 //
-// # Registration
+//	var loggerKey = di.NameKey[*logger.Logger]("logger")
 //
-//	di.Register[MyService](container, func() (*MyService, error) {
-//	    return NewMyService(), nil
-//	})
+//	// Registration
+//	di.Provide(c, loggerKey, func() (*logger.Logger, error) { return logger.New() })
+//	di.ProvideSingleton(c, loggerKey, existingLogger)
+//	di.ProvideTransient(c, loggerKey, func() (*logger.Logger, error) { return logger.New() })
 //
-// # Resolution
+//	// Resolution
+//	log, err := di.ResolveKey(c, loggerKey)
+//	log := di.MustResolveKey(c, loggerKey)  // panics on error; startup/tests only
 //
-//	svc := di.MustResolve[MyService](container)
+// The container supports eager, lazy, singleton, and transient registration
+// modes. Circular dependency detection is built in. Constructor injection is
+// the only supported pattern (no setter injection, no service locator).
 package di

--- a/di/typed.go
+++ b/di/typed.go
@@ -67,6 +67,21 @@ func ProvideSingleton[T any](c Container, k Key[T], v T) error {
 	return c.RegisterSingleton(k.fullKey(), v)
 }
 
+// ProvideTransient registers a constructor for k that creates a new instance
+// on every [ResolveKey] call. The result is never cached.
+func ProvideTransient[T any](c Container, k Key[T], ctor any) error {
+	if c == nil {
+		return fmt.Errorf("di: container is nil")
+	}
+	if ctor == nil {
+		return fmt.Errorf("di: constructor for %s must not be nil", k.fullKey())
+	}
+	if err := validateCtor[T](ctor); err != nil {
+		return fmt.Errorf("di: provide transient %s: %w", k.fullKey(), err)
+	}
+	return c.RegisterTransient(k.fullKey(), ctor)
+}
+
 // ResolveKey resolves k from c and returns the typed value. It returns an
 // error if the key is not registered or if the resolved value's type does
 // not match T (which can only happen if the container was modified through

--- a/di/typed_test.go
+++ b/di/typed_test.go
@@ -172,3 +172,134 @@ func TestKey_ContextType(t *testing.T) {
 		t.Fatalf("ResolveKey: %v", err)
 	}
 }
+
+func TestProvideTransient_NewInstancePerResolve(t *testing.T) {
+	c := di.NewContainer()
+	calls := 0
+	err := di.ProvideTransient(c, svcKey, func() *svc {
+		calls++
+		return &svc{N: calls}
+	})
+	if err != nil {
+		t.Fatalf("ProvideTransient: %v", err)
+	}
+
+	a, err := di.ResolveKey(c, svcKey)
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	b, err := di.ResolveKey(c, svcKey)
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+
+	if a == b {
+		t.Fatal("transient should return different pointers")
+	}
+	if a.N != 1 || b.N != 2 {
+		t.Fatalf("a.N=%d b.N=%d; constructor should be called each time", a.N, b.N)
+	}
+}
+
+func TestProvideTransient_NilCtorRejected(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.ProvideTransient(c, svcKey, nil); err == nil {
+		t.Fatal("expected error for nil ctor")
+	}
+}
+
+func TestProvideTransient_BadCtorRejected(t *testing.T) {
+	c := di.NewContainer()
+	if err := di.ProvideTransient(c, svcKey, "not-a-func"); err == nil {
+		t.Fatal("expected error for non-function ctor")
+	}
+}
+
+func TestCircularDependencyDetection(t *testing.T) {
+	c := di.NewContainer()
+	keyA := di.NameKey[*svc]("a")
+	keyB := di.NameKey[*svc]("b")
+
+	// A depends on B
+	if err := di.Provide(c, keyA, func(c di.Container) (*svc, error) {
+		_, err := di.ResolveKey(c, keyB)
+		if err != nil {
+			return nil, err
+		}
+		return &svc{N: 1}, nil
+	}); err != nil {
+		t.Fatalf("Provide A: %v", err)
+	}
+
+	// B depends on A — circular
+	if err := di.Provide(c, keyB, func(c di.Container) (*svc, error) {
+		_, err := di.ResolveKey(c, keyA)
+		if err != nil {
+			return nil, err
+		}
+		return &svc{N: 2}, nil
+	}); err != nil {
+		t.Fatalf("Provide B: %v", err)
+	}
+
+	_, err := di.ResolveKey(c, keyA)
+	if err == nil {
+		t.Fatal("expected circular dependency error")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Fatalf("expected 'circular' in error, got: %v", err)
+	}
+}
+
+func TestCircularDependencyDetection_SelfReference(t *testing.T) {
+	c := di.NewContainer()
+	selfKey := di.NameKey[*svc]("self")
+
+	if err := di.Provide(c, selfKey, func(c di.Container) (*svc, error) {
+		_, err := di.ResolveKey(c, selfKey)
+		if err != nil {
+			return nil, err
+		}
+		return &svc{N: 1}, nil
+	}); err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+
+	_, err := di.ResolveKey(c, selfKey)
+	if err == nil {
+		t.Fatal("expected circular dependency error for self-reference")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Fatalf("expected 'circular' in error, got: %v", err)
+	}
+}
+
+func TestTransient_NoCachingEvenAfterError(t *testing.T) {
+	c := di.NewContainer()
+	calls := 0
+	err := di.ProvideTransient(c, svcKey, func() (*svc, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("first call fails")
+		}
+		return &svc{N: calls}, nil
+	})
+	if err != nil {
+		t.Fatalf("ProvideTransient: %v", err)
+	}
+
+	// First resolve fails
+	_, err = di.ResolveKey(c, svcKey)
+	if err == nil {
+		t.Fatal("expected first resolve to fail")
+	}
+
+	// Second resolve succeeds (no cached error)
+	got, err := di.ResolveKey(c, svcKey)
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if got.N != 2 {
+		t.Fatalf("got.N = %d want 2", got.N)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/kbukum/gokit/hook v0.0.0-20260429061310-faacea370b6d
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/viper v1.21.0
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kbukum/gokit/hook v0.0.0-20260429061310-faacea370b6d h1:LmEz4P1JBlcKHvpVQbHzJZzjHCGvj2N1qetvB4nHtCk=
+github.com/kbukum/gokit/hook v0.0.0-20260429061310-faacea370b6d/go.mod h1:QoDiCn/OE3GMO4YdySDCBuzyOwvfgVEcaBIK8FxY/8E=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/hook/doc.go
+++ b/hook/doc.go
@@ -2,7 +2,8 @@
 //
 // It allows registering handlers for arbitrary event types. Handlers run
 // sequentially in registration order, with short-circuit on Abort and
-// chained Modify results.
+// chained Modify results. Panicking handlers are recovered and converted
+// to errors without disrupting subsequent handler dispatch.
 //
 // The hook module is domain-agnostic — applications define their own event
 // types by implementing the Event interface. For example, the agent module
@@ -11,7 +12,7 @@
 // Usage:
 //
 //	registry := hook.NewRegistry()
-//	registry.On("my_event", func(e hook.Event) hook.Result {
+//	registry.On("my_event", func(ctx context.Context, e hook.Event) hook.Result {
 //	    log.Printf("event: %s", e.Type())
 //	    return hook.Continue()
 //	})

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -1,6 +1,9 @@
 package hook_test
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/kbukum/gokit/hook"
@@ -63,6 +66,17 @@ func TestContinue(t *testing.T) {
 	}
 }
 
+func TestContinueWithError(t *testing.T) {
+	err := errors.New("something went wrong")
+	r := hook.ContinueWithError(err)
+	if r.Action != hook.ActionContinue {
+		t.Errorf("Action = %v, want Continue", r.Action)
+	}
+	if !errors.Is(r.Err, err) {
+		t.Errorf("Err = %v, want %v", r.Err, err)
+	}
+}
+
 func TestAbort(t *testing.T) {
 	r := hook.Abort("rate limited")
 	if r.Action != hook.ActionAbort {
@@ -70,6 +84,20 @@ func TestAbort(t *testing.T) {
 	}
 	if r.Reason != "rate limited" {
 		t.Errorf("Reason = %q, want %q", r.Reason, "rate limited")
+	}
+}
+
+func TestAbortWithError(t *testing.T) {
+	err := errors.New("forbidden")
+	r := hook.AbortWithError("rate limited", err)
+	if r.Action != hook.ActionAbort {
+		t.Errorf("Action = %v, want Abort", r.Action)
+	}
+	if r.Reason != "rate limited" {
+		t.Errorf("Reason = %q, want %q", r.Reason, "rate limited")
+	}
+	if !errors.Is(r.Err, err) {
+		t.Errorf("Err = %v, want %v", r.Err, err)
 	}
 }
 
@@ -88,7 +116,7 @@ func TestModify(t *testing.T) {
 
 func TestRegistry_EmitWithNoHandlers(t *testing.T) {
 	reg := hook.NewRegistry()
-	result := reg.Emit(alphaEvent{Value: "test"})
+	result := reg.Emit(context.Background(), alphaEvent{Value: "test"})
 	if result.Action != hook.ActionContinue {
 		t.Errorf("expected Continue with no handlers, got %v", result.Action)
 	}
@@ -98,12 +126,12 @@ func TestRegistry_SingleHandler(t *testing.T) {
 	reg := hook.NewRegistry()
 	var received hook.EventType
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		received = e.Type()
 		return hook.Continue()
 	})
 
-	reg.Emit(alphaEvent{Value: "hello"})
+	reg.Emit(context.Background(), alphaEvent{Value: "hello"})
 
 	if received != eventAlpha {
 		t.Errorf("handler received %q, want %q", received, eventAlpha)
@@ -114,13 +142,13 @@ func TestRegistry_TypeAssertionInHandler(t *testing.T) {
 	reg := hook.NewRegistry()
 	var capturedValue string
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		a := e.(alphaEvent)
 		capturedValue = a.Value
 		return hook.Continue()
 	})
 
-	reg.Emit(alphaEvent{Value: "captured!"})
+	reg.Emit(context.Background(), alphaEvent{Value: "captured!"})
 
 	if capturedValue != "captured!" {
 		t.Errorf("capturedValue = %q, want %q", capturedValue, "captured!")
@@ -131,20 +159,20 @@ func TestRegistry_MultipleHandlers_ExecutionOrder(t *testing.T) {
 	reg := hook.NewRegistry()
 	var order []int
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		order = append(order, 1)
 		return hook.Continue()
 	})
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		order = append(order, 2)
 		return hook.Continue()
 	})
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		order = append(order, 3)
 		return hook.Continue()
 	})
 
-	reg.Emit(alphaEvent{Value: "test"})
+	reg.Emit(context.Background(), alphaEvent{Value: "test"})
 
 	if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
 		t.Errorf("expected order [1,2,3], got %v", order)
@@ -155,16 +183,16 @@ func TestRegistry_AbortShortCircuits(t *testing.T) {
 	reg := hook.NewRegistry()
 	handlersCalled := 0
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		handlersCalled++
 		return hook.Abort("blocked")
 	})
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		handlersCalled++
 		return hook.Continue()
 	})
 
-	result := reg.Emit(alphaEvent{Value: "dangerous"})
+	result := reg.Emit(context.Background(), alphaEvent{Value: "dangerous"})
 
 	if result.Action != hook.ActionAbort {
 		t.Errorf("expected Abort, got %v", result.Action)
@@ -180,14 +208,14 @@ func TestRegistry_AbortShortCircuits(t *testing.T) {
 func TestRegistry_ModifyChains(t *testing.T) {
 	reg := hook.NewRegistry()
 
-	reg.On(eventBeta, func(e hook.Event) hook.Result {
+	reg.On(eventBeta, func(ctx context.Context, e hook.Event) hook.Result {
 		return hook.Modify("step1")
 	})
-	reg.On(eventBeta, func(e hook.Event) hook.Result {
+	reg.On(eventBeta, func(ctx context.Context, e hook.Event) hook.Result {
 		return hook.Modify("step2")
 	})
 
-	result := reg.Emit(betaEvent{Count: 1})
+	result := reg.Emit(context.Background(), betaEvent{Count: 1})
 
 	if result.Action != hook.ActionModify {
 		t.Errorf("expected Modify, got %v", result.Action)
@@ -201,19 +229,19 @@ func TestRegistry_Unsubscribe(t *testing.T) {
 	reg := hook.NewRegistry()
 	calls := 0
 
-	unsub := reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	unsub := reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		calls++
 		return hook.Continue()
 	})
 
-	reg.Emit(alphaEvent{Value: "1"})
+	reg.Emit(context.Background(), alphaEvent{Value: "1"})
 	if calls != 1 {
 		t.Fatalf("expected 1 call before unsub, got %d", calls)
 	}
 
 	unsub()
 
-	reg.Emit(alphaEvent{Value: "2"})
+	reg.Emit(context.Background(), alphaEvent{Value: "2"})
 	if calls != 1 {
 		t.Errorf("expected 1 call after unsub, got %d", calls)
 	}
@@ -223,18 +251,19 @@ func TestRegistry_DifferentEventTypes(t *testing.T) {
 	reg := hook.NewRegistry()
 	var alphaCalls, betaCalls int
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		alphaCalls++
 		return hook.Continue()
 	})
-	reg.On(eventBeta, func(e hook.Event) hook.Result {
+	reg.On(eventBeta, func(ctx context.Context, e hook.Event) hook.Result {
 		betaCalls++
 		return hook.Continue()
 	})
 
-	reg.Emit(alphaEvent{Value: "a"})
-	reg.Emit(alphaEvent{Value: "b"})
-	reg.Emit(betaEvent{Count: 1})
+	ctx := context.Background()
+	reg.Emit(ctx, alphaEvent{Value: "a"})
+	reg.Emit(ctx, alphaEvent{Value: "b"})
+	reg.Emit(ctx, betaEvent{Count: 1})
 
 	if alphaCalls != 2 {
 		t.Errorf("alphaCalls = %d, want 2", alphaCalls)
@@ -251,7 +280,7 @@ func TestRegistry_HasHandlers(t *testing.T) {
 		t.Error("should have no handlers initially")
 	}
 
-	unsub := reg.On(eventAlpha, func(e hook.Event) hook.Result {
+	unsub := reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 		return hook.Continue()
 	})
 
@@ -269,8 +298,8 @@ func TestRegistry_HasHandlers(t *testing.T) {
 func TestRegistry_Clear(t *testing.T) {
 	reg := hook.NewRegistry()
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result { return hook.Continue() })
-	reg.On(eventBeta, func(e hook.Event) hook.Result { return hook.Continue() })
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result { return hook.Continue() })
+	reg.On(eventBeta, func(ctx context.Context, e hook.Event) hook.Result { return hook.Continue() })
 
 	reg.Clear(eventAlpha)
 	if reg.HasHandlers(eventAlpha) {
@@ -284,8 +313,8 @@ func TestRegistry_Clear(t *testing.T) {
 func TestRegistry_ClearAll(t *testing.T) {
 	reg := hook.NewRegistry()
 
-	reg.On(eventAlpha, func(e hook.Event) hook.Result { return hook.Continue() })
-	reg.On(eventBeta, func(e hook.Event) hook.Result { return hook.Continue() })
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result { return hook.Continue() })
+	reg.On(eventBeta, func(ctx context.Context, e hook.Event) hook.Result { return hook.Continue() })
 
 	reg.Clear()
 	if reg.HasHandlers(eventAlpha) || reg.HasHandlers(eventBeta) {
@@ -299,7 +328,7 @@ func TestRegistry_ConcurrentSafety(t *testing.T) {
 
 	for i := range 10 {
 		go func(n int) {
-			reg.On(eventAlpha, func(e hook.Event) hook.Result {
+			reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
 				return hook.Continue()
 			})
 			done <- struct{}{}
@@ -308,12 +337,145 @@ func TestRegistry_ConcurrentSafety(t *testing.T) {
 
 	for range 10 {
 		go func() {
-			reg.Emit(alphaEvent{Value: "concurrent"})
+			reg.Emit(context.Background(), alphaEvent{Value: "concurrent"})
 			done <- struct{}{}
 		}()
 	}
 
 	for range 20 {
 		<-done
+	}
+}
+
+// --- Context support tests ---
+
+func TestRegistry_ContextCancellation(t *testing.T) {
+	reg := hook.NewRegistry()
+	handlersCalled := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		handlersCalled++
+		return hook.Continue()
+	})
+
+	result := reg.Emit(ctx, alphaEvent{Value: "test"})
+
+	if result.Action != hook.ActionAbort {
+		t.Errorf("expected Abort on canceled context, got %v", result.Action)
+	}
+	if result.Err == nil {
+		t.Error("expected error on canceled context")
+	}
+	if handlersCalled != 0 {
+		t.Errorf("expected 0 handlers called on canceled context, got %d", handlersCalled)
+	}
+}
+
+func TestRegistry_ContextPassedToHandler(t *testing.T) {
+	reg := hook.NewRegistry()
+	type ctxKey struct{}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "injected")
+
+	var received string
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		received = ctx.Value(ctxKey{}).(string)
+		return hook.Continue()
+	})
+
+	reg.Emit(ctx, alphaEvent{Value: "test"})
+
+	if received != "injected" {
+		t.Errorf("handler received ctx value %q, want %q", received, "injected")
+	}
+}
+
+// --- Panic recovery tests ---
+
+func TestRegistry_PanicRecovery(t *testing.T) {
+	reg := hook.NewRegistry()
+	var order []int
+
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		order = append(order, 1)
+		return hook.Continue()
+	})
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		panic("handler exploded")
+	})
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		order = append(order, 3)
+		return hook.Continue()
+	})
+
+	result := reg.Emit(context.Background(), alphaEvent{Value: "test"})
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 3 {
+		t.Errorf("expected order [1,3] (skipping panicked handler), got %v", order)
+	}
+	if result.Err == nil {
+		t.Error("expected error from panicked handler")
+	}
+	if !strings.Contains(result.Err.Error(), "panicked") {
+		t.Errorf("error should mention panic, got: %v", result.Err)
+	}
+}
+
+func TestRegistry_PanicDoesNotPreventAbort(t *testing.T) {
+	reg := hook.NewRegistry()
+
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		panic("boom")
+	})
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		return hook.Abort("stop")
+	})
+
+	result := reg.Emit(context.Background(), alphaEvent{Value: "test"})
+
+	if result.Action != hook.ActionAbort {
+		t.Errorf("expected Abort after panic recovery, got %v", result.Action)
+	}
+}
+
+// --- Error propagation tests ---
+
+func TestRegistry_ContinueWithErrorPropagates(t *testing.T) {
+	reg := hook.NewRegistry()
+	expectedErr := errors.New("non-fatal issue")
+
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		return hook.ContinueWithError(expectedErr)
+	})
+
+	result := reg.Emit(context.Background(), alphaEvent{Value: "test"})
+
+	if result.Action != hook.ActionContinue {
+		t.Errorf("expected Continue, got %v", result.Action)
+	}
+	if !errors.Is(result.Err, expectedErr) {
+		t.Errorf("expected error %v, got %v", expectedErr, result.Err)
+	}
+}
+
+func TestRegistry_LastContinueErrorWins(t *testing.T) {
+	reg := hook.NewRegistry()
+	err1 := errors.New("first")
+	err2 := errors.New("second")
+
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		return hook.ContinueWithError(err1)
+	})
+	reg.On(eventAlpha, func(ctx context.Context, e hook.Event) hook.Result {
+		return hook.ContinueWithError(err2)
+	})
+
+	result := reg.Emit(context.Background(), alphaEvent{Value: "test"})
+
+	if !errors.Is(result.Err, err2) {
+		t.Errorf("expected last error %v, got %v", err2, result.Err)
 	}
 }

--- a/hook/registry.go
+++ b/hook/registry.go
@@ -1,11 +1,17 @@
 package hook
 
-import "sync"
+import (
+	"context"
+	"fmt"
+	"sync"
+)
 
 // Registry manages hook handlers and dispatches events.
 // Handlers are executed sequentially in registration order.
 // An Abort result short-circuits remaining handlers.
 // Modify results chain — each handler sees the previous modification.
+// Panicking handlers are recovered and converted to errors without
+// disrupting dispatch to subsequent handlers.
 type Registry struct {
 	mu       sync.RWMutex
 	handlers map[EventType][]entry
@@ -50,7 +56,9 @@ func (r *Registry) On(eventType EventType, h Handler) func() {
 // Emit dispatches an event to all registered handlers for its type.
 // Handlers run sequentially. First Abort short-circuits.
 // Returns the merged result (last non-Continue result wins).
-func (r *Registry) Emit(event Event) Result {
+// Panicking handlers are recovered: the panic is converted to an error
+// on the Result and dispatch continues to the next handler.
+func (r *Registry) Emit(ctx context.Context, event Event) Result {
 	r.mu.RLock()
 	entries := make([]entry, len(r.handlers[event.Type()]))
 	copy(entries, r.handlers[event.Type()])
@@ -59,18 +67,37 @@ func (r *Registry) Emit(event Event) Result {
 	merged := Continue()
 
 	for _, e := range entries {
-		result := e.handler(event)
+		if err := ctx.Err(); err != nil {
+			return Result{Action: ActionAbort, Reason: "context canceled", Err: err}
+		}
+
+		result := r.safeCall(ctx, e.handler, event)
 		switch result.Action {
 		case ActionAbort:
 			return result
 		case ActionModify:
 			merged = result
 		case ActionContinue:
-			// keep current merged
+			if result.Err != nil {
+				merged.Err = result.Err
+			}
 		}
 	}
 
 	return merged
+}
+
+// safeCall invokes a handler with panic recovery.
+func (r *Registry) safeCall(ctx context.Context, h Handler, event Event) (result Result) {
+	defer func() {
+		if rv := recover(); rv != nil {
+			result = Result{
+				Action: ActionContinue,
+				Err:    fmt.Errorf("hook handler panicked: %v", rv),
+			}
+		}
+	}()
+	return h(ctx, event)
 }
 
 // HasHandlers returns true if any handlers are registered for the event type.

--- a/hook/types.go
+++ b/hook/types.go
@@ -1,5 +1,7 @@
 package hook
 
+import "context"
+
 // EventType identifies the kind of hook event.
 // Applications define their own EventType constants.
 type EventType string
@@ -33,6 +35,8 @@ type Result struct {
 	ModifiedData any
 	// Reason explains why execution was aborted (Action == Abort).
 	Reason string
+	// Err reports an error from the handler without aborting dispatch.
+	Err error
 }
 
 // Continue returns a Result that lets execution proceed.
@@ -40,9 +44,19 @@ func Continue() Result {
 	return Result{Action: ActionContinue}
 }
 
+// ContinueWithError returns a Result that lets execution proceed but records an error.
+func ContinueWithError(err error) Result {
+	return Result{Action: ActionContinue, Err: err}
+}
+
 // Abort returns a Result that stops execution.
 func Abort(reason string) Result {
 	return Result{Action: ActionAbort, Reason: reason}
+}
+
+// AbortWithError returns a Result that stops execution with an error.
+func AbortWithError(reason string, err error) Result {
+	return Result{Action: ActionAbort, Reason: reason, Err: err}
 }
 
 // Modify returns a Result that replaces event data.
@@ -51,4 +65,5 @@ func Modify(data any) Result {
 }
 
 // Handler processes a hook event and returns a result.
-type Handler func(Event) Result
+// The context carries deadlines, cancellation, and request-scoped values.
+type Handler func(ctx context.Context, event Event) Result

--- a/provider/duplex_middleware.go
+++ b/provider/duplex_middleware.go
@@ -1,0 +1,20 @@
+package provider
+
+// DuplexMiddleware transforms a Duplex provider by wrapping it.
+// The returned Duplex typically delegates to the original while
+// adding cross-cutting behavior (logging, metrics, tracing, etc.).
+type DuplexMiddleware[I, O any] func(Duplex[I, O]) Duplex[I, O]
+
+// ChainDuplex composes multiple duplex middlewares into one. Middlewares are
+// applied in order: the first middleware is outermost (executes first on the
+// way in, last on the way out).
+//
+// ChainDuplex(a, b, c)(duplex) is equivalent to a(b(c(duplex))).
+func ChainDuplex[I, O any](middlewares ...DuplexMiddleware[I, O]) DuplexMiddleware[I, O] {
+	return func(inner Duplex[I, O]) Duplex[I, O] {
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			inner = middlewares[i](inner)
+		}
+		return inner
+	}
+}

--- a/provider/manager.go
+++ b/provider/manager.go
@@ -3,9 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
-
-	"github.com/kbukum/gokit/logger"
 )
 
 // Manager provides the main API for working with providers,
@@ -16,23 +15,40 @@ type Manager[T Provider] struct {
 	selector    Selector[T]
 	providers   map[string]T
 	defaultName string
-	log         *logger.Logger
+	log         *slog.Logger
+}
+
+// ManagerOption configures a Manager.
+type ManagerOption[T Provider] func(*Manager[T])
+
+// WithLogger sets the logger for the Manager. If not provided, a default
+// no-op logger is used.
+func WithLogger[T Provider](l *slog.Logger) ManagerOption[T] {
+	return func(m *Manager[T]) {
+		if l != nil {
+			m.log = l
+		}
+	}
 }
 
 // NewManager creates a Manager backed by the given registry and selector.
-func NewManager[T Provider](registry *Registry[T], selector Selector[T]) *Manager[T] {
-	return &Manager[T]{
+func NewManager[T Provider](registry *Registry[T], selector Selector[T], opts ...ManagerOption[T]) *Manager[T] {
+	m := &Manager[T]{
 		registry:  registry,
 		selector:  selector,
 		providers: make(map[string]T),
-		log:       logger.Get("provider"),
+		log:       slog.Default(),
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // Register adds a factory to the underlying registry.
 func (m *Manager[T]) Register(name string, factory Factory[T]) {
 	m.registry.RegisterFactory(name, factory)
-	m.log.Info("factory registered", map[string]interface{}{"provider": name})
+	m.log.Info("factory registered", "provider", name)
 }
 
 // Initialize creates a provider from its factory, calls Init() if the
@@ -71,7 +87,7 @@ func (m *Manager[T]) InitializeWithResilience(ctx context.Context, name string, 
 	m.providers[name] = instance
 	m.mu.Unlock()
 	m.registry.Set(name, instance)
-	m.log.InfoCtx(ctx, "provider initialized with resilience", map[string]interface{}{"provider": name})
+	m.log.InfoContext(ctx, "provider initialized with resilience", "provider", name)
 	return nil
 }
 
@@ -94,7 +110,7 @@ func (m *Manager[T]) InitializeWithContext(ctx context.Context, name string, cfg
 	m.providers[name] = instance
 	m.mu.Unlock()
 	m.registry.Set(name, instance)
-	m.log.InfoCtx(ctx, "provider initialized", map[string]interface{}{"provider": name})
+	m.log.InfoContext(ctx, "provider initialized", "provider", name)
 	return nil
 }
 
@@ -134,7 +150,7 @@ func (m *Manager[T]) SetDefault(name string) error {
 		return fmt.Errorf("provider %q not initialized", name)
 	}
 	m.defaultName = name
-	m.log.Info("default provider set", map[string]interface{}{"provider": name})
+	m.log.Info("default provider set", "provider", name)
 	return nil
 }
 
@@ -171,7 +187,7 @@ func (m *Manager[T]) CloseAll(ctx context.Context) error {
 			if err := c.Close(ctx); err != nil {
 				errs = append(errs, fmt.Errorf("close provider %q: %w", name, err))
 			} else {
-				m.log.InfoCtx(ctx, "provider closed", map[string]interface{}{"provider": name})
+				m.log.InfoContext(ctx, "provider closed", "provider", name)
 			}
 		}
 	}

--- a/provider/stream_middleware.go
+++ b/provider/stream_middleware.go
@@ -1,0 +1,20 @@
+package provider
+
+// StreamMiddleware transforms a Stream provider by wrapping it.
+// The returned Stream typically delegates to the original while
+// adding cross-cutting behavior (logging, metrics, tracing, etc.).
+type StreamMiddleware[I, O any] func(Stream[I, O]) Stream[I, O]
+
+// ChainStream composes multiple stream middlewares into one. Middlewares are
+// applied in order: the first middleware is outermost (executes first on the
+// way in, last on the way out).
+//
+// ChainStream(a, b, c)(stream) is equivalent to a(b(c(stream))).
+func ChainStream[I, O any](middlewares ...StreamMiddleware[I, O]) StreamMiddleware[I, O] {
+	return func(inner Stream[I, O]) Stream[I, O] {
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			inner = middlewares[i](inner)
+		}
+		return inner
+	}
+}


### PR DESCRIPTION
## Description

Align Group 02 L2 modules (component, hook, DI, provider, bootstrap) per the cross-kit lifecycle review. This brings gokit's composition substrate to parity with rskit and pykit.

## Motivation

Cross-kit alignment of the L2 pattern/contract layer. These modules define the composition substrate that every higher-layer module depends on. Findings from `02-component-lifecycle-di.md` review prompt.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Module(s) Affected

- component
- hook
- di
- provider
- bootstrap
- agent (caller updates)

## Changes Made

### component/
- Add `State` enum with 6 lifecycle states (Created → Starting → Running → Stopping → Stopped → Failed)
- Rewrite `Registry` with state tracking, `errors.Join` aggregation, snapshot-based `HealthAll`
- Add `StopAllDetailed()` returning `[]StopResult` for structured shutdown errors
- Rollback already-started components on partial startup failure

### hook/
- `Handler` signature now takes `context.Context` as first parameter
- `Result` gains `Err error` field with `ContinueWithError`/`AbortWithError` constructors
- Panic recovery per handler via `safeCall()` with `defer/recover`
- Context cancellation check before each handler in `Emit`

### di/
- Add `Transient` registration mode (no caching, new instance per resolve)
- Add circular dependency detection via goroutine-local resolution tracking
- Circular errors are non-retryable (skip retry/circuit-breaker)
- Add `ProvideTransient[T]` to typed API

### provider/
- Add `StreamMiddleware[I,O]` + `ChainStream` for Stream shape middleware
- Add `DuplexMiddleware[I,O]` + `ChainDuplex` for Duplex shape middleware
- Replace gokit `*logger.Logger` with stdlib `*slog.Logger` via `WithLogger` option

### bootstrap/
- Replace ad-hoc hook lists (`onStart/onReady/onStop []Hook`) with `hook.Registry`
- Add `lifecycleEvent` type implementing `hook.Event` with `EventStart`/`EventReady`/`EventStop`
- Single-pass startup: configure → StartAll → OnStart hooks → ReadyCheck → OnReady hooks
- Partial rollback: run OnStop hooks on startup failure
- Replace global logger init with `logger.New` injection

## Testing

- [x] Added new tests for my changes
- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)

## Breaking Changes

- `hook.Handler` signature changed: `func(Event) Result` → `func(context.Context, Event) Result`
- `bootstrap` startup order changed: configure → StartAll → hooks (was: start → hooks → configure)
- `component.Registry` API additions: `State()`, `StopAllDetailed()`
- `provider.NewManager` now takes variadic options instead of logger directly
- All pre-stable (alpha) — no backward compatibility required

## Checklist

- [x] My code follows the coding standards in CONTRIBUTING.md
- [x] I have run `make tidy` to ensure go.mod/go.sum are clean
- [x] I have added godoc comments for exported types/functions
- [x] I have added tests that prove my fix/feature works
- [x] New dependencies: none
