### PR TITLE
chore: govulncheck toolchain fix + gokit review-prompt system

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,25 +21,27 @@
 
 ## Module(s) Affected
 
-<!-- List the modules this PR changes (e.g., server, database, logger) -->
+<!-- List the modules this PR changes (e.g., server, database, logging) -->
 
-- 
+-
 
 ## Changes Made
 
 <!-- List key changes in bullet points -->
 
-- 
-- 
-- 
+-
+-
+-
 
 ## Testing
 
-<!-- Describe how you tested your changes -->
+<!-- Describe how you tested your changes. Prefer affected-scope commands. -->
 
-- [ ] Added new tests for my changes
-- [ ] All existing tests pass (`make test`)
-- [ ] Linter passes (`make lint`)
+- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
+- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
+- [ ] `make fmt` reports no diffs (`gofmt -s`)
+- [ ] `govulncheck ./...` passes for the affected module(s)
+- [ ] `make check-<domain>` passes for the affected domain
 - [ ] Manual testing performed (describe below if applicable)
 
 ### Test Evidence
@@ -53,17 +55,34 @@ $ make test M=<module>
 
 ## Breaking Changes
 
-<!-- If this is a breaking change, describe the impact and migration path -->
+<!-- Pre-stable: breaking changes are allowed and preferred over compat shims.
+If this is breaking, describe the impact and the redesign (not a migration shim). -->
+
+## Sibling Parity
+
+<!-- gokit mirrors rskit (the reference kit) and pykit. If this change touches a
+public abstraction (error codes, Component lifecycle, Provider shapes, stream, etc.),
+confirm parity or link the corresponding sibling item as a full URL, e.g.
+https://github.com/kbukum/rskit/issues/123 -->
+
+- [ ] Sibling-parity not required (internal change)
+- [ ] Sibling-parity tracked: rskit <url>, pykit <url>
+- [ ] Reveals an upstream rskit gap (tagged **IMPROVE-RSKIT** in the description)
 
 ## Checklist
 
-- [ ] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
-- [ ] I have run `make tidy` to ensure go.mod/go.sum are clean
-- [ ] I have added godoc comments for exported types/functions
-- [ ] I have updated relevant documentation (README.md, doc.go, etc.)
-- [ ] I have added tests that prove my fix/feature works
-- [ ] I have considered backward compatibility
-- [ ] New dependencies (if any) are justified and minimal
+- [ ] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
+- [ ] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
+- [ ] Bug fixes include a regression test that fails without the fix
+- [ ] Suite is green under `-race -shuffle=on`; coverage gates met (≥80% pkg, ≥85% overall/security)
+- [ ] No public `interface{}`/`any` (generics/typed); documented exceptions only
+- [ ] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
+- [ ] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
+- [ ] Code split by concern into focused files — not piled into one file
+- [ ] Exported items have godoc; each package has a `doc.go`; docs updated
+- [ ] `make tidy` run so go.mod/go.sum are clean for affected modules
+- [ ] CHANGELOG entry added under `[Unreleased]`
+- [ ] New dependencies (if any) are justified, minimal, and pass `govulncheck`
 
 ## Additional Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 
 ## Module(s) Affected
 
-<!-- List the modules this PR changes (e.g., server, database, logging) -->
+<!-- List the modules this PR changes (e.g., server, database, cache) -->
 
 -
 
@@ -74,7 +74,7 @@ https://github.com/kbukum/rskit/issues/123 -->
 - [ ] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
 - [ ] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
 - [ ] Bug fixes include a regression test that fails without the fix
-- [ ] Suite is green under `-race -shuffle=on`; coverage gates met (≥80% pkg, ≥85% overall/security)
+- [ ] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI codecov gate (project 80% / patch 85%)
 - [ ] No public `interface{}`/`any` (generics/typed); documented exceptions only
 - [ ] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
 - [ ] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,29 @@
 # gokit
 
-Multi-module Go library providing foundational infrastructure for service development. This is the reference implementation — pykit (Python) and rskit (Rust) mirror its structure.
+Multi-module Go library providing foundational infrastructure for service development. A
+sibling kit to rskit (Rust) and pykit (Python): same module structure and naming, same
+engineering baseline, idiomatic per language. rskit is the current reference for shape and
+quality; gokit is kept at parity with it.
+
+## Engineering principles
+
+Shared engineering baseline — apply to all work here:
+
+- **Phases:** discover → decide (Redesign / Align / Enhance / Drop / Leave) → implement completely → validate. Prefer root-cause redesign over symptom patches; no compatibility shims in pre-stable code.
+- **Layering & reuse:** explicit, acyclic dependency direction — lower layers never import higher (enforced by `depguard`). Reuse or enhance the canonical owner before writing new code; never duplicate shared concerns (errors, config, logging, auth, retries, observability, HTTP, registries).
+- **APIs:** typed and minimal; generics-first, no `interface{}`/`any` in public surfaces (except genuinely opaque values, documented); actionable typed errors that preserve cause.
+- **Errors & resilience:** no `panic()` / `log.Fatal` / ignored errors (`_ =`) / unchecked type assertions on runtime paths; no success-shaped fallbacks; timeout every remote call via `context.Context`; bounded jittered retries for idempotent ops only; circuit-break and degrade gracefully.
+- **Concurrency:** every goroutine has ownership, cancellation (context), timeout, and shutdown; bound channels / buffers / concurrency with documented backpressure; drain on shutdown; no goroutine leaks.
+- **Security & privacy:** validate at every trust boundary; least-privilege and secure-by-default; parameterized queries and argv-only subprocess (via `process`); tokens in headers, not query strings; current crypto only; minimize, redact, and retention-bound sensitive data.
+- **Composition:** explicit injected registries and config-driven selection; no `init()` side effects, no mutable package-global registries; inject logger / tracer / policies rather than reaching for globals.
+- **Tests:** behavioral and deterministic; green under `-race -shuffle=on -count=1`; cover failure paths; injected clocks (never `time.Sleep`); fixtures over embedded config; regression-test every fix.
+- **AI / model features:** treat model output and retrieved context as untrusted; enforce structured outputs; least-privilege tool calls with a human gate on destructive actions; version prompts / models and gate changes on evals.
+- **Supply chain:** pin CI actions by SHA; scan dependencies (`govulncheck` + licenses); sign release artifacts; attach SBOM and provenance.
+- **Currency:** use current Go idioms and standards, not folklore — `log/slog`, `errors.Is/As/Join`, `slices`/`maps`/`cmp`, `any` over `interface{}`; verify the dependency is maintained, the stdlib doesn't already cover it, and no open CVE applies.
+
+Standing, re-runnable review prompts encoding this baseline live in
+[`.github/prompts/reviews/`](prompts/reviews/README.md) — run them in a fresh, clean-context
+agent after every change set and before releases.
 
 ## Build, Test, and Lint
 
@@ -37,15 +60,34 @@ When adding a new module:
 
 ## Code Style
 
-- `gofmt` + `golangci-lint` (`.golangci.yml` at root)
-- Generics-first: all public APIs use Go generics. No `interface{}` in public APIs.
+- `gofmt -s` + `golangci-lint` (`.golangci.yml` at root; `depguard` enforces layer direction).
+- Generics-first: all public APIs use Go generics. No `interface{}`/`any` in public APIs
+  (except genuinely opaque values — JSON body, `ctx.Value`, DB scan — documented).
 - Interfaces have 1–3 methods. Components opt-in to capabilities via separate interfaces.
 - Constructors accept `...Option` for extensibility (functional options pattern).
 - Package names: lowercase, single-word, no plurals.
 - Every package has a `doc.go`.
 - Exported interfaces + factory functions; concrete implementations unexported.
 - Errors: RFC 7807 `AppError` with typed error codes.
-- Tests: parallel, table-driven, use `testutil` helpers.
+- Tests: parallel, table-driven, use `testutil` helpers; deterministic under `-race -shuffle`.
+- **Readability & structure (load-bearing, not cosmetic):** organize by focused, well-named
+  files within a package — never pile unrelated logic into one large file. Split by concern
+  (types, options, registry, middleware, adapter) into separate files so the next reader can
+  navigate by filename. A file that has grown to cover several responsibilities is a refactor
+  signal, not a normal state.
+
+## Validation scope
+
+Scope commands to what changed; the full workspace gates are for audits/CI sign-off:
+
+```bash
+make lint M=<module>                 # golangci-lint, one module
+make test M=<module> T=<pattern>     # scoped tests (-race -count=1)
+make test-affected                   # only modules the diff touches
+make check-<domain>                  # per-domain gate: core|patterns|crosscutting|composition|
+                                     #   transport|auth|data|ai|media|infra
+make check                           # full canonical gate (build + vet + test) — audit/CI
+```
 
 ## Key Patterns
 

