### PR TITLE
fix(media): avoid short-buffer signature indexing

### DIFF
--- a/media/image.go
+++ b/media/image.go
@@ -2,6 +2,16 @@ package media
 
 import "bytes"
 
+var (
+	jpegSignature          = []byte{0xFF, 0xD8, 0xFF}
+	pngSignature           = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	gifSignature           = []byte("GIF")
+	bmpSignature           = []byte("BM")
+	tiffLittleEndSignature = []byte{'I', 'I', 0x2A, 0x00}
+	tiffBigEndSignature    = []byte{'M', 'M', 0x00, 0x2A}
+	icoSignature           = []byte{0x00, 0x00, 0x01, 0x00}
+)
+
 // detectImage checks for known image format signatures.
 func detectImage(data []byte) (Info, bool) {
 	if len(data) < 4 {
@@ -9,17 +19,17 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// JPEG — 0xFF 0xD8 0xFF
-	if bytes.HasPrefix(data, []byte{0xFF, 0xD8, 0xFF}) {
+	if bytes.HasPrefix(data, jpegSignature) {
 		return Info{Type: Image, Format: "jpeg", MimeType: "image/jpeg"}, true
 	}
 
 	// PNG — 8-byte signature: 0x89 PNG \r \n 0x1A \n
-	if bytes.HasPrefix(data, []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}) {
+	if bytes.HasPrefix(data, pngSignature) {
 		return Info{Type: Image, Format: "png", MimeType: "image/png"}, true
 	}
 
 	// GIF — "GIF87a" or "GIF89a"
-	if bytes.HasPrefix(data, []byte("GIF")) {
+	if bytes.HasPrefix(data, gifSignature) {
 		return Info{Type: Image, Format: "gif", MimeType: "image/gif"}, true
 	}
 
@@ -29,18 +39,18 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// BMP — "BM"
-	if bytes.HasPrefix(data, []byte("BM")) {
+	if bytes.HasPrefix(data, bmpSignature) {
 		return Info{Type: Image, Format: "bmp", MimeType: "image/bmp"}, true
 	}
 
 	// TIFF — "II" (little-endian) or "MM" (big-endian) + 0x002A
-	if bytes.HasPrefix(data, []byte{'I', 'I', 0x2A, 0x00}) ||
-		bytes.HasPrefix(data, []byte{'M', 'M', 0x00, 0x2A}) {
+	if bytes.HasPrefix(data, tiffLittleEndSignature) ||
+		bytes.HasPrefix(data, tiffBigEndSignature) {
 		return Info{Type: Image, Format: "tiff", MimeType: "image/tiff"}, true
 	}
 
 	// ICO — 0x00 0x00 0x01 0x00
-	if bytes.HasPrefix(data, []byte{0x00, 0x00, 0x01, 0x00}) {
+	if bytes.HasPrefix(data, icoSignature) {
 		return Info{Type: Image, Format: "ico", MimeType: "image/x-icon"}, true
 	}
 

--- a/media/image.go
+++ b/media/image.go
@@ -30,7 +30,8 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// GIF — "GIF87a" or "GIF89a"
-	if bytes.HasPrefix(data, gif87aSignature) || bytes.HasPrefix(data, gif89aSignature) {
+	if len(data) >= len(gif87aSignature) &&
+		(bytes.HasPrefix(data, gif87aSignature) || bytes.HasPrefix(data, gif89aSignature)) {
 		return Info{Type: Image, Format: "gif", MimeType: "image/gif"}, true
 	}
 

--- a/media/image.go
+++ b/media/image.go
@@ -1,5 +1,7 @@
 package media
 
+import "bytes"
+
 // detectImage checks for known image format signatures.
 func detectImage(data []byte) (Info, bool) {
 	if len(data) < 4 {
@@ -7,19 +9,17 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// JPEG — 0xFF 0xD8 0xFF
-	if data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
+	if bytes.HasPrefix(data, []byte{0xFF, 0xD8, 0xFF}) {
 		return Info{Type: Image, Format: "jpeg", MimeType: "image/jpeg"}, true
 	}
 
 	// PNG — 8-byte signature: 0x89 PNG \r \n 0x1A \n
-	if len(data) >= 8 &&
-		data[0] == 0x89 && data[1] == 'P' && data[2] == 'N' && data[3] == 'G' &&
-		data[4] == 0x0D && data[5] == 0x0A && data[6] == 0x1A && data[7] == 0x0A {
+	if bytes.HasPrefix(data, []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}) {
 		return Info{Type: Image, Format: "png", MimeType: "image/png"}, true
 	}
 
 	// GIF — "GIF87a" or "GIF89a"
-	if len(data) >= 6 && data[0] == 'G' && data[1] == 'I' && data[2] == 'F' {
+	if bytes.HasPrefix(data, []byte("GIF")) {
 		return Info{Type: Image, Format: "gif", MimeType: "image/gif"}, true
 	}
 
@@ -29,20 +29,18 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// BMP — "BM"
-	if data[0] == 'B' && data[1] == 'M' {
+	if bytes.HasPrefix(data, []byte("BM")) {
 		return Info{Type: Image, Format: "bmp", MimeType: "image/bmp"}, true
 	}
 
 	// TIFF — "II" (little-endian) or "MM" (big-endian) + 0x002A
-	if len(data) >= 4 {
-		if (data[0] == 'I' && data[1] == 'I' && data[2] == 0x2A && data[3] == 0x00) ||
-			(data[0] == 'M' && data[1] == 'M' && data[2] == 0x00 && data[3] == 0x2A) {
-			return Info{Type: Image, Format: "tiff", MimeType: "image/tiff"}, true
-		}
+	if bytes.HasPrefix(data, []byte{'I', 'I', 0x2A, 0x00}) ||
+		bytes.HasPrefix(data, []byte{'M', 'M', 0x00, 0x2A}) {
+		return Info{Type: Image, Format: "tiff", MimeType: "image/tiff"}, true
 	}
 
 	// ICO — 0x00 0x00 0x01 0x00
-	if data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x01 && data[3] == 0x00 {
+	if bytes.HasPrefix(data, []byte{0x00, 0x00, 0x01, 0x00}) {
 		return Info{Type: Image, Format: "ico", MimeType: "image/x-icon"}, true
 	}
 

--- a/media/image.go
+++ b/media/image.go
@@ -5,7 +5,8 @@ import "bytes"
 var (
 	jpegSignature          = []byte{0xFF, 0xD8, 0xFF}
 	pngSignature           = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
-	gifSignature           = []byte("GIF")
+	gif87aSignature        = []byte("GIF87a")
+	gif89aSignature        = []byte("GIF89a")
 	bmpSignature           = []byte("BM")
 	tiffLittleEndSignature = []byte{'I', 'I', 0x2A, 0x00}
 	tiffBigEndSignature    = []byte{'M', 'M', 0x00, 0x2A}
@@ -29,7 +30,7 @@ func detectImage(data []byte) (Info, bool) {
 	}
 
 	// GIF — "GIF87a" or "GIF89a"
-	if bytes.HasPrefix(data, gifSignature) {
+	if bytes.HasPrefix(data, gif87aSignature) || bytes.HasPrefix(data, gif89aSignature) {
 		return Info{Type: Image, Format: "gif", MimeType: "image/gif"}, true
 	}
 

--- a/media/media_test.go
+++ b/media/media_test.go
@@ -225,6 +225,16 @@ func TestDetect_ShortData(t *testing.T) {
 	if info.Type != Unknown {
 		t.Errorf("expected Unknown for 3-byte input, got %v", info.Type)
 	}
+
+	// 4 bytes exercise the shortest guarded image/video signatures without
+	// allowing longer detectors to read past the slice.
+	for _, data := range [][]byte{
+		{0xFF, 0xD8, 0xFF, 0x00},
+		{'F', 'L', 'V', 0x00},
+		{0x1A, 0x45, 0xDF, 0xA3},
+	} {
+		_ = Detect(data)
+	}
 }
 
 func TestDetect_TextWithControlChars(t *testing.T) {

--- a/media/media_test.go
+++ b/media/media_test.go
@@ -26,6 +26,21 @@ func TestDetect_GIF(t *testing.T) {
 	assertInfo(t, info, Image, "gif", "image/gif")
 }
 
+func TestDetect_GIFRejectsTruncatedHeaders(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("GIF"),
+		[]byte("GIF8"),
+		[]byte("GIF89"),
+		[]byte("GIF87"),
+		[]byte("GIF00a"),
+	} {
+		info := Detect(data)
+		if info.Type == Image || info.Format == "gif" {
+			t.Fatalf("expected non-GIF for %q, got %#v", data, info)
+		}
+	}
+}
+
 func TestDetect_WebP(t *testing.T) {
 	data := make([]byte, 12)
 	copy(data[0:4], "RIFF")

--- a/media/media_test.go
+++ b/media/media_test.go
@@ -26,7 +26,7 @@ func TestDetect_GIF(t *testing.T) {
 	assertInfo(t, info, Image, "gif", "image/gif")
 }
 
-func TestDetect_GIFRejectsTruncatedHeaders(t *testing.T) {
+func TestDetect_GIFRejectsTruncatedOrInvalidHeaders(t *testing.T) {
 	for _, data := range [][]byte{
 		[]byte("GIF"),
 		[]byte("GIF8"),
@@ -243,12 +243,22 @@ func TestDetect_ShortData(t *testing.T) {
 
 	// 4 bytes exercise the shortest guarded image/video signatures without
 	// allowing longer detectors to read past the slice.
-	for _, data := range [][]byte{
-		{0xFF, 0xD8, 0xFF, 0x00},
-		{'F', 'L', 'V', 0x00},
-		{0x1A, 0x45, 0xDF, 0xA3},
+	for _, tc := range []struct {
+		name   string
+		data   []byte
+		typ    Type
+		format string
+	}{
+		{name: "jpeg", data: []byte{0xFF, 0xD8, 0xFF, 0x00}, typ: Image, format: "jpeg"},
+		{name: "flv", data: []byte{'F', 'L', 'V', 0x00}, typ: Video, format: "flv"},
+		{name: "ebml", data: []byte{0x1A, 0x45, 0xDF, 0xA3}, typ: Video, format: "mkv"},
 	} {
-		_ = Detect(data)
+		t.Run(tc.name, func(t *testing.T) {
+			info := Detect(tc.data)
+			if info.Type != tc.typ || info.Format != tc.format {
+				t.Fatalf("expected %s/%s, got %#v", tc.typ, tc.format, info)
+			}
+		})
 	}
 }
 

--- a/media/video.go
+++ b/media/video.go
@@ -2,6 +2,11 @@ package media
 
 import "bytes"
 
+var (
+	ebmlSignature = []byte{0x1A, 0x45, 0xDF, 0xA3}
+	flvSignature  = []byte("FLV")
+)
+
 // detectVideo checks for known video format signatures.
 func detectVideo(data []byte) (Info, bool) {
 	if len(data) < 4 {
@@ -33,7 +38,7 @@ func detectVideo(data []byte) (Info, bool) {
 	}
 
 	// WebM / MKV — EBML header: 0x1A 0x45 0xDF 0xA3
-	if bytes.HasPrefix(data, []byte{0x1A, 0x45, 0xDF, 0xA3}) {
+	if bytes.HasPrefix(data, ebmlSignature) {
 		// Search for DocType in the first bytes.
 		docType := findEBMLDocType(data)
 		switch docType {
@@ -50,7 +55,7 @@ func detectVideo(data []byte) (Info, bool) {
 	}
 
 	// FLV — "FLV" header.
-	if bytes.HasPrefix(data, []byte("FLV")) {
+	if bytes.HasPrefix(data, flvSignature) {
 		return Info{Type: Video, Format: "flv", MimeType: "video/x-flv", Container: "FLV"}, true
 	}
 

--- a/media/video.go
+++ b/media/video.go
@@ -1,5 +1,7 @@
 package media
 
+import "bytes"
+
 // detectVideo checks for known video format signatures.
 func detectVideo(data []byte) (Info, bool) {
 	if len(data) < 4 {
@@ -31,7 +33,7 @@ func detectVideo(data []byte) (Info, bool) {
 	}
 
 	// WebM / MKV — EBML header: 0x1A 0x45 0xDF 0xA3
-	if data[0] == 0x1A && data[1] == 0x45 && data[2] == 0xDF && data[3] == 0xA3 {
+	if bytes.HasPrefix(data, []byte{0x1A, 0x45, 0xDF, 0xA3}) {
 		// Search for DocType in the first bytes.
 		docType := findEBMLDocType(data)
 		switch docType {
@@ -48,7 +50,7 @@ func detectVideo(data []byte) (Info, bool) {
 	}
 
 	// FLV — "FLV" header.
-	if data[0] == 'F' && data[1] == 'L' && data[2] == 'V' {
+	if bytes.HasPrefix(data, []byte("FLV")) {
 		return Info{Type: Video, Format: "flv", MimeType: "video/x-flv", Container: "FLV"}, true
 	}
 


### PR DESCRIPTION
## Summary
- Fixes CodeQL alerts for off-by-one short-buffer signature checks in media image/video detection.
- Replaces direct magic-byte indexing with guarded prefix checks.
- Adds short-input coverage for image/video signatures.

## Validation
- go test ./media
- golangci-lint run ./media