### PR TITLE
feat(toven): onboard gokit with initial Go ecosystem task config

### DIFF
--- a/toven.toml
+++ b/toven.toml
@@ -1,0 +1,70 @@
+[project]
+name = "gokit"
+root = "."
+base_ref = "origin/main"
+
+# Smart defaults fill in tasks, run strategy, and toolchain probes.
+# Uncomment to override, e.g.:
+#   run_strategy = "leaf-to-top"
+[ecosystems.go]
+modules = "auto"
+
+[ecosystems.go.tasks.build]
+argv = ["go", "-C", "{module.root}", "build", "{args}", "{module.selector}"]
+fan_out = "per-module"
+selector = ["./..."]
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.check]
+argv = ["go", "-C", "{module.root}", "vet", "{args}", "{module.selector}"]
+fan_out = "per-module"
+selector = ["./..."]
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.format]
+argv = ["gofmt", "-w", "{args}", "{workspace.root}"]
+cacheable = false
+fan_out = "whole-workspace"
+kind = "format"
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.format-check]
+argv = ["gofmt", "-l", "{args}", "{workspace.root}"]
+fan_out = "whole-workspace"
+kind = "format"
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.lint]
+argv = ["golangci-lint", "run", "--allow-parallel-runners", "{args}", "{module.selector}"]
+fan_out = "per-module"
+selector = ["{module.root}/..."]
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.run]
+argv = ["go", "-C", "{module.root}", "run", ".", "{args}"]
+fan_out = "per-module"
+persistent = true
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.test]
+argv = ["go", "-C", "{module.root}", "test", "{args}", "{module.selector}"]
+fan_out = "per-module"
+selector = ["./..."]
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.tidy]
+argv = ["go", "-C", "{module.root}", "mod", "tidy", "-diff", "{args}"]
+fan_out = "per-module"
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.tidy-fix]
+argv = ["go", "-C", "{module.root}", "mod", "tidy", "{args}"]
+cacheable = false
+fan_out = "per-module"
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]
+
+[ecosystems.go.tasks.vuln]
+argv = ["govulncheck", "-C", "{module.root}", "{args}", "{module.selector}"]
+fan_out = "per-module"
+selector = ["./..."]
+shared_inputs = ["go.sum", "go.work", "go.work.sum"]


### PR DESCRIPTION
## Description

Adds an initial Toven configuration (`toven.toml`) to gokit, onboarding the Go multi-module workspace to Toven's discover → plan → execute task runner.

## Motivation

gokit had no Toven config. This wires up the standard Go task catalog (build, check, format, lint, run, test, tidy, and vulnerability scanning) so gokit gets the same reviewable, dependency-ordered task execution as the sibling kits.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Module(s) Affected

- None (adds workspace `toven.toml` configuration only)

## Changes Made

- Add `toven.toml` defining per-module Go tasks (build/check/format/lint/run/test/tidy).
- Add a `vuln` task running `govulncheck` per module (order-independent).

## Testing

- [x] Manual testing performed — `toven run vuln` fans out per module and surfaces the known GO-2026-5676 advisory; other tasks (build, format) schedule and cache as expected.

## Breaking Changes

None — additive config only.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Additional Notes

Configuration-only change; no Go source touched.