--- a/.github/prompts/reviews/00-structure-placement.md
+++ b/.github/prompts/reviews/00-structure-placement.md
@@ -1,0 +1,77 @@
+# Pass 00 — Structure and placement
+
+Confirm every touched (or, in project mode, every existing) item lives in the right module,
+package, and layer, and that the dependency direction stays acyclic. This is the first gate:
+misplaced code makes every later pass moot, so reject on failure here before going further.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* check the packages the diff touches plus the blast radius — a
+change to a core package's public surface fans out to every sub-module, nested adapter, and
+downstream consumer. *Project mode:* sweep each module's packages and dependency edges; the
+placement and acyclicity rules below are invariants for the whole toolkit.
+
+## The layering invariant
+
+Dependency direction is explicit and acyclic; lower layers never import higher. A cycle or an
+upward import is a **blocker**, enforced by `depguard` in `.golangci.yml`. The module layering
+(downward dep direction only):
+
+```
+L0  errors, util, version               L5  server, httpclient, grpc, sse, discovery, connect
+L1  config, logger, validation,         L6  auth*, authz, database, cache, storage,
+    encryption, schema                      vectorstore, messaging
+L2  component, hook, provider, di       L7  llm, embedding, agent, tool, mcp, inference, ai, skill
+L3  observability, resilience, security L8  media
+L4  bootstrap, pipeline, chain, dag,    L9  workload, cli, bench, dataset
+    worker, process, stateful
+```
+
+## Module/package placement
+
+gokit is a multi-module monorepo split by dependency weight and role:
+
+| Kind | Location | Owns |
+|------|----------|------|
+| Root-module package | `github.com/kbukum/gokit/<name>` (shared root `go.mod`) | foundation + cross-cutting packages with no heavy deps |
+| Sub-module | `<name>/` with its own `go.mod` | packages with heavy external deps (auth, database, messaging, server, …) |
+| Nested adapter | `<parent>/<backend>/` (e.g. `storage/s3`, `cache/redis`, `messaging/kafka`) | an opt-in backend that owns its SDK dependency |
+| Test util | `<parent>/testutil/` | test helpers for that area |
+
+## Checks
+
+- **Package placement.** No-heavy-deps foundation code → root module. Heavy-deps code →
+  sub-module with its own `go.mod`. A backend adapter → nested `<parent>/<backend>/` owning its
+  SDK. A foundation concern buried in a sub-module, or a heavy-dep import pulled into the root
+  module, is a structure violation (blocker).
+- **Acyclic, downward-only edges.** No lower-layer package imports a higher one; no cycle. This
+  is gated by `depguard` — run `make lint`. An upward import is a blocker.
+- **New sub-module wiring.** Own `go.mod`, a `replace github.com/kbukum/gokit => ../` directive
+  for local dev, added to `go.work` / `core.go.work` / `contrib.go.work` as appropriate, and to
+  `domains.toml` + the matching `make check-<domain>` set. Missing any is a should-fix.
+- **doc.go present.** Every package has a `doc.go` with a package doc comment. Missing is a
+  should-fix.
+- **No misplaced concerns.** Each cross-cutting concern stays in its canonical package — e.g.
+  gRPC status mapping belongs in `grpc`, not `errors`. (Reuse of those owners is pass `01`.)
+- **Backend opt-in.** A nested adapter registers via an explicit `Register(registry)` call, not
+  an `init()` side effect, and the core package keeps a lean in-memory/local default.
+
+## Detection starters
+
+These flag candidates, not verdicts — read each hit to judge intent.
+
+```bash
+# what each module actually depends on (intra-gokit edges)
+for m in */go.mod; do echo "== $m =="; grep -E '^\s+github.com/kbukum/gokit' "$m"; done
+# packages missing a doc.go
+for d in $(find . -name '*.go' -not -name '*_test.go' | xargs -n1 dirname | sort -u); do \
+  ls "$d"/doc.go >/dev/null 2>&1 || echo "no doc.go: $d"; done
+# init() functions (import-time side effects — should be explicit Register)
+grep -rn --include=*.go '^func init()' . | grep -v _test.go
+```
+
+Then run `make lint` (depguard enforces the layer direction) and `make check-<domain>` for the
+touched domain.

--- a/.github/prompts/reviews/01-canonical-reuse.md
+++ b/.github/prompts/reviews/01-canonical-reuse.md
@@ -1,0 +1,68 @@
+# Pass 01 — Canonical-owner reuse
+
+gokit *is* the canonical toolkit, so the duplication risk is internal: **did the change
+reimplement something an existing package (or the standard library) already owns?** Vibe-coded
+code reaches for a fresh local helper instead of the owner — assume duplication until proven
+otherwise. Treat findings here as a blocker class.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* for each new type/helper in the diff, name the concern and find
+its owner. *Project mode:* sweep the tree for the patterns below and reconcile each against the
+owning package — long-lived internal forks are exactly what this pass exists to surface.
+
+## The rule
+
+Reuse or enhance the canonical owner before writing new code. Never duplicate a shared concern
+— **errors, config, logging, auth, retries/resilience, observability, HTTP, registries,
+validation, process, di**. If the owner is inadequate, enhance it *generically* rather than
+forking a copy in another package. gokit must stay foundational and multi-purpose: a fix
+belongs in the owner so every consumer benefits.
+
+## How to check, not just glance
+
+For each candidate, name the concern, locate its owning package, and confirm the change calls
+the owner rather than rewriting it:
+
+- **Errors.** gokit `AppError` (RFC 7807) with typed error codes and wrapped cause via `%w`.
+  A fresh `errors.New`/`fmt.Errorf` sentinel for a shared concern, or a bespoke error struct
+  duplicating `AppError`, is duplication. Use `errors.Is/As/Join`.
+- **Resilience.** Retries / timeouts / circuit-breaking come from `resilience`, not hand-rolled
+  loops or ad-hoc `context.WithTimeout` scattering with bespoke backoff.
+- **Config / logging / di / observability.** Route through the owning package; no parallel
+  re-implementation, no second logger/tracer setup. Logging is `log/slog`-based via `logger`,
+  not a fresh `log` or `fmt.Print`.
+- **HTTP / transport.** Reuse `httpclient` / `server`; a raw `http.Client{}` with bespoke
+  retry/timeout in an adapter is duplication.
+- **Subprocess.** Execution goes through `process` (argv-only), not a bare `exec.Command`.
+- **Currency (part of reuse).** Before adding a dependency or helper, verify the stdlib does
+  not already cover it (`slices`, `maps`, `cmp`, `errors.Join`, `sync.OnceValue`), the
+  dependency is maintained, and no open CVE applies. Reinventing a std facility is a should-fix.
+- **"Almost the same" counts.** A near-copy with one tweaked line is still a fork — enhance the
+  owner to cover the new case.
+
+## Detection starters
+
+These flag candidates, not verdicts — read each hit, then name the owner that should have been
+used.
+
+```bash
+grep -rn --include=*.go 'errors.New(\|fmt.Errorf(' . | grep -v _test.go   # vs AppError for shared concerns
+grep -rn --include=*.go 'exec.Command' . | grep -v _test.go               # should route through process
+grep -rn --include=*.go 'http.Client{\|&http.Client' . | grep -v _test.go # should reuse httpclient
+grep -rn --include=*.go 'time.After\|context.WithTimeout\|backoff\|retry' . | grep -v _test.go  # resilience owner
+grep -rn --include=*.go 'log.Print\|fmt.Print\|"log"' . | grep -v _test.go # should use logger (slog)
+```
+
+For each hit: is there a package owner for this concern? If yes and the code does not use it →
+**blocker** (reuse). If no owner exists and it is a genuinely foundational concern → it should
+be **added to the owning package** (or a new one), not solved locally; a local solution is a
+**should-fix** with an "upstream to the owner" note.
+
+## Output for this pass
+
+Per finding, name the concrete package/type that should have been used (e.g. "use `resilience`
+retry policy instead of a hand-rolled loop", "wrap with `process` rather than `exec.Command`").

--- a/.github/prompts/reviews/02-principles.md
+++ b/.github/prompts/reviews/02-principles.md
@@ -1,0 +1,75 @@
+# Pass 02 — Principle conformance
+
+Each item here is a hard principle from
+[`.github/copilot-instructions.md`](../../copilot-instructions.md), not a preference. This is
+where vibe coding drifts most — especially around resilience, concurrency, and composition.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* grep the touched packages and reason about each runtime path.
+*Project mode:* the panic/concurrency/composition invariants below hold across the whole
+library surface — sweep the tree.
+
+## Typed, minimal APIs
+
+Generics-first: no `interface{}`/`any` on public surfaces except genuinely opaque values (JSON
+body, `ctx.Value`, DB column scan, third-party interface contract) — and those are documented.
+Actionable typed errors (`AppError`) that preserve cause via `%w`. Minimal public surface — no
+incidental exported identifiers; unexport what callers don't need.
+
+## Errors & resilience
+
+- No `panic()` / `log.Fatal` / ignored errors (`_ = f()`) / unchecked type assertions
+  (`x.(T)` without the `, ok` form) on runtime paths (tests excepted). `MustXxx` allowed only
+  for compile-time-safe construction (`regexp.MustCompile`, `template.Must`) and explicit Must*
+  twins of error-returning funcs.
+- No success-shaped fallbacks that mask failure (returning a zero value + `nil` error on a real
+  failure).
+- Every remote call has a **timeout** via `context.Context`. Retries are **bounded, jittered,
+  and applied to idempotent ops only**. Failures circuit-break and degrade gracefully rather
+  than hang or cascade. (Reuse `resilience` — see pass `01`.)
+
+## Concurrency
+
+- Every goroutine has clear **ownership, cancellation (context), timeout, and shutdown**
+  handling; no goroutine leaks (a `go func()` with no way to stop it is a **blocker**).
+- Channels / buffers / concurrency are **bounded with documented backpressure**; components
+  **drain in-flight work on shutdown**. An unbounded queue on an ingest path is a **blocker**.
+- No data races: shared state guarded by `sync.Mutex`/`sync.RWMutex` or confined to one
+  goroutine; verified under `-race`. Context is the first parameter, never stored in a struct.
+
+## Composition
+
+- Registries and policies are **explicitly injected**; selection is config-driven.
+- **No `init()` side effects, no mutable package-global registries**, no reaching for a global
+  logger/tracer — inject them. A package-level `var registry = …` mutated at runtime, or an
+  `init()` that dials network / reads env / registers into a global, is a **blocker**.
+- Constructors take `...Option`; dependencies passed in, not resolved from a global.
+
+## Currency
+
+Current Go idioms, not folklore (also enforced in pass `01`). `log/slog` not `logrus`/`zap`;
+`errors.Is/As/Join`; `slices`/`maps`/`cmp`; `any` over `interface{}`; loop-var capture is fixed
+in 1.22+ (no `v := v` workarounds). Flag superseded patterns.
+
+## AI / model features (only if the change touches them)
+
+Model output and retrieved context are **untrusted**; outputs are structured/validated; tool
+calls are least-privilege with a **human gate on destructive actions**; prompts/models are
+versioned and changes gated on evals.
+
+## Detection starters
+
+Exclude `_test.go` when judging runtime-path hits.
+
+```bash
+grep -rn --include=*.go 'panic(\|log.Fatal' . | grep -v _test.go
+grep -rn --include=*.go 'interface{}\|[^.]\bany\b' . | grep -v _test.go   # public-surface any/interface{}
+grep -rn --include=*.go '_ = \|_, _ =' . | grep -v _test.go               # ignored errors
+grep -rn --include=*.go 'go func\|go [a-zA-Z]' . | grep -v _test.go       # each needs ownership/cancel/shutdown
+grep -rn --include=*.go 'make(chan ' . | grep -v _test.go                 # bounded? backpressure?
+grep -rn --include=*.go '^var .*[Rr]egistry\|^func init()' . | grep -v _test.go  # global-registry / init smell
+```

--- a/.github/prompts/reviews/03-security-privacy.md
+++ b/.github/prompts/reviews/03-security-privacy.md
@@ -1,0 +1,53 @@
+# Pass 03 — Security & privacy
+
+A dedicated pass because a vibe-coded path that "just works" usually skips boundary validation,
+and gokit is shared infrastructure — a gap here propagates to every consumer. For a deeper
+sweep on security-sensitive changes, pair this with a dedicated security review; this pass is
+the standing baseline.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* trace each new input path from its trust boundary to its use.
+*Project mode:* audit the toolkit's external-facing surfaces (HTTP, process, storage/database
+adapters, auth, crypto) for the invariants below.
+
+## Checks
+
+- **Validate at every trust boundary.** Untrusted input is validated before use; least-
+  privilege and secure-by-default. An input that flows into a query, a path, a command, or a
+  deserialization without validation is a blocker.
+- **Injection-safe data access.** Parameterized queries only — never string-built SQL
+  (`fmt.Sprintf`/concatenation into a query). Argv-only subprocess execution via `process` — no
+  `sh -c` / shell interpolation of untrusted input.
+- **Token hygiene.** Tokens/credentials go in headers, never query strings; never logged.
+  Redact sensitive fields in errors and logs. Auth is header-only; reject query-string tokens.
+- **Current crypto.** No deprecated/weak algorithms (MD5, SHA-1 for security, DES, ECB, static
+  IVs, hard-coded keys); use current primitives (AES-GCM, ChaCha20-Poly1305, Argon2id, Ed25519,
+  RS256/ES256). Reject `alg: none` in JWT; require `exp`/`iss`/`aud`. Crypto belongs in
+  `encryption` / `security`, not hand-rolled.
+- **Data minimization.** Minimize, redact, and retention-bound sensitive data; do not persist
+  or log more than needed.
+
+## Detection starters
+
+Read each hit to judge intent — these flag candidates, not verdicts.
+
+```bash
+# string-built SQL / shelled commands with interpolation
+grep -rn --include=*.go 'fmt.Sprintf(.*SELECT\|fmt.Sprintf(.*INSERT\|"sh", "-c"\|"bash"' .
+# secrets in URLs/logs, or logging a token/password/secret
+grep -rn --include=*.go '(token\|secret\|password\|api_\?key)=' .
+grep -rni --include=*.go 'slog\.\|logger\.' . | grep -i 'token\|secret\|password\|apikey'
+# weak crypto / alg:none
+grep -rni --include=*.go 'md5\|sha1\|"DES"\|ecb\|alg.*none' .
+# hard-coded credentials
+grep -rn --include=*.go '\(password\|secret\|apiKey\|token\)\s*[:=]\s*"' . | grep -v _test.go
+```
+
+Flag any unbounded read of untrusted input (set explicit size limits — `io.LimitReader`) and
+any path/selector from an untrusted source flowing into filesystem or process execution without
+validation. Path-shaped values use `filepath.Join` (never hardcoded separators) and a temp-dir
+helper over hardcoded `/tmp/...`.

--- a/.github/prompts/reviews/04-quality.md
+++ b/.github/prompts/reviews/04-quality.md
@@ -1,0 +1,73 @@
+# Pass 04 — Quality, readability & maintainability
+
+This is the pass the user cares about most: **is the code readable, maintainable, and well
+organized — or is it piled into one file?** Correctness passes (`02`, `03`) can be green while
+the code is still a maintenance liability. Vibe-coded output tends to grow one giant file with a
+few 300-line functions; this pass rejects that.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* judge the readability of the touched files and functions.
+*Project mode:* sweep for oversized files, god-packages, and duplicated logic across the tree.
+
+## File & package organization (primary focus)
+
+- **No piling into one file.** A package's functionality is split into focused files by concern
+  — e.g. `client.go`, `options.go`, `errors.go`, `types.go`, `doc.go` — not one 800-line
+  `<name>.go` holding everything. A single file that mixes types, construction, transport, and
+  helpers is a **should-fix**; refactor into cohesive files.
+- **One clear responsibility per file.** A reader should predict a file's contents from its
+  name. Group related types + their methods together; keep unrelated concerns in separate files.
+- **Cohesive packages.** A package is one concept. A grab-bag `utils`/`helpers` package
+  accreting unrelated functions is a smell — place each helper with the concern it serves, or in
+  the canonical owner (pass `01`).
+- **Right-sized functions.** A function that does not fit on a screen or mixes several
+  abstraction levels should be decomposed. Deeply nested conditionals → early returns / guard
+  clauses. Prefer small, named helpers over inline complexity.
+
+## Readability
+
+- **Names reveal intent.** No cryptic abbreviations, no `data2`/`tmp3`, no misleading names.
+  Exported identifiers read well at the call site (Go style: no stutter — `cache.New`, not
+  `cache.NewCache`).
+- **Straight-line where possible.** Minimize state and mutation; prefer clear sequential logic
+  over clever one-liners. Complexity that must exist is isolated and named.
+- **Errors add context.** Wrapped with `%w` and a message that says what failed, not a bare
+  re-return that loses the call site.
+
+## Maintainability
+
+- **DRY within reason.** Copy-pasted blocks with small tweaks → one parameterized helper. (But
+  do not over-abstract a single use.)
+- **No dead or speculative code.** No commented-out blocks (git history exists), no unused
+  exports, no "might need it later" scaffolding. Remove it.
+- **Consistent with neighbors.** Matches the patterns of the surrounding package (option
+  structs, constructor shape, error style) rather than introducing a one-off style.
+
+## Detection starters
+
+Read each hit — size and nesting are signals, not automatic verdicts.
+
+```bash
+# largest .go files (piling-into-one-file candidates)
+find . -name '*.go' -not -name '*_test.go' | xargs wc -l | sort -rn | head -30
+# packages that are a single big file (no concern split)
+for d in $(find . -name '*.go' -not -name '*_test.go' | xargs -n1 dirname | sort -u); do \
+  n=$(ls "$d"/*.go 2>/dev/null | grep -v _test.go | wc -l); echo "$n $d"; done | sort -n | head
+# grab-bag packages
+find . -type d \( -name utils -o -name helpers -o -name common -o -name misc \)
+# commented-out code / stale markers
+grep -rn --include=*.go '^\s*//\s*[a-z].*(' . | grep -v _test.go   # candidate commented-out lines
+grep -rn --include=*.go 'TODO\|FIXME\|HACK' . | grep -v _test.go   # each needs a tracked issue link
+```
+
+Then run `make fmt` (`gofmt -s`) and `make lint` — a clean gofmt/golangci-lint run is necessary
+but not sufficient; the organization judgments above are the point of this pass.
+
+## Output for this pass
+
+For each finding, name the concrete refactor: which file to split, into which files, and along
+which concern boundary — so it is directly actionable, not just "this file is too big".

--- a/.github/prompts/reviews/05-tests-tdd.md
+++ b/.github/prompts/reviews/05-tests-tdd.md
@@ -1,0 +1,60 @@
+# Pass 05 — Tests & TDD
+
+Behavior is only real if a test proves it. Vibe-coded changes routinely ship without tests, or
+with tests that assert implementation detail instead of behavior. This pass verifies the change
+is covered, deterministic, and race-clean.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* every behavioral change in the diff has a test in the same
+change; every bug fix has a regression test. *Project mode:* assess coverage against the gates
+and hunt for flaky/implementation-coupled tests across the suite.
+
+## Checks
+
+- **Tests ship with the change.** New/changed behavior has tests in the same change set; a bug
+  fix has a regression test that fails without the fix. Behavior added with no test is a
+  **blocker**.
+- **Behavioral, not implementation-coupled.** Tests assert observable behavior and public
+  contracts, not private field values or call sequences that would break on a harmless refactor.
+- **Deterministic.** Clocks are **injected** (never `time.Sleep` to "wait" for async work), RNG
+  is **seeded**, no real network / filesystem in unit tests (use fakes / `testutil` / `t.TempDir`).
+  A test that sleeps or hits the network is a should-fix.
+- **Race / shuffle / parallel green.** Suite passes under `go test -race -shuffle=on`, and
+  `t.Parallel()` tests are actually independent. Table-driven tests capture the range var
+  correctly (trivially safe on 1.22+, but still check shared mutable state).
+- **Coverage gates.** ≥80% per package, ≥85% overall; ≥85% for the security-load-bearing
+  packages (`errors`, `auth`, `authz`, `security`, `resilience`, `encryption`). A change that
+  drops a gated package below its floor is a blocker.
+- **Fuzz where it matters.** Parsers, validators, auth/JWT, codecs, and schema have `Fuzz`
+  targets. A new parser/validator with no fuzz target is a should-fix.
+- **Environment-independent.** Tests use `t.Setenv` (auto-restored) rather than mutating global
+  env; no ordering dependency between tests.
+
+## Detection starters
+
+```bash
+# behavior touched vs tests touched (changes mode)
+git diff --name-only | grep '\.go$' | grep -v _test.go   # source changed
+git diff --name-only | grep '_test\.go$'                 # tests changed — should be non-empty
+# non-deterministic / external-dependency smells in tests
+grep -rn --include=*_test.go 'time.Sleep\|time.Now()\|http.Get\|net.Dial\|rand.Int' .
+# missing fuzz on parser/validator/codec/auth packages
+grep -rLn --include=*_test.go 'func Fuzz' codec schema auth validation 2>/dev/null
+```
+
+## Validation gate
+
+Run the scoped suite for the touched domain, with race + shuffle:
+
+```bash
+make test-affected                 # race-enabled, only affected modules (fast inner loop)
+./gomod.sh cmd "go test -race -shuffle=on -count=1 ./..." -m <module>   # one module, thorough
+make check-<domain>                # domain gate (fmt + vet + lint + test) for the touched area
+```
+
+A behavioral change with a green race+shuffle run and coverage above the gate passes; anything
+untested, sleeping, or below the coverage floor does not.

--- a/.github/prompts/reviews/05-tests-tdd.md
+++ b/.github/prompts/reviews/05-tests-tdd.md
@@ -28,7 +28,8 @@ and hunt for flaky/implementation-coupled tests across the suite.
   correctly (trivially safe on 1.22+, but still check shared mutable state).
 - **Coverage gates.** ≥80% per package, ≥85% overall; ≥85% for the security-load-bearing
   packages (`errors`, `auth`, `authz`, `security`, `resilience`, `encryption`). A change that
-  drops a gated package below its floor is a blocker.
+  drops a gated package below its floor is a blocker. (CI enforces project 80% / patch 85% via
+  `codecov.yml`; the per-package floors are checked each step via `make test-coverage`.)
 - **Fuzz where it matters.** Parsers, validators, auth/JWT, codecs, and schema have `Fuzz`
   targets. A new parser/validator with no fuzz target is a should-fix.
 - **Environment-independent.** Tests use `t.Setenv` (auto-restored) rather than mutating global

--- a/.github/prompts/reviews/06-docs-supply-chain.md
+++ b/.github/prompts/reviews/06-docs-supply-chain.md
@@ -33,7 +33,7 @@ wiring for the invariants below.
   pass `01`), maintained (recent releases), license-compatible, and free of known advisories.
   An unjustified or unmaintained dependency is a should-fix; one with an open CVE is a blocker.
 - **Vulnerability + license clean.** `govulncheck` passes; new findings are triaged in
-  `govulncheck-suppressions.json` with a rationale, not silently ignored. `gosec` (config in
+  `.github/govulncheck-suppressions.json` with a rationale, not silently ignored. `gosec` (config in
   `gosec.toml`) passes.
 - **Tidy modules.** `go.mod`/`go.sum` reflect exactly what is used (`go mod tidy` run per
   affected module); no leftover or phantom requires; `go.work` / `core.go.work` /

--- a/.github/prompts/reviews/06-docs-supply-chain.md
+++ b/.github/prompts/reviews/06-docs-supply-chain.md
@@ -1,0 +1,67 @@
+# Pass 06 — Docs & supply chain
+
+Docs drift and dependency risk are the quiet failures — the code works, so nobody notices the
+stale godoc or the unvetted new dependency until much later. This pass keeps the published
+surface honest and the dependency set clean.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* check the docs and deps the diff touches or invalidates.
+*Project mode:* audit every module's `doc.go`, READMEs, `go.mod`/`go.sum`, and the CI/release
+wiring for the invariants below.
+
+## Docs
+
+- **Public API documented.** Every exported identifier has a godoc comment starting with its
+  name; every package has a `doc.go` with a package overview. gokit publishes to **pkg.go.dev**,
+  so godoc *is* the public documentation — missing docs on new exports is a should-fix.
+- **Docs match behavior.** A behavioral change updates the affected godoc, package overview, and
+  any README/example. Stale docs that now describe removed or changed behavior are a should-fix.
+  (Godoc *accuracy* vs the code is pass `07`; this check is that docs were updated at all.)
+- **Canonical docs regenerated.** A module rename/add/remove updates `domains.toml`,
+  `docs/MODULE-INDEX.md`, and `docs/parity-matrix.md` in the same change. A stale parity matrix
+  or module index is a should-fix.
+- **Examples compile.** Example code / `Example` test functions build and reflect the current
+  API.
+
+## Supply chain
+
+- **New dep justified.** Each added dependency is necessary (stdlib does not already cover it —
+  pass `01`), maintained (recent releases), license-compatible, and free of known advisories.
+  An unjustified or unmaintained dependency is a should-fix; one with an open CVE is a blocker.
+- **Vulnerability + license clean.** `govulncheck` passes; new findings are triaged in
+  `govulncheck-suppressions.json` with a rationale, not silently ignored. `gosec` (config in
+  `gosec.toml`) passes.
+- **Tidy modules.** `go.mod`/`go.sum` reflect exactly what is used (`go mod tidy` run per
+  affected module); no leftover or phantom requires; `go.work` / `core.go.work` /
+  `contrib.go.work` include any new module.
+- **CI/release hygiene** (if touched). GitHub Actions pinned by commit SHA (never a moving
+  tag); minimum job permissions; release artifacts signed (cosign) and SBOM (CycloneDX)
+  produced. A workflow pinned to a tag or granting broad permissions is a should-fix.
+
+## Detection starters
+
+```bash
+# exported identifiers missing a doc comment (spot-check the hits)
+grep -rn --include=*.go '^func [A-Z]\|^type [A-Z]\|^var [A-Z]\|^const [A-Z]' . | grep -v _test.go
+# packages missing doc.go
+for d in $(find . -name '*.go' -not -name '*_test.go' | xargs -n1 dirname|sort -u); do \
+  ls "$d"/doc.go >/dev/null 2>&1 || echo "no doc.go: $d"; done
+# actions pinned by tag rather than SHA
+grep -rn 'uses:' .github/workflows | grep -v '@[0-9a-f]\{40\}'
+# module map / matrix touched when modules change?
+git diff --name-only | grep -E 'domains.toml|MODULE-INDEX|parity-matrix'
+```
+
+## Validation gate
+
+```bash
+./gomod.sh cmd "go mod tidy" -m <module>          # per affected module
+make lint                                          # includes vet; depguard for layering
+govulncheck ./...                                  # vuln scan (from the affected module)
+```
+
+Docs updated alongside behavior, tidy modules, and a clean `govulncheck` pass this gate.

--- a/.github/prompts/reviews/07-comments-godoc.md
+++ b/.github/prompts/reviews/07-comments-godoc.md
@@ -1,0 +1,53 @@
+# Pass 07 — Comments & godoc semantics
+
+The final pass, and a subtle one: comments and godoc are trusted by future readers and by
+pkg.go.dev, so a **wrong** comment is worse than no comment. Vibe-coded comments tend to narrate
+the obvious, restate the code, or describe what the code *used to* do. This pass keeps prose
+truthful and useful.
+
+> **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
+> An independent reviewer re-derives every judgment from the code and the principles instead of
+> trusting prior reasoning. A plan/spec may be passed in as a scope checklist only; it never
+> excuses a baseline violation.
+
+**Scope note.** *Changes mode:* read every comment and godoc line in the diff against the code
+beside it. *Project mode:* sample doc comments across packages, prioritizing public API godoc
+that pkg.go.dev renders.
+
+## Checks
+
+- **Godoc is accurate.** Each doc comment matches what the function/type actually does now —
+  parameters, return values, error conditions, side effects, and any concurrency/ownership
+  contract. A comment that describes the old behavior after a change is a should-fix (it will
+  mislead every future reader and ship to pkg.go.dev).
+- **Godoc convention.** Doc comments start with the identifier name (`// New returns …`,
+  `// Cache is …`); package overview lives in `doc.go`. Exported items on the public surface are
+  documented (ties to pass `06`; here the focus is *correctness* of the prose).
+- **Comments earn their place.** Explain **why** — the non-obvious constraint, invariant, or
+  trade-off — not **what** the code plainly says. Delete comments that merely restate the line
+  below them.
+- **No historical narration.** Comments describe the code as it is now, not the bug that was
+  fixed or how it used to work. "Previously we… now we…" belongs in the commit message / git
+  history, not the source. This is an explicit user preference — flag every instance.
+- **No stale references.** Comments don't name removed types, old parameter names, dead flags,
+  or moved files. TODO/FIXME/HACK carry a tracked issue link or they don't belong (ties to
+  pass `04`).
+- **Accurate, minimal.** When in doubt, fewer comments — but the ones present must be correct.
+  A misleading comment is a should-fix even if the code is right.
+
+## Detection starters
+
+Comment semantics are read-and-judge work; these only surface candidates.
+
+```bash
+# historical narration in comments (user-flagged anti-pattern)
+grep -rn --include=*.go '//.*\(previously\|used to\|old \|before we\|now we\|changed to\|no longer\)' . | grep -v _test.go
+# what-not-why restatement candidates: doc comment not starting with the identifier
+grep -rn --include=*.go '^// [a-z]' . | grep -v _test.go
+# stale-marker comments
+grep -rn --include=*.go 'TODO\|FIXME\|HACK\|XXX' . | grep -v _test.go
+```
+
+Then read the doc comment on each changed exported identifier next to its implementation and
+confirm the prose is true. Accurate godoc that explains *why* passes; anything describing old
+behavior, restating the obvious, or narrating the fix does not.

--- a/.github/prompts/reviews/README.md
+++ b/.github/prompts/reviews/README.md
@@ -1,0 +1,121 @@
+# gokit review prompts
+
+A set of standing, re-runnable review prompts for this repository. They encode gokit's
+permanent engineering baseline (see [`.github/copilot-instructions.md`](../../copilot-instructions.md)
+and the sibling rskit baseline) so any change set — or the whole toolkit — can be reviewed the
+same way every time.
+
+gokit is shared foundation infrastructure: a defect in a core package propagates to every
+sub-module, every nested adapter, and every downstream consumer (rskit/pykit parity repos and
+the services that import gokit). The bar here is correspondingly high — security, concurrency,
+and composition each get their own lens. Each prompt works as either a human checklist or the
+instruction block you hand an AI reviewer.
+
+## What is here
+
+Three orchestrators that run the full review:
+
+- [`review-changes.md`](./review-changes.md) — review a diff (a branch, commit range, or
+  `HEAD~1`) by sequencing the focused passes. Use after every change set, especially fast/
+  "vibe-coded" work.
+- [`review-project.md`](./review-project.md) — audit the whole tree, independent of any diff.
+  Use periodically, before a release, or when onboarding to a module.
+- [`review-details.md`](./review-details.md) — an alternative driver that fans the review out
+  into **parallel subagent passes by Go concern** (mechanical, correctness, concurrency,
+  composition, security, API, tests) and then plans and applies fixes. Use when one driver
+  should take a change from review through to merged fixes.
+
+Eight focused passes, each runnable on its own when you only need one lens:
+
+- [`00-structure-placement.md`](./00-structure-placement.md) — module placement (root vs
+  sub-module vs nested adapter), acyclic layering (`depguard`), `doc.go` and go.work wiring.
+- [`01-canonical-reuse.md`](./01-canonical-reuse.md) — did the code reimplement a concern an
+  existing package (or the stdlib) already owns?
+- [`02-principles.md`](./02-principles.md) — typed/minimal APIs, errors & resilience,
+  concurrency, composition, currency, AI/model features.
+- [`03-security-privacy.md`](./03-security-privacy.md) — trust-boundary validation, injection
+  safety, token hygiene, crypto, data minimization.
+- [`04-quality.md`](./04-quality.md) — root-cause over patches, dead code, file/package
+  organization, maintainability, style gates.
+- [`05-tests-tdd.md`](./05-tests-tdd.md) — TDD, determinism under `-race -shuffle`, injected
+  clocks, env/cwd test discipline, fixtures.
+- [`06-docs-supply-chain.md`](./06-docs-supply-chain.md) — `doc.go`/godoc, Conventional
+  Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM/provenance.
+- [`07-comments-godoc.md`](./07-comments-godoc.md) — comments and godoc explain the code as it
+  is, not plans/history/process; rewrite or delete the rest. Runnable any time over the tree.
+
+The orchestrators sequence these passes and add scope handling; the focused files hold the
+actual checks. Read the focused file you need and run it directly when a full review is
+overkill.
+
+## Run reviews in a separate, clean-context agent
+
+Always dispatch a review to a **fresh reviewer agent with no shared session context** — never
+inline in the session that produced the code. A reviewer that "remembers" writing the change
+rationalizes it; an independent agent re-derives every judgment from the code and the
+principles. Hand the agent only the scope (diff or module/area), the relevant prompt, and this
+`reviews/` folder.
+
+A plan, spec, issue, or roadmap (e.g. an entry under `tmp/release-parity-plan/`) may be passed
+in *as a scope checklist only* — it defines intended scope ("verify the change did what it
+claimed, with tests") but never excuses a baseline violation. If the code diverges from the
+plan, report the divergence; the baseline in
+[`.github/copilot-instructions.md`](../../copilot-instructions.md) wins over any plan.
+
+## How to run any prompt
+
+1. **Pick scope.** Changes review: set a base ref and get the diff (`git diff <base>...HEAD
+   --stat`, then per file). Project review: pick the module(s)/domain or the whole tree.
+2. **Work passes in order** (00 → 07). Stop and reject as soon as a change fails pass `00` or
+   `01` — misplaced or duplicated code makes every later pass moot.
+3. **Run the validation commands** (below). Treat green `make check` as necessary but not
+   sufficient: it does not catch goroutine leaks, missing timeouts/cancellation, unbounded
+   channels, global-registry composition smells, duplicated owners, or boundary-validation
+   gaps. Those are on the reviewer.
+
+## Severity and finding format
+
+Record every finding as:
+
+```
+severity (blocker / should-fix / nit) — file:line — what's wrong — which principle — suggested fix
+```
+
+- **blocker** — violates a hard principle (upward/cyclic import, concern reimplemented,
+  `panic()`/`log.Fatal` on a runtime path, goroutine with no cancellation / unbounded channel,
+  package-global mutable registry / `init()` side effect, trust boundary not validated,
+  `interface{}`/`any` on a public surface, behavioral change with no test). Must be fixed
+  before merge.
+- **should-fix** — real defect or debt that is not a baseline violation (compat shim,
+  `time.Sleep` in a test, unguarded env/cwd test, inline config instead of a fixture,
+  reinvented stdlib facility, one large file that should be split by concern).
+- **nit** — minor/style, take-it-or-leave-it.
+
+## Validation commands
+
+**For a change set, scope every command to the changed module(s)** — the full-tree gates are
+slow across all modules and belong to a project audit or CI sign-off, not a per-change review:
+
+```bash
+make fmt                             # gofmt -s (or verify clean)
+make lint M=<module>                 # golangci-lint, scoped to the module
+make test M=<module> T=<pattern>     # scoped tests, -race -count=1
+make test-affected                   # only modules the diff touches
+make check-<domain>                  # per-domain gate: core|patterns|crosscutting|composition|
+                                     #   transport|auth|data|ai|media|infra
+```
+
+Cross-module operations use `./gomod.sh` (e.g. `./gomod.sh cmd "go test ./..." -m messaging`).
+
+**For a project audit or final sign-off**, run the full gates:
+
+```bash
+make build && make vet && make test  # full validation
+make check                           # canonical gate (build + vet + test)
+make test-coverage                   # coverage report / gate
+govulncheck ./...                    # vulnerability scan (per module via ./gomod.sh)
+```
+
+Treat green `make check` as necessary but **not sufficient** — it does not catch goroutine
+leaks, missing timeouts/cancellation, unbounded channels, global-registry composition smells,
+duplicated owners, or boundary-validation gaps. Those are on the reviewer.

--- a/.github/prompts/reviews/review-changes.md
+++ b/.github/prompts/reviews/review-changes.md
@@ -1,0 +1,95 @@
+# Review changes
+
+Standing, re-runnable review of a **change set** in this repository — a branch, a commit range,
+or `HEAD~1`. Use it after every change set, especially fast/"vibe-coded" work. It sequences the
+eight focused passes in [`reviews/`](./) over a diff and adds scope handling; the actual checks
+live in the focused files.
+
+## Run this in a separate, clean-context agent
+
+**Always dispatch this review to a fresh reviewer agent with no shared session context.** A
+reviewer that "remembers" writing the code rationalizes it; an independent agent re-derives
+every judgment from the diff and the principles. Do not run it inline in the same session that
+produced the change.
+
+- Hand the reviewer agent: the diff (or base ref), this file, and the [`reviews/`](./) folder.
+  Nothing else from the authoring session.
+- The reviewer reads the code as-is; it does not trust prior reasoning about why the code
+  "should" be correct.
+- **Optional plan check.** If a plan/spec exists (e.g. an entry under
+  `tmp/release-parity-plan/`, an issue, or a design doc), pass it in *as a scope checklist
+  only* — "here is what this change set claimed to do; verify the diff actually did it, with
+  tests." The plan defines intended scope; it never excuses a principle violation. If the diff
+  diverges from the plan, report the divergence; the baseline in
+  [`.github/copilot-instructions.md`](../../copilot-instructions.md) wins over any plan.
+
+## Pass 0 — Scope and context
+
+- Get the actual diff: `git diff <base>...HEAD --stat`, then per file. Review only what changed
+  plus its blast radius; do not audit the whole repo (that is
+  [`review-project.md`](./review-project.md)).
+- gokit is a foundation toolkit: a change to a core package's public surface fans out to every
+  sub-module, nested adapter, and downstream repo (rskit/pykit parity, consuming services).
+  List that blast radius before reviewing.
+- Note whether the change belongs in the **root module**, a **sub-module** (own `go.mod`), or a
+  **nested adapter** (e.g. `storage/s3`), and whether it belongs in *this* package at all.
+
+## Passes — run in order, stop early on a structural failure
+
+Work the focused files top to bottom. **Stop and reject as soon as a change fails pass `00` or
+`01`** — misplaced or duplicated code makes every later pass moot.
+
+1. [`00-structure-placement.md`](./00-structure-placement.md) — module/package placement,
+   acyclic layering, `doc.go` and go.work wiring.
+2. [`01-canonical-reuse.md`](./01-canonical-reuse.md) — reuse vs. reimplementation of a
+   package/stdlib-owned concern. *(blocker class)*
+3. [`02-principles.md`](./02-principles.md) — typed/minimal APIs, errors & resilience,
+   concurrency, composition, currency, AI features.
+4. [`03-security-privacy.md`](./03-security-privacy.md) — trust-boundary validation, injection
+   safety, token hygiene, crypto, data minimization.
+5. [`04-quality.md`](./04-quality.md) — root-cause over patches, dead code, file/package
+   organization, style gates.
+6. [`05-tests-tdd.md`](./05-tests-tdd.md) — TDD, `-race -shuffle` determinism, clock/env/cwd
+   discipline, fixtures.
+7. [`06-docs-supply-chain.md`](./06-docs-supply-chain.md) — `doc.go`/godoc, Conventional
+   Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM.
+8. [`07-comments-godoc.md`](./07-comments-godoc.md) — comments and godoc explain the code as it
+   is; rewrite or delete plan/history/process prose.
+
+Each focused file carries a "Changes mode" scope note — follow that mode here. When you only
+need one lens (e.g. just security, just TDD), run that focused file directly instead of this
+orchestrator.
+
+## Findings
+
+Record every finding as:
+
+```
+severity (blocker / should-fix / nit) — file:line — what's wrong — which principle — suggested fix
+```
+
+See [`README.md`](./README.md) for severity definitions.
+
+## Validation
+
+**Scope every command to the changed module(s) — do not run the full-tree gates here.** gokit
+has many modules; `make check` / `make test` / `make build` across the whole tree are slow and
+are reserved for [`review-project.md`](./review-project.md) or final pre-merge sign-off
+(typically in CI). For a change set, run only:
+
+```bash
+make fmt                             # gofmt -s clean
+make lint M=<module>                 # golangci-lint, scoped
+make test M=<module> T=<pattern>     # narrow further with a test pattern, -race -count=1
+make test-affected                   # only modules the diff touches
+make check-<domain>                  # per-domain gate if the change spans a domain
+```
+
+Use `./gomod.sh cmd "<command>" -m <module>` for a command in one module, or `govulncheck ./...`
+in the touched module if a dependency changed. Prefer `make test-affected` over the unscoped
+targets — it runs only the modules impacted by the current changes. Step up to a per-domain
+`make check-<domain>` when the change spans a domain. Run the full `make check` only when the
+change is genuinely tree-wide, or leave it to CI for sign-off. A green scoped run is necessary
+but **not sufficient** — it will not catch goroutine leaks, missing timeouts/cancellation,
+unbounded channels, global-registry composition smells, duplicated owners, or boundary-
+validation gaps. Those are on the reviewer.

--- a/.github/prompts/reviews/review-details.md
+++ b/.github/prompts/reviews/review-details.md
@@ -142,8 +142,9 @@ Check: behavioral code in scope has tests covering it (changes mode: in the same
 mode: anywhere in the tree); bug fixes have a regression test that fails without the fix; failure
 paths asserted, not just happy paths; tests **green under `-race -shuffle=on`** and depend on no
 wall clock, network, or working directory unless intentional (time uses an **injected clock**;
-env-var tests use `t.Setenv`; filesystem tests use `t.TempDir`); coverage meets the gates (≥80%
-per package, ≥85% overall, ≥85% for `errors`/`auth`/`authz`/`security`/`resilience`/`encryption`);
+env-var tests use `t.Setenv`; filesystem tests use `t.TempDir`); coverage meets the per-package
+floors (≥80% per package, ≥85% overall, ≥85% for `errors`/`auth`/`authz`/`security`/`resilience`/`encryption`,
+checked via `make test-coverage`; CI codecov enforces project 80% / patch 85%);
 parsers/validators/auth/codecs/schema carry `Fuzz` targets; fixtures over large inline config; an
 operation does what its name implies; every exported identifier has godoc that **matches
 implemented behavior**, each package has a `doc.go`, examples compile; comments describe the code

--- a/.github/prompts/reviews/review-details.md
+++ b/.github/prompts/reviews/review-details.md
@@ -1,0 +1,193 @@
+# Go Review — Plan, Clarify, Apply
+
+An alternative orchestrator to [`review-changes.md`](./review-changes.md) /
+[`review-project.md`](./review-project.md): instead of sequencing the 00–07 lenses, it fans the
+review out into **parallel subagent passes by Go concern**, then plans and applies fixes. Use it
+when you want one driver to take a change from review through to merged fixes.
+
+Run each pass as a **separate subagent with clean context**. The orchestrator (this file)
+sequences them and collects findings. Do not concatenate passes into one prompt.
+
+Mode is either **changes** (a diff: branch, commit range, `HEAD~1`) or **project** (whole tree,
+no diff). State the mode up front.
+
+> The focused 00–07 files hold the canonical, gokit-specific checks (placement, canonical-owner
+> reuse, security/privacy, supply chain, comments). This file is the *driver*; when a pass below
+> needs the full rule for a lens, defer to the matching focused file rather than duplicating it.
+
+---
+
+## Phase 1 — Scope
+
+1. `git status`, `git diff --stat`, `git diff` (changes mode) or `ls` the module tree +
+   dependency map (project mode). Preserve uncommitted changes; integrate on top, never discard.
+2. List the surface to review: changed modules/packages (changes mode) or chosen
+   modules/workspace (project mode). Note cross-cutting touches: a root-module package's public
+   surface fans out to every sub-module, every nested adapter, and downstream consumers
+   (rskit/pykit parity). Also flag `go.work` / `core.go.work` / `contrib.go.work` edits, shared
+   error types (`AppError`), public re-exports, `.golangci.yml`/`depguard` config.
+3. Determine which passes apply via the triggers below. Skip non-applicable passes explicitly in
+   the final report.
+
+The reviewer judges code as written, against the rules below and the baseline in
+[`.github/copilot-instructions.md`](../../copilot-instructions.md). PR descriptions, commit
+messages, or plan/ADR docs are scope hints only — never justifications.
+
+## Phase 2 — Passes
+
+Run **A first** (cheap, gates the rest). Then **B–F in parallel** where independent. Then **G
+last** (cross-references everything).
+
+Each subagent receives: its scope, the pass spec below, and nothing else. Scope `go`/`make` to
+the touched module(s) with `./gomod.sh cmd "<cmd>" -m <module>` or `make check-<domain>`; the
+unscoped workspace gates are slow across every module and belong to sign-off/CI.
+
+### Pass A — Mechanical (always runs)
+
+Tool output only, no judgment. Use gokit's real gates:
+
+```bash
+make fmt                                          # gofmt -s, whole tree (fast)
+make lint                                         # golangci-lint incl. vet + depguard (layering)
+make check-<domain>                               # fmt+vet+lint+test for the touched domain
+govulncheck ./...                                 # from the touched module, if deps/public in scope
+```
+
+Report pass/fail per command with the first failure block verbatim.
+
+### Pass B — Correctness
+
+**Scope:** all in-scope `.go` files.
+
+Check: `panic()` / `log.Fatal` / ignored errors (`_ = f()`) / unchecked type assertions
+(`x.(T)` without `, ok`) on fallible runtime paths (tests excepted); no success-shaped fallback
+that masks failure (zero value + `nil` error on real failure); error context preserved through
+`%w`/`errors.Is`/`As`/`Join` as gokit `AppError` with its typed code and cause intact; `MustXxx`
+only for compile-time-safe construction; resource cleanup on every return path including errors
+(`defer` for `Close`/`Unlock`); `context.Context` is the first parameter and propagated, never
+stored in a struct. *(Canonical owner: pass [`01`](./01-canonical-reuse.md).)*
+
+Skip if: scope is docs-only or config-only.
+
+### Pass C — Concurrency
+
+**Scope:** files with `go func`/`go <call>`, `sync`, `chan`, `context`, `errgroup`, or
+`atomic`.
+
+Check: every spawned goroutine has clear ownership, cancellation (context), timeout, and
+shutdown — a `go func()` with no stop path is a **blocker**; no `sync.Mutex`/`RWMutex` held
+across a blocking call or channel op; no data races (shared state guarded or goroutine-confined,
+verified under `-race`); structured concurrency via `errgroup`/`worker` over loose `go`;
+channels/queues/buffers are **bounded with documented backpressure** and components **drain
+in-flight work on shutdown** (an unbounded channel or a goroutine with no cancellation path is a
+**blocker**); context cancellation actually observed (`select` on `ctx.Done()`). Time-dependent
+paths are testable via an **injected clock**, not wall-clock `time.Sleep`.
+
+Skip if: no goroutine/channel/sync surface in scope.
+
+### Pass D — Composition and lifecycle
+
+**Scope:** registries, `Component` impls, `di`/`bootstrap` wiring, provider/adapter
+construction, anything wiring dependencies together.
+
+Check: registries and policies are **explicitly injected**, selection is config-driven; **no
+`init()` side effects, no mutable package-global registry**, no reaching for a global
+logger/tracer — inject them (a package-level `var registry`, or an `init()` that dials
+network / reads env / registers into a global, is a **blocker**); `Component` lifecycle
+(`Start`/`Stop`/`Health`) honored with registry ordering and drain-on-stop; adapters register
+via explicit `Register(registry)` and sit behind their own sub-module/package, not wired
+unconditionally into the core default. *(Placement: pass [`00`](./00-structure-placement.md);
+composition principle: pass [`02`](./02-principles.md).)*
+
+Skip if: no composition/lifecycle/registry surface in scope.
+
+### Pass E — Security, config, and boundaries
+
+**Scope:** external-facing surfaces (HTTP, process, storage/database/cache adapters, auth,
+crypto), config loaders, env-var handling, path handling, and docs describing config or env.
+
+Check: untrusted input validated at every trust boundary before flowing into a query, path,
+command, or deserialization (an unvalidated path is a **blocker**); parameterized queries only —
+never `fmt.Sprintf`-built SQL; argv-only subprocess via `process`, no `sh -c` interpolation of
+untrusted input; tokens/credentials in headers not query strings, never logged, redacted in
+errors; auth header-only, reject query-string tokens, JWT alg allow-list + reject `alg: none` +
+require `exp`/`iss`/`aud`; current crypto only (no MD5/SHA-1-for-security/ECB/static-IV/
+hard-coded key) routed through `encryption`/`security`; unbounded reads of untrusted input get
+explicit limits (`io.LimitReader`); path-shaped values use `filepath.Join` (never hardcoded
+separators) and `t.TempDir`/temp helpers over `/tmp/...`. *(Full rule: pass
+[`03`](./03-security-privacy.md).)*
+
+Skip if: no security-sensitive, config, env, or path code in scope.
+
+### Pass F — API surface and dependencies
+
+**Scope:** package public surfaces, `doc.go`, `go.mod`, anything changing exported items.
+
+Check: new exported items intentional (unexport what callers don't need — no stutter,
+`cache.New` not `cache.NewCache`); no `interface{}`/`any` escape hatch on a public surface
+except documented genuinely-opaque values; generics over `interface{}` for typed containers;
+`...Option` constructor shape; new deps justified (maintained, no open CVE, not duplicating an
+owning package or the stdlib — currency, pass [`01`](./01-canonical-reuse.md)); `go.mod`/`go.sum`
+tidy per affected module (`go mod tidy`); MSRV/`go` directive correct; a new module wired into
+`go.work` / `core.go.work` / `contrib.go.work`, `domains.toml`, and the matching
+`make check-<domain>`, with a `doc.go` package overview.
+
+Skip if: no public items, deps, or `go.mod` in scope.
+
+### Pass G — Tests, docs, semantics (runs last)
+
+**Scope:** the in-scope code plus findings from A–F.
+
+Check: behavioral code in scope has tests covering it (changes mode: in the same diff; project
+mode: anywhere in the tree); bug fixes have a regression test that fails without the fix; failure
+paths asserted, not just happy paths; tests **green under `-race -shuffle=on`** and depend on no
+wall clock, network, or working directory unless intentional (time uses an **injected clock**;
+env-var tests use `t.Setenv`; filesystem tests use `t.TempDir`); coverage meets the gates (≥80%
+per package, ≥85% overall, ≥85% for `errors`/`auth`/`authz`/`security`/`resilience`/`encryption`);
+parsers/validators/auth/codecs/schema carry `Fuzz` targets; fixtures over large inline config; an
+operation does what its name implies; every exported identifier has godoc that **matches
+implemented behavior**, each package has a `doc.go`, examples compile; comments describe the code
+as it is, not plans/history. *(Full rules: passes [`05`](./05-tests-tdd.md) and
+[`06`](./06-docs-supply-chain.md); comment hygiene: pass [`07`](./07-comments-godoc.md).)*
+
+Always runs.
+
+## Phase 3 — Consolidate
+
+Orchestrator collects findings into one table:
+
+```
+pass | severity (blocker/should-fix/nit) | file:line | finding | suggested fix
+```
+
+Severity rule: **blocker** = principle violation, behavior is wrong, or a contract is broken
+(see [`README.md`](./README.md) for the full definition). Otherwise should-fix or nit.
+
+Group by file in the final report. State explicitly any pass that was **skipped** (with the
+trigger that failed) and any pass that was **deferred** (with reason).
+
+## Phase 4 — Plan and clarify
+
+Group findings by pass, order by severity. For each group write a one-line fix plan: what
+changes, where, how it's verified. Flag ambiguities (behavior change vs strict fix, breaking API
+vs deprecation, doc-only vs behavior-aligning) with a proposed default and the alternative.
+**Pause for user confirmation before editing.**
+
+## Phase 5 — Apply
+
+After confirmation:
+
+1. Apply fixes in plan order, one pass per commit where reasonable (Conventional Commits:
+   `feat`/`fix`/`docs`/`refactor`/`test`/`chore`).
+2. Re-run the matching pass's validation after each fix, scoped to the touched module(s). Stop
+   and report if anything fails.
+3. Final step: re-run Pass A across the in-scope modules.
+
+## Reviewer notes
+
+- Code judges itself. External narrative (PR description, commit message, plan/ADR doc) is scope
+  only, not justification.
+- Detection commands (`rg`/`grep`, `go`, `make`) are loaded by the subagent when it searches, not
+  held in the resident prompt.
+- If scope is trivial (docs-only, single-line fix), run only A and G; skip the rest with explicit
+  reason.

--- a/.github/prompts/reviews/review-project.md
+++ b/.github/prompts/reviews/review-project.md
@@ -1,0 +1,99 @@
+# Review project
+
+Standing, re-runnable **whole-toolkit audit**, independent of any diff. Use it periodically,
+before a release, when onboarding to a module, or whenever you want assurance the tree as a
+whole still honors the baseline. It sequences the same eight focused passes in [`reviews/`](./)
+but over the existing code rather than a change set.
+
+## Run this in a separate, clean-context agent
+
+**Always dispatch this audit to a fresh agent with no shared session context.** The point of a
+full audit is an independent read of the code as it exists — not filtered through whatever a
+prior session believed about it. Do not run it inline in a session that has been editing the
+same code.
+
+- Hand the agent: the module(s)/domain to audit (or "the whole tree"), this file, and the
+  [`reviews/`](./) folder.
+- The agent judges the code as written, against the principles in
+  [`.github/copilot-instructions.md`](../../copilot-instructions.md) — not against any
+  session's recollection.
+- **Optional roadmap check.** If there is a roadmap or versioning plan (e.g. under
+  `tmp/release-parity-plan/`, `docs/VERSIONING.md`), pass it in *as context for intended state
+  only* — "here is where the toolkit is meant to be; flag where the tree has not caught up." It
+  frames expectations; it never excuses a baseline violation.
+
+## Scope first to keep the audit tractable
+
+The whole tree is large. Prefer auditing **one domain or module at a time** rather than
+everything at once:
+
+- a single package or domain (`errors`, `auth/`, the `data` domain),
+- a whole workspace (`core.go.work` vs `contrib.go.work` members), or
+- the full tree only when you have time for the slow gates.
+
+State the chosen surface up front so findings are bounded.
+
+## Pass 0 — Scope and context
+
+- Get a structural picture before diving in: list modules and their dependency edges, skim each
+  package tree.
+
+```bash
+ls -d */                                             # top-level modules/packages
+for m in */go.mod; do echo "== $m =="; grep -E '^\s+github.com/kbukum/gokit' "$m"; done
+```
+
+## Passes — run in order
+
+Work the focused files top to bottom; each carries a "Project mode" scope note describing how
+to sweep the tree for that lens.
+
+1. [`00-structure-placement.md`](./00-structure-placement.md) — module/package placement,
+   acyclic layering, `doc.go`/go.work wiring across the tree.
+2. [`01-canonical-reuse.md`](./01-canonical-reuse.md) — sweep for local forks of an owned
+   concern. *(blocker class)*
+3. [`02-principles.md`](./02-principles.md) — typed/minimal, errors & resilience, concurrency,
+   composition, currency, AI features across the full surface.
+4. [`03-security-privacy.md`](./03-security-privacy.md) — trust-boundary validation, injection
+   safety, token hygiene, crypto, data minimization.
+5. [`04-quality.md`](./04-quality.md) — root-cause over patches, dead code, file/package
+   organization, outdated patterns, style gates.
+6. [`05-tests-tdd.md`](./05-tests-tdd.md) — coverage of behavior and failure paths,
+   determinism, clock/env/cwd discipline, fixtures.
+7. [`06-docs-supply-chain.md`](./06-docs-supply-chain.md) — `doc.go`/godoc, Conventional
+   Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM/provenance.
+8. [`07-comments-godoc.md`](./07-comments-godoc.md) — sweep all source prose: comments and
+   godoc describe the current code, not plans/history; rewrite or delete the rest.
+
+When you only need one lens across the project (e.g. a standalone security or TDD sweep), run
+that focused file directly with its "Project mode" note.
+
+## Findings
+
+Record every finding as:
+
+```
+severity (blocker / should-fix / nit) — file:line — what's wrong — which principle — suggested fix
+```
+
+Group findings by module and by pass so the report is actionable. See [`README.md`](./README.md)
+for severity definitions.
+
+## Validation
+
+A full audit is the place for the slow, complete gates:
+
+```bash
+make fmt
+make lint                 # whole-tree golangci-lint (or M=<module>)
+make build
+make vet
+make test                 # -race -count=1
+make test-coverage        # coverage gate
+make check                # full canonical gate
+govulncheck ./...         # per module via ./gomod.sh cmd "govulncheck ./..."
+```
+
+A green `make check` is necessary but **not sufficient** — goroutine leaks, missing timeouts/
+cancellation, unbounded channels, global-registry composition smells, duplicated owners, and
+boundary-validation gaps are on the reviewer, not the gate.

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ docs/testutil*.md
 .env
 
 # Temporary / planning files
-.tmp/
+tmp/

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/agent
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/ai/go.mod
+++ b/ai/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/ai
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/auth
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/authz/go.mod
+++ b/authz/go.mod
@@ -2,4 +2,4 @@ module github.com/kbukum/gokit/authz
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/bench
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/bench/storage/go.mod
+++ b/bench/storage/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/bench/storage
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit/bench v0.0.0

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/cache
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require github.com/kbukum/gokit v0.2.0
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/cache/redis
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/connect
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/connect/testutil/go.mod
+++ b/connect/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/connect/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/dag/testutil/go.mod
+++ b/dag/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/dag/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/database/go.mod
+++ b/database/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/database
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/database/sqlite/go.mod
+++ b/database/sqlite/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/database/sqlite
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/database/testutil/go.mod
+++ b/database/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/database/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/discovery/go.mod
+++ b/discovery/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/discovery
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/discovery/testutil/go.mod
+++ b/discovery/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/discovery/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/embedding/go.mod
+++ b/embedding/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/embedding
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/git/go.mod
+++ b/git/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/git
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/go-git/go-git/v5 v5.19.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/go-playground/validator/v10 v10.30.3

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.5
 
 use (
 	.

--- a/grpc/go.mod
+++ b/grpc/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/grpc
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/httpclient/go.mod
+++ b/httpclient/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/httpclient
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require github.com/kbukum/gokit v0.2.0
 

--- a/inference/go.mod
+++ b/inference/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/inference
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/inference/tgi/go.mod
+++ b/inference/tgi/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/inference/tgi
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/inference/triton/go.mod
+++ b/inference/triton/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/inference/triton
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/inference/vllm/go.mod
+++ b/inference/vllm/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/inference/vllm
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/llm/go.mod
+++ b/llm/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/llm
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/llm/providers/go.mod
+++ b/llm/providers/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/llm/providers
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/mcp
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/messaging/go.mod
+++ b/messaging/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/messaging
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/messaging/kafka/go.mod
+++ b/messaging/kafka/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/messaging/kafka
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/messaging/nats/go.mod
+++ b/messaging/nats/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/messaging/nats
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/messaging/rabbitmq/go.mod
+++ b/messaging/rabbitmq/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/messaging/rabbitmq
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/schema
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require github.com/invopop/jsonschema v0.14.0
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/server
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/MarceloPetrucio/go-scalar-api-reference v0.0.0-20240521013641-ce5d2efe0e06

--- a/server/testutil/go.mod
+++ b/server/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/server/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/skill/go.mod
+++ b/skill/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/skill
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/stateful/go.mod
+++ b/stateful/go.mod
@@ -2,4 +2,4 @@ module github.com/kbukum/gokit/stateful
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/storage
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require github.com/kbukum/gokit v0.2.0
 

--- a/storage/s3/go.mod
+++ b/storage/s3/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/storage/s3
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/storage/testutil/go.mod
+++ b/storage/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/storage/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/testutil/go.mod
+++ b/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require github.com/kbukum/gokit v0.2.0
 

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/tool
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0

--- a/vectorstore/go.mod
+++ b/vectorstore/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/vectorstore
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 replace github.com/kbukum/gokit => ../
 

--- a/workload/go.mod
+++ b/workload/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/workload
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/workload/testutil/go.mod
+++ b/workload/testutil/go.mod
@@ -2,7 +2,7 @@ module github.com/kbukum/gokit/workload/testutil
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/kbukum/gokit v0.2.0


### PR DESCRIPTION
## Description

Two grouped changes toward gokit release readiness:

1. **Security fix** — clears the failing `govulncheck` CI job (all four findings are Go standard-library vulns reachable via `net/http`).
2. **Docs** — adds a gokit review-prompt system mirroring rskit, engineering principles in copilot-instructions, and an upgraded PR template.

## Motivation

`govulncheck` was failing in CI ([run 29168726995](https://github.com/kbukum/gokit/actions/runs/29168726995/job/86586280486)) for every `net/http` module because the pinned `toolchain go1.26.3` (and `go.work` on `go1.26.2`) predates the stdlib fixes. Separately, gokit lacked rskit's structured review lenses and durable engineering principles needed to drive the parity/release work.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Module(s) Affected

- All modules (`toolchain` directive bump in every `go.mod` + `go.work`)
- `.github/` (review prompts, copilot-instructions, PR template)

## Changes Made

- Bump `toolchain` → `go1.26.5` across 45 `go.mod` files + `go.work` (language directive `go 1.26.0` unchanged), resolving GO-2026-5040 (crypto/tls), GO-2026-5039 (net/textproto), GO-2026-5037 (crypto/x509), GO-2026-4971 (net).
- Add `.github/prompts/reviews/` — README, three orchestrators (changes/project/details), and eight focused passes (00-structure … 07-comments-godoc), adapted from rskit to Go tooling and layering.
- Expand `.github/copilot-instructions.md` with engineering principles and readability/file-organization rules.
- Upgrade `.github/PULL_REQUEST_TEMPLATE.md` to match rskit (sibling parity, CI-gate-aligned testing, quality checklist).
- Ignore `tmp/` planning artifacts.

## Testing

- [x] `govulncheck ./...` passes for the affected module(s)
- [ ] `make test` — no code behavior changed (docs + toolchain only)
- [x] `make lint` clean (unchanged Go source)
- [x] `make fmt` reports no diffs

### Test Evidence

```
$ cd connect && govulncheck ./...
No vulnerabilities found. Your code is affected by 0 vulnerabilities.
# same for root (.) and database modules
```

## Breaking Changes

None. Toolchain patch bump only; no API or behavior changes.

## Sibling Parity

- [x] Sibling-parity not required (toolchain + repo docs; no public abstraction changed)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [ ] Behavior was developed test-first — n/a (no behavior change)
- [ ] Bug fixes include a regression test — n/a (stdlib toolchain bump; covered by CI govulncheck)
- [x] No public `interface{}`/`any` introduced
- [x] Dependencies injected — no globals or `init()` side effects introduced
- [x] Code split by concern into focused files (review prompts are one file per pass)
- [x] `make tidy` clean for affected modules
- [ ] CHANGELOG entry under `[Unreleased]` — see note below
- [x] New dependencies: none

## Additional Notes

- The `tmp/release-parity-plan/` grouped implementation plan (incl. `TDD-WORKFLOW.md`) is intentionally **not** committed — `tmp/` is gitignored as local planning material.
- No CHANGELOG entry added since there is no user-facing library change (toolchain metadata + repo tooling only); happy to add one if preferred.
