### PR TITLE
feat(skill): harden skill pack loader and reuse fs path safety

### DIFF
--- a/.github/prompts/reviews/01-canonical-reuse.md
+++ b/.github/prompts/reviews/01-canonical-reuse.md
@@ -22,47 +22,72 @@ validation, process, di**. If the owner is inadequate, enhance it *generically* 
 forking a copy in another package. gokit must stay foundational and multi-purpose: a fix
 belongs in the owner so every consumer benefits.
 
-## How to check, not just glance
+## How to check — build the owner map, then reconcile
 
-For each candidate, name the concern, locate its owning package, and confirm the change calls
-the owner rather than rewriting it:
+Do not eyeball it and do not rely on a fixed concern list — that is how a fork slips through.
+Work it as a method, in order:
 
-- **Errors.** gokit `AppError` (RFC 9457) with typed error codes and wrapped cause via `%w`.
-  A fresh `errors.New`/`fmt.Errorf` sentinel for a shared concern, or a bespoke error struct
-  duplicating `AppError`, is duplication. Use `errors.Is/As/Join`.
-- **Resilience.** Retries / timeouts / circuit-breaking come from `resilience`, not hand-rolled
-  loops or ad-hoc `context.WithTimeout` scattering with bespoke backoff.
-- **Config / logging / di / observability.** Route through the owning package; no parallel
-  re-implementation, no second logger/tracer setup. Logging is `log/slog`-based via `logger`,
-  not a fresh `log` or `fmt.Print`.
-- **HTTP / transport.** Reuse `httpclient` / `server`; a raw `http.Client{}` with bespoke
-  retry/timeout in an adapter is duplication.
-- **Subprocess.** Execution goes through `process` (argv-only), not a bare `exec.Command`.
-- **Currency (part of reuse).** Before adding a dependency or helper, verify the stdlib does
-  not already cover it (`slices`, `maps`, `cmp`, `errors.Join`, `sync.OnceValue`), the
-  dependency is maintained, and no open CVE applies. Reinventing a std facility is a should-fix.
-- **"Almost the same" counts.** A near-copy with one tweaked line is still a fork — enhance the
-  owner to cover the new case.
-
-## Detection starters
-
-These flag candidates, not verdicts — read each hit, then name the owner that should have been
-used.
+**1. Build the owner map.** Every gokit module is a potential owner. Establish what this module
+*could* reuse before judging what it *does*:
 
 ```bash
-grep -rn --include=*.go 'errors.New(\|fmt.Errorf(' . | grep -v _test.go   # vs AppError for shared concerns
-grep -rn --include=*.go 'exec.Command' . | grep -v _test.go               # should route through process
-grep -rn --include=*.go 'http.Client{\|&http.Client' . | grep -v _test.go # should reuse httpclient
-grep -rn --include=*.go 'time.After\|context.WithTimeout\|backoff\|retry' . | grep -v _test.go  # resilience owner
-grep -rn --include=*.go 'log.Print\|fmt.Print\|"log"' . | grep -v _test.go # should use logger (slog)
+ls -d */ | tr -d /                                       # all gokit modules = the candidate owner set
+grep -E '^\s+github.com/kbukum/gokit' <module>/go.mod    # owners it already imports (reuse adds no new edge)
 ```
 
-For each hit: is there a package owner for this concern? If yes and the code does not use it →
-**blocker** (reuse). If no owner exists and it is a genuinely foundational concern → it should
-be **added to the owning package** (or a new one), not solved locally; a local solution is a
-**should-fix** with an "upstream to the owner" note.
+**2. Scan the module for every low-level operation and reconcile each against that map.** The
+class most often missed is a **drop to the standard library for a capability a gokit module
+already wraps** (safe file/path handling, subprocess, HTTP, atomic writes) — not just a
+reimplemented named concern. Sweep the in-scope code, not the tree:
+
+```bash
+grep -rnE 'os\.|filepath\.|ioutil\.|exec\.Command|net/http|http\.Client|sort\.Slice|"sort"|errors\.New\(|fmt\.Errorf\(|log\.Print|fmt\.Print|time\.After|context\.WithTimeout' <module> --include=*.go | grep -v _test.go
+```
+
+For each hit and each new local helper, name the concern, find its owner in the map, and decide:
+
+- **Filesystem / paths / file IO** → `fs` (path confinement, symlink-escape rejection, atomic
+  writes, permissions) and `util` (copy, ensure-dir, read/write helpers). Raw
+  `os.Open`+`filepath.EvalSymlinks`+`Rel` escape checks, `os.WriteFile` where atomicity matters,
+  or a hand-rolled dir walk are candidate forks — reconcile against `fs`/`util`.
+- **Errors** → `errors` (`AppError`, RFC 9457, typed codes, cause via `%w`, `errors.Is/As/Join`).
+  A fresh sentinel or bespoke error struct for a shared concern is a fork.
+- **Resilience** → `resilience` (retry / timeout / circuit-break), not hand-rolled loops or
+  scattered `context.WithTimeout` + bespoke backoff.
+- **HTTP** → `httpclient` / `server`, not a raw `http.Client{}` with bespoke retry/timeout.
+- **Subprocess** → `process` (argv-only), not a bare `exec.Command`.
+- **Config / logging / di / observability** → the owning package; logging is `log/slog` via
+  `logger`, never a fresh `log` or `fmt.Print`.
+- **Collections / time / crypto / codec** → a modern stdlib primitive first (`slices`, `maps`,
+  `cmp`, `errors.Join`, `sync.OnceValue`, `slices.SortFunc` over `sort.Slice`) or the gokit owner
+  (`util` clock/slice helpers, `encryption`/`security`, `codec`/`schema`). Reinventing either is a
+  fork.
+
+The list above is illustrative, not exhaustive: the rule is *any* module, so if a hit maps to a
+gokit owner not named here, it still counts.
+
+**3. Judge each candidate — reuse, enhance, add, or justify:**
+
+- Owner covers it → **reuse**: delete the fork, call the owner. *(blocker)*
+- Owner is close but inadequate → **enhance it generically** so every consumer benefits, then
+  reuse — never fork a tweaked copy. "Almost the same" (a near-copy with one changed line, or a
+  copied comment) is still a fork.
+- No owner and the capability is genuinely foundational and generally useful → **add it to the
+  owning module (or a new one)**, not locally — a local solution is a **should-fix** with an
+  "upstream to the owner" note.
+- Deliberately stricter/narrower policy that must not be shared → **justified local**: state why,
+  and flag it as a candidate to promote into the owner.
+
+An owner that **nothing imports yet** is a strong signal its intended consumers are running local
+forks — check it explicitly:
+
+```bash
+grep -rln 'kbukum/gokit/<owner>' --include=*.go . | grep -v _test.go | grep -v '^./<owner>/'
+```
 
 ## Output for this pass
 
-Per finding, name the concrete package/type that should have been used (e.g. "use `resilience`
-retry policy instead of a hand-rolled loop", "wrap with `process` rather than `exec.Command`").
+Per finding, name the concrete package/symbol that should have been used (e.g. "use
+`fs.ConfineExistingPath` instead of the local `ensureUnderRoot`", "use `resilience` retry policy
+instead of a hand-rolled loop", "wrap with `process` rather than `exec.Command`") and its outcome
+(reuse / enhance / add / justified-local).

--- a/fs/read.go
+++ b/fs/read.go
@@ -1,0 +1,58 @@
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	apperrors "github.com/kbukum/gokit/errors"
+)
+
+// Sentinel errors returned by the bounded reader for classifiable, policy-level
+// rejections. They are plain sentinels (not AppError) so callers can match with
+// errors.Is; raw IO failures (missing path, permission) return typed AppError.
+var (
+	// ErrFileTooLarge means a bounded read reached its byte limit.
+	ErrFileTooLarge = errors.New("file exceeds size limit")
+	// ErrNotRegularFile means the target is not a regular file.
+	ErrNotRegularFile = errors.New("path is not a regular file")
+)
+
+// ReadFileLimit reads at most maxBytes from a regular file, failing closed once
+// the limit is exceeded so a caller never buffers an unbounded file. It resolves
+// symlinks like [os.Open]; callers that must reject symlinks verify the path
+// first. A non-regular target yields [ErrNotRegularFile], an oversized file
+// yields [ErrFileTooLarge], and other IO failures return a typed AppError.
+func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		code, status := osErrorCode(err)
+		return nil, apperrors.New(code,
+			fmt.Sprintf("failed to open '%s': %v", path, err), status).WithCause(err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, apperrors.New(apperrors.ErrCodeInternal,
+			fmt.Sprintf("failed to inspect '%s': %v", path, err),
+			http.StatusInternalServerError).WithCause(err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s", ErrNotRegularFile, path)
+	}
+	if info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: %s (limit %d bytes)", ErrFileTooLarge, path, maxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, apperrors.New(apperrors.ErrCodeInternal,
+			fmt.Sprintf("failed to read '%s': %v", path, err),
+			http.StatusInternalServerError).WithCause(err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: %s (limit %d bytes)", ErrFileTooLarge, path, maxBytes)
+	}
+	return data, nil
+}

--- a/fs/read.go
+++ b/fs/read.go
@@ -22,11 +22,16 @@ var (
 )
 
 // ReadFileLimit reads at most maxBytes from a regular file, failing closed once
-// the limit is exceeded so a caller never buffers an unbounded file. It resolves
+// the limit is exceeded so a caller never buffers an unbounded file. A negative
+// maxBytes is rejected with an InvalidInput [apperrors.AppError]. It resolves
 // symlinks like [os.Open]; callers that must reject symlinks verify the path
 // first. A non-regular target yields [ErrNotRegularFile], an oversized file
 // yields [ErrFileTooLarge], and other IO failures return a typed AppError.
 func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
+	if maxBytes < 0 {
+		return nil, apperrors.InvalidInput("maxBytes",
+			fmt.Sprintf("maxBytes must be non-negative, got %d", maxBytes))
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		code, status := osErrorCode(err)

--- a/fs/read.go
+++ b/fs/read.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 
@@ -45,7 +46,13 @@ func ReadFileLimit(path string, maxBytes int64) ([]byte, error) {
 	if info.Size() > maxBytes {
 		return nil, fmt.Errorf("%w: %s (limit %d bytes)", ErrFileTooLarge, path, maxBytes)
 	}
-	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	// Read one byte past the limit to detect a file that grew after Stat,
+	// guarding against overflow when maxBytes is at its maximum.
+	probe := maxBytes
+	if probe < math.MaxInt64 {
+		probe++
+	}
+	data, err := io.ReadAll(io.LimitReader(f, probe))
 	if err != nil {
 		return nil, apperrors.New(apperrors.ErrCodeInternal,
 			fmt.Sprintf("failed to read '%s': %v", path, err),

--- a/fs/read_test.go
+++ b/fs/read_test.go
@@ -2,6 +2,7 @@ package fs_test
 
 import (
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,5 +46,20 @@ func TestReadFileLimitRejectsDirectory(t *testing.T) {
 func TestReadFileLimitMissingFile(t *testing.T) {
 	if _, err := fs.ReadFileLimit(filepath.Join(t.TempDir(), "missing"), 16); err == nil {
 		t.Fatal("expected error for a missing file")
+	}
+}
+
+func TestReadFileLimitMaxInt64DoesNotOverflow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := fs.ReadFileLimit(path, math.MaxInt64)
+	if err != nil {
+		t.Fatalf("max limit should read normally: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("data=%q", data)
 	}
 }

--- a/fs/read_test.go
+++ b/fs/read_test.go
@@ -1,0 +1,49 @@
+package fs_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/fs"
+)
+
+func TestReadFileLimitReadsWithinBound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := fs.ReadFileLimit(path, 16)
+	if err != nil {
+		t.Fatalf("read within bound: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("data=%q", data)
+	}
+}
+
+func TestReadFileLimitRejectsOversized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.txt")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 32)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fs.ReadFileLimit(path, 8); !errors.Is(err, fs.ErrFileTooLarge) {
+		t.Fatalf("want ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestReadFileLimitRejectsDirectory(t *testing.T) {
+	if _, err := fs.ReadFileLimit(t.TempDir(), 16); !errors.Is(err, fs.ErrNotRegularFile) {
+		t.Fatalf("want ErrNotRegularFile, got %v", err)
+	}
+}
+
+func TestReadFileLimitMissingFile(t *testing.T) {
+	if _, err := fs.ReadFileLimit(filepath.Join(t.TempDir(), "missing"), 16); err == nil {
+		t.Fatal("expected error for a missing file")
+	}
+}

--- a/fs/read_test.go
+++ b/fs/read_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	apperrors "github.com/kbukum/gokit/errors"
 	"github.com/kbukum/gokit/fs"
 )
 
@@ -46,6 +47,25 @@ func TestReadFileLimitRejectsDirectory(t *testing.T) {
 func TestReadFileLimitMissingFile(t *testing.T) {
 	if _, err := fs.ReadFileLimit(filepath.Join(t.TempDir(), "missing"), 16); err == nil {
 		t.Fatal("expected error for a missing file")
+	}
+}
+
+func TestReadFileLimitRejectsNegativeLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := fs.ReadFileLimit(path, -1)
+	if err == nil {
+		t.Fatal("expected error for negative maxBytes")
+	}
+	if errors.Is(err, fs.ErrFileTooLarge) {
+		t.Fatalf("negative maxBytes must not masquerade as ErrFileTooLarge: %v", err)
+	}
+	appErr, ok := apperrors.AsAppError(err)
+	if !ok || appErr.Code != apperrors.ErrCodeInvalidInput {
+		t.Fatalf("want InvalidInput AppError, got %v", err)
 	}
 }
 

--- a/skill/activation.go
+++ b/skill/activation.go
@@ -1,6 +1,35 @@
 package skill
 
-import "github.com/kbukum/gokit/tool"
+import (
+	"fmt"
+
+	"github.com/kbukum/gokit/tool"
+)
+
+// Activate composes the effective safety and per-tool envelopes for a skill
+// into an ActivationDecision. The skill is Allowed only when every referenced
+// tool resolves to a present envelope whose required scopes survive
+// intersection with the principal grants and operator ceiling; otherwise the
+// decision fails closed and Reason names the first blocking tool.
+func Activate(m Manifest, principalGrants, operatorCeiling []string, toolEnvelopes map[string]tool.Envelope) ActivationDecision {
+	tools := EffectiveEnvelope(m, principalGrants, operatorCeiling, toolEnvelopes)
+	decision := ActivationDecision{
+		SkillName: m.Name,
+		Allowed:   true,
+		EffectiveSafety: EffectiveSafety(m, func(name string) tool.Safety {
+			return toolEnvelopes[name].Safety
+		}),
+		Tools: tools,
+	}
+	for i := range tools {
+		if !tools[i].Allowed {
+			decision.Allowed = false
+			decision.Reason = fmt.Sprintf("tool %q: %s", tools[i].Name, tools[i].Reason)
+			break
+		}
+	}
+	return decision
+}
 
 func EffectiveSafety(m Manifest, lookup func(toolName string) tool.Safety) tool.Safety {
 	maxSafety := toToolSafety(m.Safety)

--- a/skill/activation.go
+++ b/skill/activation.go
@@ -17,7 +17,14 @@ func Activate(m Manifest, principalGrants, operatorCeiling []string, toolEnvelop
 		SkillName: m.Name,
 		Allowed:   true,
 		EffectiveSafety: EffectiveSafety(m, func(name string) tool.Safety {
-			return toolEnvelopes[name].Safety
+			env, ok := toolEnvelopes[name]
+			if !ok {
+				// A missing envelope means the referenced tool is unknown;
+				// report it as maximally unsafe so EffectiveSafety never
+				// under-reports on a denied decision.
+				return tool.SafetyDestructive
+			}
+			return env.Safety
 		}),
 		Tools: tools,
 	}

--- a/skill/activation_test.go
+++ b/skill/activation_test.go
@@ -60,6 +60,9 @@ func TestActivateDeniedWhenEnvelopeMissing(t *testing.T) {
 	if got.Allowed {
 		t.Fatal("expected denied for missing tool envelope")
 	}
+	if got.EffectiveSafety != tool.SafetyDestructive {
+		t.Fatalf("effective safety=%s, want destructive for missing envelope", got.EffectiveSafety)
+	}
 }
 
 func TestEffectiveSafetyMutatingManifest(t *testing.T) {

--- a/skill/activation_test.go
+++ b/skill/activation_test.go
@@ -1,0 +1,73 @@
+package skill_test
+
+import (
+	"testing"
+
+	"github.com/kbukum/gokit/skill"
+	"github.com/kbukum/gokit/tool"
+)
+
+func TestActivateAllowedWhenScopesGranted(t *testing.T) {
+	m := skill.Manifest{
+		Name:       "demo",
+		Safety:     skill.SafetyReadOnly,
+		References: skill.References{Tools: []string{"read", "delete"}},
+	}
+	envs := map[string]tool.Envelope{
+		"read":   {Scopes: []string{"db:read"}, Safety: tool.SafetyReadOnly},
+		"delete": {Scopes: []string{"db:delete"}, Safety: tool.SafetyDestructive},
+	}
+	grants := []string{"db:read", "db:delete"}
+	ceiling := []string{"db:read", "db:delete"}
+
+	got := skill.Activate(m, grants, ceiling, envs)
+	if got.SkillName != "demo" {
+		t.Fatalf("skill name=%q", got.SkillName)
+	}
+	if !got.Allowed {
+		t.Fatalf("expected allowed, reason=%q", got.Reason)
+	}
+	if got.EffectiveSafety != tool.SafetyDestructive {
+		t.Fatalf("effective safety=%s", got.EffectiveSafety)
+	}
+	if len(got.Tools) != 2 || !got.Tools[0].Allowed || !got.Tools[1].Allowed {
+		t.Fatalf("tools=%+v", got.Tools)
+	}
+}
+
+func TestActivateDeniedWhenScopeMissing(t *testing.T) {
+	m := skill.Manifest{
+		Name:       "demo",
+		References: skill.References{Tools: []string{"read", "delete"}},
+	}
+	envs := map[string]tool.Envelope{
+		"read":   {Scopes: []string{"db:read"}},
+		"delete": {Scopes: []string{"db:delete"}},
+	}
+	// Principal lacks db:delete, so the delete tool cannot activate.
+	got := skill.Activate(m, []string{"db:read"}, []string{"db:read", "db:delete"}, envs)
+	if got.Allowed {
+		t.Fatalf("expected denied when a referenced tool loses a scope")
+	}
+	if got.Reason == "" {
+		t.Fatal("expected a denial reason")
+	}
+}
+
+func TestActivateDeniedWhenEnvelopeMissing(t *testing.T) {
+	m := skill.Manifest{Name: "demo", References: skill.References{Tools: []string{"ghost"}}}
+	got := skill.Activate(m, nil, nil, map[string]tool.Envelope{})
+	if got.Allowed {
+		t.Fatal("expected denied for missing tool envelope")
+	}
+}
+
+func TestEffectiveSafetyMutatingManifest(t *testing.T) {
+	// A mutating manifest floor holds even when every referenced tool is
+	// read-only, exercising the SafetyMutating mapping.
+	m := skill.Manifest{Safety: skill.SafetyMutating, References: skill.References{Tools: []string{"read"}}}
+	got := skill.EffectiveSafety(m, func(string) tool.Safety { return tool.SafetyReadOnly })
+	if got != tool.SafetyMutating {
+		t.Fatalf("effective safety=%s, want mutating", got)
+	}
+}

--- a/skill/errors.go
+++ b/skill/errors.go
@@ -1,0 +1,26 @@
+package skill
+
+import "errors"
+
+// Sentinel errors for skill manifest, loading, verification, and registry
+// failures. Callers match with errors.Is; every returned error wraps one of
+// these so untrusted-input failures are classifiable and fail closed.
+var (
+	// ErrManifestInvalid marks a manifest that failed schema validation.
+	ErrManifestInvalid = errors.New("skill: invalid manifest")
+	// ErrParseManifest marks a manifest that could not be decoded.
+	ErrParseManifest = errors.New("skill: manifest parse failed")
+	// ErrFileTooLarge marks a pack file that exceeds its size limit.
+	ErrFileTooLarge = errors.New("skill: file exceeds size limit")
+	// ErrAssetsTooLarge marks a pack whose aggregate assets exceed the limit.
+	ErrAssetsTooLarge = errors.New("skill: assets exceed total size limit")
+	// ErrInvalidUTF8 marks a text pack file that is not valid UTF-8.
+	ErrInvalidUTF8 = errors.New("skill: file is not valid UTF-8")
+	// ErrInvalidPackFile marks a pack path that is not an accepted regular
+	// file or directory (symlink, escaping path, wrong type).
+	ErrInvalidPackFile = errors.New("skill: invalid pack file")
+	// ErrVerificationDenied marks a manifest rejected by the verifier.
+	ErrVerificationDenied = errors.New("skill: verification denied")
+	// ErrAlreadyRegistered marks a duplicate registration.
+	ErrAlreadyRegistered = errors.New("skill: already registered")
+)

--- a/skill/errors.go
+++ b/skill/errors.go
@@ -2,9 +2,11 @@ package skill
 
 import "errors"
 
-// Sentinel errors for skill manifest, loading, verification, and registry
-// failures. Callers match with errors.Is; every returned error wraps one of
-// these so untrusted-input failures are classifiable and fail closed.
+// Sentinel errors for classifiable skill manifest, loading, verification, and
+// registry failures. Policy rejections (invalid manifest, parse/size/UTF-8/path
+// violations, verification denial, duplicate registration) wrap one of these so
+// callers can match with errors.Is; low-level IO failures (missing or unreadable
+// files) are returned as-is.
 var (
 	// ErrManifestInvalid marks a manifest that failed schema validation.
 	ErrManifestInvalid = errors.New("skill: invalid manifest")

--- a/skill/fuzz_test.go
+++ b/skill/fuzz_test.go
@@ -1,0 +1,63 @@
+package skill_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kbukum/gokit/skill"
+	"github.com/kbukum/gokit/util"
+)
+
+// FuzzParseManifest exercises the manifest decoder and validator against
+// arbitrary bytes. Parsing must never panic and must fail closed: any returned
+// manifest must pass validation.
+func FuzzParseManifest(f *testing.F) {
+	f.Add([]byte(manifest))
+	f.Add([]byte("name: [bad"))
+	f.Add([]byte(""))
+	f.Add([]byte("schema_version: \"1\"\nname: x\nversion: 0.1.0\ndescription: d\nreferences: {}\n"))
+	f.Add([]byte("safety: destructive\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		m, err := skill.ParseManifest(data)
+		if err != nil {
+			if m != nil {
+				t.Fatalf("error returned with non-nil manifest: %v", err)
+			}
+			return
+		}
+		if err := skill.Validate(m); err != nil {
+			t.Fatalf("ParseManifest returned an invalid manifest: %v", err)
+		}
+	})
+}
+
+// FuzzLoad exercises the full activation path (manifest + body + assets) against
+// arbitrary manifest and body bytes written into a real pack directory. Loading
+// must never panic; failures must be errors, and any returned pack must carry
+// the parsed manifest.
+func FuzzLoad(f *testing.F) {
+	f.Add([]byte(manifest), []byte("# body"))
+	f.Add([]byte("name: [bad"), []byte(""))
+	f.Add([]byte(""), []byte("---\ntitle: x\n---\nbody"))
+
+	f.Fuzz(func(t *testing.T, manifestBytes, body []byte) {
+		dir := t.TempDir()
+		if err := util.WriteFile(filepath.Join(dir, skill.ManifestFileName), manifestBytes); err != nil {
+			t.Skip()
+		}
+		if err := util.WriteFile(filepath.Join(dir, skill.SkillMarkdownFileName), body); err != nil {
+			t.Skip()
+		}
+		pack, err := skill.NewLoader().Load(dir)
+		if err != nil {
+			if pack != nil {
+				t.Fatalf("error returned with non-nil pack: %v", err)
+			}
+			return
+		}
+		if pack.Manifest.Name == "" {
+			t.Fatalf("loaded pack has empty manifest name")
+		}
+	})
+}

--- a/skill/limits.go
+++ b/skill/limits.go
@@ -1,0 +1,45 @@
+package skill
+
+// Limits bounds the sizes of untrusted skill-pack files read at load time.
+// Reads fail closed once a bound is exceeded. The zero value is not usable;
+// obtain defaults from DefaultLimits or inject via WithLimits, which fills any
+// non-positive field with its default.
+type Limits struct {
+	// Manifest bounds the manifest file size.
+	Manifest int64
+	// Body bounds the SKILL.md body size.
+	Body int64
+	// Asset bounds a single inert asset size.
+	Asset int64
+	// AssetTotal bounds the aggregate size of all inert assets.
+	AssetTotal int64
+}
+
+// DefaultLimits returns the production size limits.
+func DefaultLimits() Limits {
+	return Limits{
+		Manifest:   MaxManifestBytes,
+		Body:       MaxBodyBytes,
+		Asset:      MaxAssetBytes,
+		AssetTotal: MaxAssetTotalBytes,
+	}
+}
+
+// withDefaults returns a copy where any non-positive field is replaced by its
+// default, so a partially-specified Limits stays safe.
+func (l Limits) withDefaults() Limits {
+	d := DefaultLimits()
+	if l.Manifest <= 0 {
+		l.Manifest = d.Manifest
+	}
+	if l.Body <= 0 {
+		l.Body = d.Body
+	}
+	if l.Asset <= 0 {
+		l.Asset = d.Asset
+	}
+	if l.AssetTotal <= 0 {
+		l.AssetTotal = d.AssetTotal
+	}
+	return l
+}

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -216,8 +216,24 @@ func readBounded(path string, maxBytes int64) ([]byte, error) {
 }
 
 func hashAsset(path string, total *int64, limits Limits) (string, error) {
-	data, err := readBounded(path, limits.Asset)
+	remaining := limits.AssetTotal - *total
+	if remaining < 0 {
+		remaining = 0
+	}
+	// Bound this read by the smaller of the per-asset and remaining-total
+	// budgets so an oversized asset never fully materializes in memory before
+	// the aggregate limit is enforced.
+	limit := limits.Asset
+	overTotal := false
+	if remaining < limit {
+		limit = remaining
+		overTotal = true
+	}
+	data, err := readBounded(path, limit)
 	if err != nil {
+		if overTotal && errors.Is(err, ErrFileTooLarge) {
+			return "", fmt.Errorf("%w: reading %s", ErrAssetsTooLarge, path)
+		}
 		return "", err
 	}
 	*total += int64(len(data))

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	apperrors "github.com/kbukum/gokit/errors"
 	"github.com/kbukum/gokit/fs"
 )
 
@@ -99,13 +100,15 @@ func (l *Loader) LoadMetadata(root string) (*Manifest, []string, error) {
 		return nil, nil, err
 	}
 	switch outcome.Status {
-	case VerificationDenied:
-		return nil, nil, fmt.Errorf("%w: %s", ErrVerificationDenied, outcome.Reason)
+	case VerificationVerified:
+		return manifest, nil, nil
 	case VerificationWarning:
 		l.logWarnings(root, outcome.Warnings)
 		return manifest, outcome.Warnings, nil
+	case VerificationDenied:
+		return nil, nil, fmt.Errorf("%w: %s", ErrVerificationDenied, outcome.Reason)
 	default:
-		return manifest, nil, nil
+		return nil, nil, fmt.Errorf("%w: unknown verification status %d", ErrVerificationDenied, outcome.Status)
 	}
 }
 
@@ -316,13 +319,18 @@ func enumerateAssets(canonRoot, root, dir string, total *int64, limits Limits) (
 }
 
 // confineToRoot rejects path when, after resolving symlinks, it escapes
-// canonRoot. It reuses the fs owner's confinement and maps its error onto the
-// pack-file taxonomy so callers can match ErrInvalidPackFile.
+// canonRoot. It reuses the fs owner's confinement and maps only its policy
+// rejection (an escape) onto ErrInvalidPackFile; low-level IO failures (missing
+// or unreadable paths) are returned as-is per the package error taxonomy.
 func confineToRoot(canonRoot, path string) error {
-	if _, err := fs.ConfineExistingPath(canonRoot, path); err != nil {
+	_, err := fs.ConfineExistingPath(canonRoot, path)
+	if err == nil {
+		return nil
+	}
+	if appErr, ok := apperrors.AsAppError(err); ok && appErr.Code == apperrors.ErrCodeInvalidInput {
 		return fmt.Errorf("%w: %w", ErrInvalidPackFile, err)
 	}
-	return nil
+	return err
 }
 
 func splitFrontmatter(body string) string {

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -184,8 +184,11 @@ func (p *Pack) LoadReferenceDoc(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	full := filepath.Join(p.Root, "references", filepath.Clean(name))
+	full := filepath.Join(canonRoot, "references", filepath.Clean(name))
 	if err := confineToRoot(canonRoot, full); err != nil {
+		return nil, err
+	}
+	if err := rejectSymlinkSegments(canonRoot, full); err != nil {
 		return nil, err
 	}
 	return readBounded(full, p.limits.withDefaults().Asset)
@@ -206,6 +209,29 @@ func rejectSymlink(path string) error {
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("%w: symlinked files are not allowed: %s", ErrInvalidPackFile, path)
+	}
+	return nil
+}
+
+// rejectSymlinkSegments rejects a symlink on any path segment between canonRoot
+// (exclusive) and full (inclusive). Confinement alone permits symlinked
+// directories that still resolve under the root, so this enforces the loader's
+// reject-symlinks policy on every segment and closes the path-confusion / TOCTOU
+// gap that a symlinked intermediate directory would otherwise reopen.
+func rejectSymlinkSegments(canonRoot, full string) error {
+	rel, err := filepath.Rel(canonRoot, full)
+	if err != nil {
+		return err
+	}
+	current := canonRoot
+	for _, segment := range strings.Split(rel, string(os.PathSeparator)) {
+		if segment == "" || segment == "." {
+			continue
+		}
+		current = filepath.Join(current, segment)
+		if err := rejectSymlink(current); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -267,6 +293,9 @@ func enumerateDeclaredScripts(canonRoot string, scripts []Script, total *int64, 
 		clean := filepath.Clean(script.Path)
 		full := filepath.Join(canonRoot, clean)
 		if err := confineToRoot(canonRoot, full); err != nil {
+			return nil, err
+		}
+		if err := rejectSymlinkSegments(canonRoot, full); err != nil {
 			return nil, err
 		}
 		digest, err := hashAsset(full, total, limits)

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -3,15 +3,29 @@ package skill
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
-	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/kbukum/gokit/fs"
 )
 
 const SkillMarkdownFileName = "SKILL.md"
+
+// Size limits for untrusted skill-pack files. Reads fail closed once exceeded.
+const (
+	// MaxBodyBytes bounds the SKILL.md body size.
+	MaxBodyBytes = 4 << 20 // 4 MiB
+	// MaxAssetBytes bounds a single inert asset size.
+	MaxAssetBytes = 16 << 20 // 16 MiB
+	// MaxAssetTotalBytes bounds the aggregate size of all inert assets.
+	MaxAssetTotalBytes = 64 << 20 // 64 MiB
+)
 
 type Asset struct {
 	Path   string `json:"path"`
@@ -19,51 +33,148 @@ type Asset struct {
 }
 
 type Pack struct {
-	Root       string
-	Manifest   Manifest
-	SkillBody  string
-	References []Asset
-	Scripts    []Asset
+	Root                 string
+	Manifest             Manifest
+	SkillBody            string
+	References           []Asset
+	Scripts              []Asset
+	VerificationWarnings []string
+
+	limits Limits
 }
 
-type Loader struct{}
+// LoaderOption configures a Loader.
+type LoaderOption func(*Loader)
 
-func NewLoader() *Loader { return &Loader{} }
+// WithVerifier injects the manifest verifier consulted at load time. When
+// omitted the loader uses WarnOnlyVerifier.
+func WithVerifier(v Verifier) LoaderOption {
+	return func(l *Loader) {
+		if v != nil {
+			l.verifier = v
+		}
+	}
+}
 
+// WithLogger injects the logger used to surface non-fatal verification warnings.
+func WithLogger(logger *slog.Logger) LoaderOption {
+	return func(l *Loader) { l.logger = logger }
+}
+
+// WithLimits injects the size limits enforced on untrusted pack files. Any
+// non-positive field falls back to its DefaultLimits value.
+func WithLimits(limits Limits) LoaderOption {
+	return func(l *Loader) { l.limits = limits.withDefaults() }
+}
+
+// Loader loads and activates skill packs from the filesystem, enforcing size
+// limits, rejecting symlinks and escaping paths, and running an injected
+// verifier before a pack is returned.
+type Loader struct {
+	verifier Verifier
+	logger   *slog.Logger
+	limits   Limits
+}
+
+// NewLoader builds a Loader. Without options it verifies with WarnOnlyVerifier
+// and enforces DefaultLimits.
+func NewLoader(opts ...LoaderOption) *Loader {
+	l := &Loader{verifier: WarnOnlyVerifier{}, limits: DefaultLimits()}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
+}
+
+// LoadMetadata parses, validates, and verifies only the manifest. It returns
+// the manifest and any non-fatal verification warnings, and fails closed when
+// verification is denied.
+func (l *Loader) LoadMetadata(root string) (*Manifest, []string, error) {
+	manifest, err := loadManifest(filepath.Join(root, ManifestFileName), l.limits.Manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+	outcome, err := l.verifier.Verify(manifest, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch outcome.Status {
+	case VerificationDenied:
+		return nil, nil, fmt.Errorf("%w: %s", ErrVerificationDenied, outcome.Reason)
+	case VerificationWarning:
+		l.logWarnings(root, outcome.Warnings)
+		return manifest, outcome.Warnings, nil
+	default:
+		return manifest, nil, nil
+	}
+}
+
+// Load activates a skill pack: it loads verified metadata, the SKILL.md body,
+// and the inert reference and script asset inventory.
 func (l *Loader) Load(root string) (*Pack, error) {
-	manifest, err := LoadManifest(filepath.Join(root, ManifestFileName))
+	canonRoot, err := fs.Canonicalize(root)
 	if err != nil {
 		return nil, err
 	}
-	mdPath := filepath.Join(root, SkillMarkdownFileName)
-	if symErr := rejectSymlink(mdPath); symErr != nil {
-		return nil, symErr
+	manifest, warnings, err := l.LoadMetadata(root)
+	if err != nil {
+		return nil, err
 	}
-	bodyBytes, err := os.ReadFile(mdPath)
+
+	mdPath := filepath.Join(root, SkillMarkdownFileName)
+	if escErr := confineToRoot(canonRoot, mdPath); escErr != nil {
+		return nil, escErr
+	}
+	bodyBytes, err := readBounded(mdPath, l.limits.Body)
 	if err != nil {
 		return nil, fmt.Errorf("skill: read %s: %w", SkillMarkdownFileName, err)
 	}
-	refs, err := enumerateAssets(root, "references")
+	if !utf8.Valid(bodyBytes) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidUTF8, mdPath)
+	}
+
+	var total int64
+	refs, err := enumerateAssets(canonRoot, root, "references", &total, l.limits)
 	if err != nil {
 		return nil, err
 	}
-	scripts, err := enumerateDeclaredScripts(root, manifest.Scripts)
+	scripts, err := enumerateDeclaredScripts(canonRoot, root, manifest.Scripts, &total, l.limits)
 	if err != nil {
 		return nil, err
 	}
-	return &Pack{Root: root, Manifest: *manifest, SkillBody: splitFrontmatter(string(bodyBytes)), References: refs, Scripts: scripts}, nil
+	return &Pack{
+		Root:                 root,
+		Manifest:             *manifest,
+		SkillBody:            splitFrontmatter(string(bodyBytes)),
+		References:           refs,
+		Scripts:              scripts,
+		VerificationWarnings: warnings,
+		limits:               l.limits,
+	}, nil
+}
+
+func (l *Loader) logWarnings(root string, warnings []string) {
+	if l.logger == nil {
+		return
+	}
+	for _, warning := range warnings {
+		l.logger.Warn("skill verification warning", "root", root, "warning", warning)
+	}
 }
 
 func (p *Pack) LoadReferenceDoc(name string) ([]byte, error) {
-	clean := filepath.Clean(name)
-	if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
-		return nil, fmt.Errorf("skill: invalid reference path %q", name)
+	if name == "" || fs.ValidateRelativePath(name) != nil {
+		return nil, fmt.Errorf("%w: invalid reference path %q", ErrInvalidPackFile, name)
 	}
-	full := filepath.Join(p.Root, "references", clean)
-	if err := rejectSymlink(full); err != nil {
+	canonRoot, err := fs.Canonicalize(p.Root)
+	if err != nil {
 		return nil, err
 	}
-	return os.ReadFile(full)
+	full := filepath.Join(p.Root, "references", filepath.Clean(name))
+	if err := confineToRoot(canonRoot, full); err != nil {
+		return nil, err
+	}
+	return readBounded(full, p.limits.withDefaults().Asset)
 }
 
 func (p *Pack) ListScripts() []Asset {
@@ -72,80 +183,130 @@ func (p *Pack) ListScripts() []Asset {
 	return out
 }
 
-// rejectSymlink returns an error if the path is a symbolic link,
-// preventing symlink-escape attacks in skill packs.
+// rejectSymlink returns an error if the path is a symbolic link, preventing
+// symlink-escape attacks in skill packs.
 func rejectSymlink(path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("skill: symlinked files are not allowed: %s", path)
+		return fmt.Errorf("%w: symlinked files are not allowed: %s", ErrInvalidPackFile, path)
 	}
 	return nil
 }
 
-func enumerateDeclaredScripts(root string, scripts []Script) ([]Asset, error) {
+// readBounded reads a regular file after rejecting symlinks, failing closed when
+// the file is not regular or exceeds maxBytes. It delegates the bounded read to
+// the fs owner and maps its rejections onto the pack-file error taxonomy.
+func readBounded(path string, maxBytes int64) ([]byte, error) {
+	if err := rejectSymlink(path); err != nil {
+		return nil, err
+	}
+	data, err := fs.ReadFileLimit(path, maxBytes)
+	switch {
+	case errors.Is(err, fs.ErrFileTooLarge):
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrFileTooLarge, path, maxBytes)
+	case errors.Is(err, fs.ErrNotRegularFile):
+		return nil, fmt.Errorf("%w: %s: expected regular file", ErrInvalidPackFile, path)
+	case err != nil:
+		return nil, err
+	}
+	return data, nil
+}
+
+func hashAsset(path string, total *int64, limits Limits) (string, error) {
+	data, err := readBounded(path, limits.Asset)
+	if err != nil {
+		return "", err
+	}
+	*total += int64(len(data))
+	if *total > limits.AssetTotal {
+		return "", fmt.Errorf("%w: reading %s (%d bytes)", ErrAssetsTooLarge, path, *total)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func enumerateDeclaredScripts(canonRoot, root string, scripts []Script, total *int64, limits Limits) ([]Asset, error) {
 	assets := make([]Asset, 0, len(scripts))
 	for _, script := range scripts {
-		clean := filepath.Clean(script.Path)
-		if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
-			return nil, fmt.Errorf("skill: invalid script path %q", script.Path)
+		if err := fs.ValidateRelativePath(script.Path); err != nil {
+			return nil, fmt.Errorf("%w: invalid script path %q", ErrInvalidPackFile, script.Path)
 		}
+		clean := filepath.Clean(script.Path)
 		full := filepath.Join(root, clean)
-		if err := rejectSymlink(full); err != nil {
+		if err := confineToRoot(canonRoot, full); err != nil {
 			return nil, err
 		}
-		data, err := os.ReadFile(full)
+		digest, err := hashAsset(full, total, limits)
 		if err != nil {
 			return nil, err
 		}
-		sum := sha256.Sum256(data)
-		assets = append(assets, Asset{Path: filepath.ToSlash(clean), SHA256: hex.EncodeToString(sum[:])})
+		assets = append(assets, Asset{Path: filepath.ToSlash(clean), SHA256: digest})
 	}
-	sort.Slice(assets, func(i, j int) bool { return assets[i].Path < assets[j].Path })
+	slices.SortFunc(assets, func(a, b Asset) int { return strings.Compare(a.Path, b.Path) })
 	return assets, nil
 }
 
-func enumerateAssets(root, dir string) ([]Asset, error) {
+func enumerateAssets(canonRoot, root, dir string, total *int64, limits Limits) ([]Asset, error) {
 	base := filepath.Join(root, filepath.Clean(dir))
-	if st, err := os.Stat(base); err != nil {
+	info, err := os.Lstat(base)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, err
-	} else if !st.IsDir() {
-		return nil, fmt.Errorf("skill: %s is not a directory", dir)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%w: symlinked assets are not allowed: %s", ErrInvalidPackFile, base)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s is not a directory", ErrInvalidPackFile, dir)
+	}
+	if escErr := confineToRoot(canonRoot, base); escErr != nil {
+		return nil, escErr
 	}
 	var assets []Asset
-	err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: symlinked assets are not allowed: %s", ErrInvalidPackFile, path)
 		}
 		if d.IsDir() {
 			return nil
 		}
-		if d.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("skill: symlinked assets are not allowed: %s", path)
+		if escErr := confineToRoot(canonRoot, path); escErr != nil {
+			return escErr
 		}
-		//nolint:gosec // WalkDir is scoped to base and symlinks are rejected before reading; Go 1.25 lacks os.Root-scoped reads.
-		data, err := os.ReadFile(path)
+		digest, err := hashAsset(path, total, limits)
 		if err != nil {
 			return err
 		}
-		sum := sha256.Sum256(data)
 		rel, err := filepath.Rel(base, path)
 		if err != nil {
 			return err
 		}
-		assets = append(assets, Asset{Path: filepath.ToSlash(rel), SHA256: hex.EncodeToString(sum[:])})
+		assets = append(assets, Asset{Path: filepath.ToSlash(rel), SHA256: digest})
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(assets, func(i, j int) bool { return assets[i].Path < assets[j].Path })
+	slices.SortFunc(assets, func(a, b Asset) int { return strings.Compare(a.Path, b.Path) })
 	return assets, nil
+}
+
+// confineToRoot rejects path when, after resolving symlinks, it escapes
+// canonRoot. It reuses the fs owner's confinement and maps its error onto the
+// pack-file taxonomy so callers can match ErrInvalidPackFile.
+func confineToRoot(canonRoot, path string) error {
+	if _, err := fs.ConfineExistingPath(canonRoot, path); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidPackFile, err)
+	}
+	return nil
 }
 
 func splitFrontmatter(body string) string {

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -91,11 +91,21 @@ func NewLoader(opts ...LoaderOption) *Loader {
 // the manifest and any non-fatal verification warnings, and fails closed when
 // verification is denied.
 func (l *Loader) LoadMetadata(root string) (*Manifest, []string, error) {
-	manifest, err := loadManifest(filepath.Join(root, ManifestFileName), l.limits.Manifest)
+	canonRoot, err := fs.Canonicalize(root)
 	if err != nil {
 		return nil, nil, err
 	}
-	outcome, err := l.verifier.Verify(manifest, root)
+	return l.loadMetadata(canonRoot)
+}
+
+// loadMetadata verifies the manifest under an already-canonicalized root so the
+// verifier and warning logger see the same canonical root used for confinement.
+func (l *Loader) loadMetadata(canonRoot string) (*Manifest, []string, error) {
+	manifest, err := loadManifest(filepath.Join(canonRoot, ManifestFileName), l.limits.Manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+	outcome, err := l.verifier.Verify(manifest, canonRoot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +113,7 @@ func (l *Loader) LoadMetadata(root string) (*Manifest, []string, error) {
 	case VerificationVerified:
 		return manifest, nil, nil
 	case VerificationWarning:
-		l.logWarnings(root, outcome.Warnings)
+		l.logWarnings(canonRoot, outcome.Warnings)
 		return manifest, outcome.Warnings, nil
 	case VerificationDenied:
 		return nil, nil, fmt.Errorf("%w: %s", ErrVerificationDenied, outcome.Reason)
@@ -113,18 +123,19 @@ func (l *Loader) LoadMetadata(root string) (*Manifest, []string, error) {
 }
 
 // Load activates a skill pack: it loads verified metadata, the SKILL.md body,
-// and the inert reference and script asset inventory.
+// and the inert reference and script asset inventory. Every path is anchored to
+// the canonical pack root.
 func (l *Loader) Load(root string) (*Pack, error) {
 	canonRoot, err := fs.Canonicalize(root)
 	if err != nil {
 		return nil, err
 	}
-	manifest, warnings, err := l.LoadMetadata(root)
+	manifest, warnings, err := l.loadMetadata(canonRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	mdPath := filepath.Join(root, SkillMarkdownFileName)
+	mdPath := filepath.Join(canonRoot, SkillMarkdownFileName)
 	if escErr := confineToRoot(canonRoot, mdPath); escErr != nil {
 		return nil, escErr
 	}
@@ -137,16 +148,16 @@ func (l *Loader) Load(root string) (*Pack, error) {
 	}
 
 	var total int64
-	refs, err := enumerateAssets(canonRoot, root, "references", &total, l.limits)
+	refs, err := enumerateAssets(canonRoot, "references", &total, l.limits)
 	if err != nil {
 		return nil, err
 	}
-	scripts, err := enumerateDeclaredScripts(canonRoot, root, manifest.Scripts, &total, l.limits)
+	scripts, err := enumerateDeclaredScripts(canonRoot, manifest.Scripts, &total, l.limits)
 	if err != nil {
 		return nil, err
 	}
 	return &Pack{
-		Root:                 root,
+		Root:                 canonRoot,
 		Manifest:             *manifest,
 		SkillBody:            splitFrontmatter(string(bodyBytes)),
 		References:           refs,
@@ -247,14 +258,14 @@ func hashAsset(path string, total *int64, limits Limits) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func enumerateDeclaredScripts(canonRoot, root string, scripts []Script, total *int64, limits Limits) ([]Asset, error) {
+func enumerateDeclaredScripts(canonRoot string, scripts []Script, total *int64, limits Limits) ([]Asset, error) {
 	assets := make([]Asset, 0, len(scripts))
 	for _, script := range scripts {
 		if err := fs.ValidateRelativePath(script.Path); err != nil {
 			return nil, fmt.Errorf("%w: invalid script path %q", ErrInvalidPackFile, script.Path)
 		}
 		clean := filepath.Clean(script.Path)
-		full := filepath.Join(root, clean)
+		full := filepath.Join(canonRoot, clean)
 		if err := confineToRoot(canonRoot, full); err != nil {
 			return nil, err
 		}
@@ -268,8 +279,8 @@ func enumerateDeclaredScripts(canonRoot, root string, scripts []Script, total *i
 	return assets, nil
 }
 
-func enumerateAssets(canonRoot, root, dir string, total *int64, limits Limits) ([]Asset, error) {
-	base := filepath.Join(root, filepath.Clean(dir))
+func enumerateAssets(canonRoot, dir string, total *int64, limits Limits) ([]Asset, error) {
+	base := filepath.Join(canonRoot, filepath.Clean(dir))
 	info, err := os.Lstat(base)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/skill/loader.go
+++ b/skill/loader.go
@@ -217,11 +217,15 @@ func rejectSymlink(path string) error {
 // (exclusive) and full (inclusive). Confinement alone permits symlinked
 // directories that still resolve under the root, so this enforces the loader's
 // reject-symlinks policy on every segment and closes the path-confusion / TOCTOU
-// gap that a symlinked intermediate directory would otherwise reopen.
+// gap that a symlinked intermediate directory would otherwise reopen. It fails
+// closed when full escapes canonRoot instead of probing paths outside the pack.
 func rejectSymlinkSegments(canonRoot, full string) error {
 	rel, err := filepath.Rel(canonRoot, full)
 	if err != nil {
 		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("%w: %s escapes pack root", ErrInvalidPackFile, full)
 	}
 	current := canonRoot
 	for _, segment := range strings.Split(rel, string(os.PathSeparator)) {

--- a/skill/loader_internal_test.go
+++ b/skill/loader_internal_test.go
@@ -1,0 +1,15 @@
+package skill
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestRejectSymlinkSegmentsFailsClosedOnEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(filepath.Dir(root), "outside", "x.txt")
+	if err := rejectSymlinkSegments(root, outside); !errors.Is(err, ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for path escaping root, got %v", err)
+	}
+}

--- a/skill/loader_test.go
+++ b/skill/loader_test.go
@@ -386,3 +386,32 @@ func TestLoadReferenceDocRejectsEmptyName(t *testing.T) {
 		t.Fatalf("want ErrInvalidPackFile for empty name, got %v", err)
 	}
 }
+
+type badStatusVerifier struct{}
+
+func (badStatusVerifier) Verify(*skill.Manifest, string) (skill.VerificationOutcome, error) {
+	return skill.VerificationOutcome{Status: skill.VerificationStatus(99)}, nil
+}
+
+func TestLoaderFailsClosedOnUnknownVerificationStatus(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	if _, err := skill.NewLoader(skill.WithVerifier(badStatusVerifier{})).Load(dir); !errors.Is(err, skill.ErrVerificationDenied) {
+		t.Fatalf("want ErrVerificationDenied for unknown status, got %v", err)
+	}
+}
+
+func TestLoaderMissingSkillBodyReturnsIOError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	// SKILL.md is never written; the missing body is an IO failure, not a
+	// pack-file policy violation.
+	_, err := skill.NewLoader().Load(dir)
+	if err == nil {
+		t.Fatal("expected error for missing SKILL.md")
+	}
+	if errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("missing body should pass through as an IO error, got ErrInvalidPackFile: %v", err)
+	}
+}

--- a/skill/loader_test.go
+++ b/skill/loader_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kbukum/gokit/fs"
 	"github.com/kbukum/gokit/skill"
 	"github.com/kbukum/gokit/util"
 )
@@ -161,6 +162,11 @@ func TestVerifierOutcomes(t *testing.T) {
 	unsigned := validManifest()
 	if out, _ := (skill.WarnOnlyVerifier{}).Verify(&unsigned, ""); out.Status != skill.VerificationWarning {
 		t.Fatalf("unsigned manifest should warn, got %+v", out)
+	}
+	placeholder := validManifest()
+	placeholder.Signature = &skill.Signature{}
+	if out, _ := (skill.WarnOnlyVerifier{}).Verify(&placeholder, ""); out.Status != skill.VerificationWarning {
+		t.Fatalf("placeholder signature should still warn, got %+v", out)
 	}
 	if out, _ := (skill.DenyVerifier{}).Verify(&signed, ""); out.Status != skill.VerificationDenied {
 		t.Fatalf("deny verifier should deny, got %+v", out)
@@ -413,5 +419,21 @@ func TestLoaderMissingSkillBodyReturnsIOError(t *testing.T) {
 	}
 	if errors.Is(err, skill.ErrInvalidPackFile) {
 		t.Fatalf("missing body should pass through as an IO error, got ErrInvalidPackFile: %v", err)
+	}
+}
+
+func TestLoaderPackRootIsCanonical(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir)
+	canon, err := fs.Canonicalize(dir)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if pack.Root != canon {
+		t.Fatalf("pack root=%q, want canonical %q", pack.Root, canon)
 	}
 }

--- a/skill/loader_test.go
+++ b/skill/loader_test.go
@@ -143,6 +143,39 @@ func TestLoadReferenceDocRejectsTraversal(t *testing.T) {
 	}
 }
 
+func TestLoadReferenceDocReadsDeclaredReference(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir)
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := pack.LoadReferenceDoc("a.md")
+	if err != nil {
+		t.Fatalf("read reference: %v", err)
+	}
+	if string(data) != "ref" {
+		t.Fatalf("reference content=%q, want %q", data, "ref")
+	}
+}
+
+func TestLoadReferenceDocRejectsSymlinkedSubdir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "references", "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "references", "real", "doc.md"), "hi")
+	// A symlinked directory resolving inside the pack passes confinement, so
+	// only per-segment symlink rejection can catch it.
+	if err := os.Symlink("real", filepath.Join(dir, "references", "link")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	pack := skill.Pack{Root: dir}
+	if _, err := pack.LoadReferenceDoc("link/doc.md"); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for reference via symlinked dir, got %v", err)
+	}
+}
+
 func TestRegistryDuplicateWrapsSentinel(t *testing.T) {
 	reg := skill.NewRegistry()
 	if err := reg.Register(provider{manifest: validManifest()}); err != nil {
@@ -295,6 +328,23 @@ func TestLoaderRejectsOversizedScript(t *testing.T) {
 	loader := skill.NewLoader(skill.WithLimits(skill.Limits{Asset: 8}))
 	if _, err := loader.Load(dir); !errors.Is(err, skill.ErrFileTooLarge) {
 		t.Fatalf("want ErrFileTooLarge for oversized script, got %v", err)
+	}
+}
+
+func TestLoaderRejectsScriptThroughSymlinkedDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "references", "a.md"), "ref")
+	// The declared script lives at scripts/run.sh, but "scripts" is a symlink
+	// to a real directory inside the pack. It passes confinement, so only
+	// per-segment symlink rejection can enforce the reject-symlinks policy.
+	writeFile(t, filepath.Join(dir, "real", "run.sh"), "echo nope")
+	if err := os.Symlink("real", filepath.Join(dir, "scripts")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := skill.NewLoader().Load(dir); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for script via symlinked dir, got %v", err)
 	}
 }
 

--- a/skill/loader_test.go
+++ b/skill/loader_test.go
@@ -1,0 +1,388 @@
+package skill_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/skill"
+	"github.com/kbukum/gokit/util"
+)
+
+func writePack(t *testing.T, dir string) {
+	t.Helper()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\ntitle: Demo\n---\n# Demo")
+	writeFile(t, filepath.Join(dir, "references", "a.md"), "ref")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+}
+
+func TestValidateWrapsSentinel(t *testing.T) {
+	err := skill.Validate(&skill.Manifest{})
+	if !errors.Is(err, skill.ErrManifestInvalid) {
+		t.Fatalf("want ErrManifestInvalid, got %v", err)
+	}
+}
+
+func TestParseManifestRejectsMalformed(t *testing.T) {
+	if _, err := skill.ParseManifest([]byte("name: [bad")); !errors.Is(err, skill.ErrParseManifest) {
+		t.Fatalf("want ErrParseManifest, got %v", err)
+	}
+}
+
+func TestValidateRejectsUnsafeScriptPath(t *testing.T) {
+	m := validManifest()
+	m.Scripts = []skill.Script{{Path: "../evil.sh", Description: "escape"}}
+	if err := skill.Validate(&m); !errors.Is(err, skill.ErrManifestInvalid) {
+		t.Fatalf("want ErrManifestInvalid for escaping script, got %v", err)
+	}
+}
+
+func TestLoadManifestRejectsOversizedManifest(t *testing.T) {
+	dir := t.TempDir()
+	big := strings.Repeat("a", skill.MaxManifestBytes+1)
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), big)
+	_, err := skill.LoadManifest(filepath.Join(dir, skill.ManifestFileName))
+	if !errors.Is(err, skill.ErrFileTooLarge) {
+		t.Fatalf("want ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestLoaderRejectsOversizedBody(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), strings.Repeat("x", skill.MaxBodyBytes+1))
+	_, err := skill.NewLoader().Load(dir)
+	if !errors.Is(err, skill.ErrFileTooLarge) {
+		t.Fatalf("want ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestLoaderRejectsInvalidUTF8Body(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	if err := util.WriteFile(filepath.Join(dir, "SKILL.md"), []byte{0xff, 0xfe}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := skill.NewLoader().Load(dir)
+	if !errors.Is(err, skill.ErrInvalidUTF8) {
+		t.Fatalf("want ErrInvalidUTF8, got %v", err)
+	}
+}
+
+func TestLoaderDenyVerifierFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir)
+	_, err := skill.NewLoader(skill.WithVerifier(skill.DenyVerifier{})).Load(dir)
+	if !errors.Is(err, skill.ErrVerificationDenied) {
+		t.Fatalf("want ErrVerificationDenied, got %v", err)
+	}
+	if _, _, err := skill.NewLoader(skill.WithVerifier(skill.DenyVerifier{})).LoadMetadata(dir); !errors.Is(err, skill.ErrVerificationDenied) {
+		t.Fatalf("LoadMetadata want ErrVerificationDenied, got %v", err)
+	}
+}
+
+func TestLoaderCollectsWarningsForUnsignedManifest(t *testing.T) {
+	dir := t.TempDir()
+	// Manifest without a signature triggers the warn-only path.
+	head, _, _ := strings.Cut(manifest, "signature:")
+	unsigned := head + "safety: read-only\n"
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), unsigned)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pack.VerificationWarnings) != 1 || pack.VerificationWarnings[0] != "unsigned skill manifest" {
+		t.Fatalf("warnings=%v", pack.VerificationWarnings)
+	}
+}
+
+func TestLoaderSignedManifestHasNoWarnings(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir)
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pack.VerificationWarnings) != 0 {
+		t.Fatalf("unexpected warnings=%v", pack.VerificationWarnings)
+	}
+}
+
+func TestLoaderRejectsSymlinkedReferencesDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.txt"), "secret")
+	if err := os.Symlink(outside, filepath.Join(dir, "references")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	_, err := skill.NewLoader().Load(dir)
+	if !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for symlinked references dir, got %v", err)
+	}
+}
+
+func TestLoadReferenceDocRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir)
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pack.LoadReferenceDoc("../../etc/passwd"); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile, got %v", err)
+	}
+}
+
+func TestRegistryDuplicateWrapsSentinel(t *testing.T) {
+	reg := skill.NewRegistry()
+	if err := reg.Register(provider{manifest: validManifest()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(provider{manifest: validManifest()}); !errors.Is(err, skill.ErrAlreadyRegistered) {
+		t.Fatalf("want ErrAlreadyRegistered, got %v", err)
+	}
+}
+
+func TestVerifierOutcomes(t *testing.T) {
+	signed := validManifest()
+	signed.Signature = &skill.Signature{Algorithm: "ed25519", Value: "sig", KeyID: "k"}
+	if out, _ := (skill.WarnOnlyVerifier{}).Verify(&signed, ""); out.Status != skill.VerificationVerified {
+		t.Fatalf("signed manifest should verify, got %+v", out)
+	}
+	unsigned := validManifest()
+	if out, _ := (skill.WarnOnlyVerifier{}).Verify(&unsigned, ""); out.Status != skill.VerificationWarning {
+		t.Fatalf("unsigned manifest should warn, got %+v", out)
+	}
+	if out, _ := (skill.DenyVerifier{}).Verify(&signed, ""); out.Status != skill.VerificationDenied {
+		t.Fatalf("deny verifier should deny, got %+v", out)
+	}
+}
+
+func TestLoaderLogsWarnings(t *testing.T) {
+	dir := t.TempDir()
+	head, _, _ := strings.Cut(manifest, "signature:")
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), head+"safety: read-only\n")
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	if _, err := skill.NewLoader(skill.WithLogger(logger)).Load(dir); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "unsigned skill manifest") {
+		t.Fatalf("expected warning logged, got %q", buf.String())
+	}
+}
+
+func TestLoadManifestRejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, skill.ManifestFileName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.LoadManifest(filepath.Join(dir, skill.ManifestFileName)); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile, got %v", err)
+	}
+}
+
+func TestLoaderRejectsMissingDeclaredScript(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	// Declared scripts/run.sh is never created.
+	if _, err := skill.NewLoader().Load(dir); err == nil {
+		t.Fatal("expected error for missing declared script")
+	}
+}
+
+type errVerifier struct{}
+
+func (errVerifier) Verify(*skill.Manifest, string) (skill.VerificationOutcome, error) {
+	return skill.VerificationOutcome{}, errors.New("verifier boom")
+}
+
+func TestLoaderPropagatesVerifierError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	if _, err := skill.NewLoader(skill.WithVerifier(errVerifier{})).Load(dir); err == nil {
+		t.Fatal("expected verifier error to propagate")
+	}
+	if _, _, err := skill.NewLoader(skill.WithVerifier(errVerifier{})).LoadMetadata(dir); err == nil {
+		t.Fatal("expected LoadMetadata to propagate verifier error")
+	}
+}
+
+func TestLoadRejectsMissingRoot(t *testing.T) {
+	_, err := skill.NewLoader().Load(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error resolving a missing pack root")
+	}
+}
+
+func TestLoaderRejectsEscapingSkillBody(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.md"), "secret")
+	if err := os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := skill.NewLoader().Load(dir); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for escaping SKILL.md, got %v", err)
+	}
+}
+
+func TestLoaderRejectsSymlinkedSkillBody(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "inside.md"), "body")
+	// Symlink resolves within the root, so the escape check passes and the
+	// symlink rejection in readBounded is what must fail the load.
+	if err := os.Symlink("inside.md", filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := skill.NewLoader().Load(dir); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for symlinked SKILL.md, got %v", err)
+	}
+}
+
+func TestLoaderRejectsSymlinkedReferenceFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+	writeFile(t, filepath.Join(dir, "references", "real.md"), "ref")
+	if err := os.Symlink("real.md", filepath.Join(dir, "references", "link.md")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := skill.NewLoader().Load(dir); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for symlinked reference file, got %v", err)
+	}
+}
+
+func TestLoaderRejectsOversizedAsset(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "references", "big.md"), strings.Repeat("x", 32))
+	loader := skill.NewLoader(skill.WithLimits(skill.Limits{Asset: 8}))
+	if _, err := loader.Load(dir); !errors.Is(err, skill.ErrFileTooLarge) {
+		t.Fatalf("want ErrFileTooLarge for oversized asset, got %v", err)
+	}
+}
+
+func TestLoaderRejectsOversizedScript(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), strings.Repeat("x", 32))
+	loader := skill.NewLoader(skill.WithLimits(skill.Limits{Asset: 8}))
+	if _, err := loader.Load(dir); !errors.Is(err, skill.ErrFileTooLarge) {
+		t.Fatalf("want ErrFileTooLarge for oversized script, got %v", err)
+	}
+}
+
+func TestLoaderRejectsAssetsExceedingTotal(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+	writeFile(t, filepath.Join(dir, "references", "a.md"), strings.Repeat("x", 10))
+	writeFile(t, filepath.Join(dir, "references", "b.md"), strings.Repeat("y", 10))
+	// Each asset is under Asset but their sum exceeds AssetTotal.
+	loader := skill.NewLoader(skill.WithLimits(skill.Limits{Asset: 100, AssetTotal: 15}))
+	if _, err := loader.Load(dir); !errors.Is(err, skill.ErrAssetsTooLarge) {
+		t.Fatalf("want ErrAssetsTooLarge, got %v", err)
+	}
+}
+
+const multiAssetManifest = `schema_version: "1"
+name: demo
+version: 0.1.0
+description: d
+references:
+  tools: []
+  prompts: []
+  resources: []
+  mcp_servers: []
+human_approval: []
+scripts:
+  - path: scripts/a.sh
+    description: a
+  - path: scripts/b.sh
+    description: b
+`
+
+func TestLoaderSortsMultipleAssets(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), multiAssetManifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "references", "b.md"), "b")
+	writeFile(t, filepath.Join(dir, "references", "a.md"), "a")
+	writeFile(t, filepath.Join(dir, "scripts", "b.sh"), "b")
+	writeFile(t, filepath.Join(dir, "scripts", "a.sh"), "a")
+	pack, err := skill.NewLoader().Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pack.References) != 2 || pack.References[0].Path != "a.md" || pack.References[1].Path != "b.md" {
+		t.Fatalf("references not sorted: %+v", pack.References)
+	}
+	if len(pack.Scripts) != 2 || pack.Scripts[0].Path != "scripts/a.sh" || pack.Scripts[1].Path != "scripts/b.sh" {
+		t.Fatalf("scripts not sorted: %+v", pack.Scripts)
+	}
+}
+
+func TestLoaderPartialLimitsFallBackToDefaults(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "# body")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "echo nope")
+	writeFile(t, filepath.Join(dir, "references", "a.md"), "ref")
+	// Only Body is set; Asset/AssetTotal/Manifest fall back to defaults, so a
+	// normal-sized pack still loads.
+	loader := skill.NewLoader(skill.WithLimits(skill.Limits{Body: 1 << 20}))
+	if _, err := loader.Load(dir); err != nil {
+		t.Fatalf("partial limits should keep defaults for unset fields: %v", err)
+	}
+}
+
+func TestLoadReferenceDocRejectsMissingRoot(t *testing.T) {
+	pack := skill.Pack{Root: filepath.Join(t.TempDir(), "does-not-exist")}
+	if _, err := pack.LoadReferenceDoc("a.md"); err == nil {
+		t.Fatal("expected error resolving a missing pack root")
+	}
+}
+
+func TestLoadReferenceDocRejectsSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.md"), "secret")
+	if err := os.MkdirAll(filepath.Join(dir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(dir, "references", "link.md")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	pack := skill.Pack{Root: dir}
+	if _, err := pack.LoadReferenceDoc("link.md"); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for escaping reference, got %v", err)
+	}
+}
+
+func TestLoadReferenceDocRejectsEmptyName(t *testing.T) {
+	pack := skill.Pack{Root: t.TempDir()}
+	if _, err := pack.LoadReferenceDoc(""); !errors.Is(err, skill.ErrInvalidPackFile) {
+		t.Fatalf("want ErrInvalidPackFile for empty name, got %v", err)
+	}
+}

--- a/skill/manifest.go
+++ b/skill/manifest.go
@@ -100,6 +100,13 @@ type Signature struct {
 	KeyID     string `yaml:"key_id" json:"key_id"`
 }
 
+// IsPresent reports whether the signature carries the fields required to
+// identify a signature scheme and payload. An empty or placeholder object
+// (e.g. `signature: {}` or a blank value) is not present.
+func (s *Signature) IsPresent() bool {
+	return s != nil && s.Algorithm != "" && s.Value != ""
+}
+
 // LoadManifest reads and parses a manifest file, enforcing MaxManifestBytes and
 // rejecting symlinks before reading.
 func LoadManifest(path string) (*Manifest, error) {

--- a/skill/manifest.go
+++ b/skill/manifest.go
@@ -3,12 +3,16 @@ package skill
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
 	"go.yaml.in/yaml/v4"
+
+	"github.com/kbukum/gokit/fs"
 )
+
+// MaxManifestBytes bounds the manifest file size accepted at load time.
+const MaxManifestBytes = 1 << 20 // 1 MiB
 
 const ManifestFileName = "kit.skill.yaml"
 
@@ -17,7 +21,7 @@ var semverPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$
 type Safety string
 
 const (
-	SafetyReadOnly    Safety = "read_only"
+	SafetyReadOnly    Safety = "read-only"
 	SafetyMutating    Safety = "mutating"
 	SafetyDestructive Safety = "destructive"
 )
@@ -96,16 +100,33 @@ type Signature struct {
 	KeyID     string `yaml:"key_id" json:"key_id"`
 }
 
+// LoadManifest reads and parses a manifest file, enforcing MaxManifestBytes and
+// rejecting symlinks before reading.
 func LoadManifest(path string) (*Manifest, error) {
-	data, err := os.ReadFile(path)
+	return loadManifest(path, MaxManifestBytes)
+}
+
+func loadManifest(path string, maxBytes int64) (*Manifest, error) {
+	data, err := readBounded(path, maxBytes)
 	if err != nil {
 		return nil, err
 	}
+	m, err := ParseManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("skill: %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// ParseManifest decodes and validates a manifest from raw YAML bytes. Unknown
+// fields are rejected and the result is validated, so it fails closed on
+// malformed or untrusted input.
+func ParseManifest(data []byte) (*Manifest, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	var m Manifest
 	if err := dec.Decode(&m); err != nil {
-		return nil, fmt.Errorf("skill: parse %s: %w", path, err)
+		return nil, fmt.Errorf("%w: %w", ErrParseManifest, err)
 	}
 	if err := Validate(&m); err != nil {
 		return nil, err
@@ -113,21 +134,30 @@ func LoadManifest(path string) (*Manifest, error) {
 	return &m, nil
 }
 
+// Validate checks a manifest's required fields and structural invariants.
+// Every failure wraps ErrManifestInvalid.
 func Validate(m *Manifest) error {
+	if err := validateManifest(m); err != nil {
+		return fmt.Errorf("%w: %w", ErrManifestInvalid, err)
+	}
+	return nil
+}
+
+func validateManifest(m *Manifest) error {
 	if m == nil {
-		return fmt.Errorf("skill: manifest is nil")
+		return fmt.Errorf("manifest is nil")
 	}
 	if strings.TrimSpace(m.SchemaVersion) == "" {
-		return fmt.Errorf("skill: schema_version is required")
+		return fmt.Errorf("schema_version is required")
 	}
 	if strings.TrimSpace(m.Name) == "" {
-		return fmt.Errorf("skill: name is required")
+		return fmt.Errorf("name is required")
 	}
 	if strings.TrimSpace(m.Version) == "" || !semverPattern.MatchString(m.Version) {
-		return fmt.Errorf("skill: version must be semver")
+		return fmt.Errorf("version must be semver")
 	}
 	if strings.TrimSpace(m.Description) == "" {
-		return fmt.Errorf("skill: description is required")
+		return fmt.Errorf("description is required")
 	}
 	if err := validateUnique("references.tools", m.References.Tools); err != nil {
 		return err
@@ -147,28 +177,31 @@ func Validate(m *Manifest) error {
 	seenPrompts := map[string]struct{}{}
 	for _, prompt := range m.References.Prompts {
 		if strings.TrimSpace(prompt.Name) == "" || strings.TrimSpace(prompt.Version) == "" {
-			return fmt.Errorf("skill: references.prompts name and version are required")
+			return fmt.Errorf("references.prompts name and version are required")
 		}
 		key := prompt.Name + "@" + prompt.Version
 		if _, ok := seenPrompts[key]; ok {
-			return fmt.Errorf("skill: duplicate references.prompts value %q", key)
+			return fmt.Errorf("duplicate references.prompts value %q", key)
 		}
 		seenPrompts[key] = struct{}{}
 	}
 	for _, approval := range m.HumanApproval {
 		if strings.TrimSpace(approval.Step) == "" || strings.TrimSpace(approval.When) == "" || strings.TrimSpace(approval.Rationale) == "" {
-			return fmt.Errorf("skill: human_approval step, when, and rationale are required")
+			return fmt.Errorf("human_approval step, when, and rationale are required")
 		}
 	}
 	for _, script := range m.Scripts {
 		if strings.TrimSpace(script.Path) == "" || strings.TrimSpace(script.Description) == "" {
-			return fmt.Errorf("skill: scripts path and description are required")
+			return fmt.Errorf("scripts path and description are required")
+		}
+		if err := fs.ValidateRelativePath(script.Path); err != nil {
+			return fmt.Errorf("scripts path %q escapes the skill pack: %w", script.Path, err)
 		}
 	}
 	switch m.Safety {
 	case "", SafetyReadOnly, SafetyMutating, SafetyDestructive:
 	default:
-		return fmt.Errorf("skill: invalid safety %q", m.Safety)
+		return fmt.Errorf("invalid safety %q", m.Safety)
 	}
 	return nil
 }
@@ -178,10 +211,10 @@ func validateUnique(field string, values []string) error {
 	for _, value := range values {
 		value = strings.TrimSpace(value)
 		if value == "" {
-			return fmt.Errorf("skill: %s contains empty value", field)
+			return fmt.Errorf("%s contains empty value", field)
 		}
 		if _, ok := seen[value]; ok {
-			return fmt.Errorf("skill: duplicate %s value %q", field, value)
+			return fmt.Errorf("duplicate %s value %q", field, value)
 		}
 		seen[value] = struct{}{}
 	}

--- a/skill/manifest_test.go
+++ b/skill/manifest_test.go
@@ -1,0 +1,77 @@
+package skill_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kbukum/gokit/skill"
+)
+
+func TestValidateFieldFailures(t *testing.T) {
+	base := func() skill.Manifest {
+		return skill.Manifest{SchemaVersion: "1", Name: "demo", Version: "0.1.0", Description: "d"}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*skill.Manifest)
+	}{
+		{"missing name", func(m *skill.Manifest) { m.Name = "" }},
+		{"non-semver version", func(m *skill.Manifest) { m.Version = "one" }},
+		{"missing description", func(m *skill.Manifest) { m.Description = "" }},
+		{"duplicate tools", func(m *skill.Manifest) { m.References.Tools = []string{"a", "a"} }},
+		{"empty tool value", func(m *skill.Manifest) { m.References.Tools = []string{"  "} }},
+		{"duplicate resources", func(m *skill.Manifest) { m.References.Resources = []string{"r", "r"} }},
+		{"duplicate mcp servers", func(m *skill.Manifest) { m.References.MCPServers = []string{"s", "s"} }},
+		{"duplicate scopes", func(m *skill.Manifest) { m.Requires.Scopes = []string{"x", "x"} }},
+		{"duplicate capabilities", func(m *skill.Manifest) { m.Requires.Capabilities = []string{"c", "c"} }},
+		{"prompt missing version", func(m *skill.Manifest) {
+			m.References.Prompts = []skill.PromptReference{{Name: "p"}}
+		}},
+		{"duplicate prompt", func(m *skill.Manifest) {
+			m.References.Prompts = []skill.PromptReference{{Name: "p", Version: "1"}, {Name: "p", Version: "1"}}
+		}},
+		{"human approval incomplete", func(m *skill.Manifest) {
+			m.HumanApproval = []skill.HumanApproval{{Step: "s"}}
+		}},
+		{"script missing description", func(m *skill.Manifest) {
+			m.Scripts = []skill.Script{{Path: "scripts/a.sh"}}
+		}},
+		{"absolute script path", func(m *skill.Manifest) {
+			m.Scripts = []skill.Script{{Path: "/abs.sh", Description: "d"}}
+		}},
+		{"invalid safety", func(m *skill.Manifest) { m.Safety = "spicy" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := base()
+			tc.mutate(&m)
+			if err := skill.Validate(&m); !errors.Is(err, skill.ErrManifestInvalid) {
+				t.Fatalf("want ErrManifestInvalid, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadManifestMissingFile(t *testing.T) {
+	if _, err := skill.LoadManifest(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("expected error for a missing manifest file")
+	}
+}
+
+func TestLoadManifestUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, skill.ManifestFileName)
+	writeFile(t, path, manifest)
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	if _, err := skill.LoadManifest(path); err == nil {
+		t.Skip("file remained readable; cannot exercise the open-error path")
+	}
+}

--- a/skill/registry.go
+++ b/skill/registry.go
@@ -36,7 +36,7 @@ func (r *MemoryRegistry) Register(provider Provider) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.providers[m.Name]; exists {
-		return fmt.Errorf("%w: %s", ErrAlreadyRegistered, m.Name)
+		return fmt.Errorf("%w: provider %q", ErrAlreadyRegistered, m.Name)
 	}
 	r.providers[m.Name] = provider
 	return nil

--- a/skill/registry.go
+++ b/skill/registry.go
@@ -36,7 +36,7 @@ func (r *MemoryRegistry) Register(provider Provider) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.providers[m.Name]; exists {
-		return fmt.Errorf("skill: provider %q already registered", m.Name)
+		return fmt.Errorf("%w: %s", ErrAlreadyRegistered, m.Name)
 	}
 	r.providers[m.Name] = provider
 	return nil

--- a/skill/registry_test.go
+++ b/skill/registry_test.go
@@ -1,0 +1,15 @@
+package skill_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kbukum/gokit/skill"
+)
+
+func TestRegistryRejectsInvalidManifest(t *testing.T) {
+	reg := skill.NewRegistry()
+	if err := reg.Register(provider{manifest: skill.Manifest{}}); !errors.Is(err, skill.ErrManifestInvalid) {
+		t.Fatalf("want ErrManifestInvalid, got %v", err)
+	}
+}

--- a/skill/skill_test.go
+++ b/skill/skill_test.go
@@ -56,7 +56,7 @@ signature:
   algorithm: ed25519
   value: abc
   key_id: test-key
-safety: read_only
+safety: read-only
 `
 
 func TestLoadManifestRejectsUnknownFields(t *testing.T) {
@@ -176,9 +176,6 @@ func TestManifestValidationFailures(t *testing.T) {
 func TestLoaderEdgeCasesAndVerifier(t *testing.T) {
 	if err := skill.Validate(nil); err == nil {
 		t.Fatal("nil manifest should fail")
-	}
-	if err := (skill.WarnOnlyVerifier{}).Verify(nil, skill.Signature{}); err != nil {
-		t.Fatal(err)
 	}
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, skill.ManifestFileName), manifest)

--- a/skill/verifier.go
+++ b/skill/verifier.go
@@ -1,34 +1,57 @@
 package skill
 
-import (
-	"context"
-	"errors"
-	"log/slog"
+// VerificationStatus is the outcome kind of a manifest verification.
+type VerificationStatus int
+
+const (
+	// VerificationVerified indicates the manifest passed verification.
+	VerificationVerified VerificationStatus = iota
+	// VerificationWarning indicates verification succeeded with non-fatal warnings.
+	VerificationWarning
+	// VerificationDenied indicates verification rejected the manifest.
+	VerificationDenied
 )
 
-// ErrSignatureRejected is returned by DenyVerifier and signals that the
-// operator has chosen to reject all skill manifests until a real signature
-// verifier (Sigstore/cosign) is wired in.
-var ErrSignatureRejected = errors.New("skill: deny verifier rejects all signatures")
+// VerificationOutcome is the result of verifying a manifest at load time.
+type VerificationOutcome struct {
+	Status   VerificationStatus
+	Warnings []string
+	Reason   string
+}
 
-// Verifier validates a skill manifest's signature.
+// Verified reports a passing verification with no warnings.
+func Verified() VerificationOutcome { return VerificationOutcome{Status: VerificationVerified} }
+
+// Warning reports a passing verification carrying non-fatal warnings.
+func Warning(messages ...string) VerificationOutcome {
+	return VerificationOutcome{Status: VerificationWarning, Warnings: messages}
+}
+
+// Denied reports a rejected verification with a human-readable reason.
+func Denied(reason string) VerificationOutcome {
+	return VerificationOutcome{Status: VerificationDenied, Reason: reason}
+}
+
+// Verifier verifies a skill manifest at load time. The loader consults it after
+// parsing and validation: Denied fails the load, Warning is surfaced on the
+// pack, and Verified proceeds silently.
 //
 // Implementations MUST be safe for concurrent use.
 type Verifier interface {
-	Verify(manifestBytes []byte, sig Signature) error
+	Verify(manifest *Manifest, root string) (VerificationOutcome, error)
 }
 
-// WarnOnlyVerifier permits unsigned manifests with a warning log. Suitable
-// for development and tests; operators SHOULD pair it with DenyVerifier or a
-// real signature verifier in production.
-type WarnOnlyVerifier struct{ Logger *slog.Logger }
+// WarnOnlyVerifier permits unsigned manifests with a warning and treats any
+// signed manifest as verified. Suitable for development and tests; operators
+// SHOULD pair it with DenyVerifier or a real signature verifier in production.
+type WarnOnlyVerifier struct{}
 
-// Verify logs a warning when no signature is present and otherwise allows.
-func (v WarnOnlyVerifier) Verify(manifestBytes []byte, sig Signature) error {
-	if sig.Value == "" && v.Logger != nil {
-		v.Logger.WarnContext(context.Background(), "skill manifest signature missing", "manifest_bytes", len(manifestBytes))
+// Verify returns Verified for signed manifests and a Warning otherwise.
+func (WarnOnlyVerifier) Verify(manifest *Manifest, _ string) (VerificationOutcome, error) {
+	if manifest != nil && manifest.Signature != nil {
+		return Verified(), nil
 	}
-	return nil
+	return Warning("unsigned skill manifest"), nil
 }
 
 // DenyVerifier is the canonical operator-deny verifier: it rejects every
@@ -36,5 +59,7 @@ func (v WarnOnlyVerifier) Verify(manifestBytes []byte, sig Signature) error {
 // verifier (e.g., Sigstore/cosign) is wired in.
 type DenyVerifier struct{}
 
-// Verify always returns ErrSignatureRejected.
-func (DenyVerifier) Verify(_ []byte, _ Signature) error { return ErrSignatureRejected }
+// Verify always denies.
+func (DenyVerifier) Verify(*Manifest, string) (VerificationOutcome, error) {
+	return Denied("deny verifier: signatures rejected"), nil
+}

--- a/skill/verifier.go
+++ b/skill/verifier.go
@@ -48,7 +48,7 @@ type WarnOnlyVerifier struct{}
 
 // Verify returns Verified for signed manifests and a Warning otherwise.
 func (WarnOnlyVerifier) Verify(manifest *Manifest, _ string) (VerificationOutcome, error) {
-	if manifest != nil && manifest.Signature != nil {
+	if manifest != nil && manifest.Signature.IsPresent() {
 		return Verified(), nil
 	}
 	return Warning("unsigned skill manifest"), nil


### PR DESCRIPTION
## Description

Hardens the `skill` package's pack loader and manifest verification, and reuses the `fs` package for path safety instead of hand-rolled filesystem handling. Skill packs are untrusted input, so the loader now fails closed on oversized files, non-UTF-8 bodies, symlinks, and any path that escapes the pack root, and it runs an injectable verifier before a pack is returned.

## Motivation

The previous loader read pack files with unbounded `os.ReadFile`, carried ad-hoc traversal checks, and exposed a byte-oriented verifier that could not express a warn-vs-deny outcome. That is unsafe for a surface that loads third-party skill packs and duplicated path-safety logic that the `fs` package already owns.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Module(s) Affected

- `skill`
- `fs`

## Changes Made

- Enforce size limits (manifest, body, per-asset, and aggregate-asset) on all untrusted pack files, with UTF-8 validation of the body; reads fail closed once a bound is exceeded.
- Reject symlinks and confine every pack path to the canonical pack root, failing closed on escape.
- Replace the signature-bytes verifier with an injectable `Verifier` returning a typed `VerificationOutcome` (verified / warning / denied); denial fails the load and warnings are surfaced on the pack and logged via an injected logger.
- Add classifiable sentinel errors for manifest, loading, verification, and registry failures, matchable with `errors.Is`.
- Reuse `fs` path-safety primitives (`Canonicalize`, `ConfineExistingPath`, `ValidateRelativePath`) and add `fs.ReadFileLimit` as the canonical bounded-read helper, removing the duplicated local implementations.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [x] `make lint` is clean (includes `vet` + `depguard` layering)
- [x] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [x] Manual testing performed (describe below if applicable)

### Test Evidence

```
$ cd skill && go test -race -shuffle=on -count=1 ./...
ok  github.com/kbukum/gokit/skill
$ go test -race -count=1 -coverprofile=... ./... && go tool cover -func | tail -1
total: (statements) 98.0%

$ cd fs && go test -race -shuffle=on -count=1 ./...
ok  github.com/kbukum/gokit/fs   (total 82.3%)

$ cd mcp && go build ./...   # skill consumers still build
```

## Breaking Changes

The `Verifier` interface changed from `Verify(manifestBytes []byte, sig Signature) error` to `Verify(manifest *Manifest, root string) (VerificationOutcome, error)`, `WarnOnlyVerifier` no longer carries a `Logger` field, and `ErrSignatureRejected` is removed in favor of a `VerificationDenied` outcome. This is a clean redesign rather than a shim; no in-repo consumer depends on the old surface.

## Sibling Parity

- [x] Sibling-parity tracked: this mirrors the `skill` loader/verifier shape in the reference kit (rskit); no public error-code or Component/Provider abstraction changed.

## Additional Notes

`fs` previously had no importers outside its own tests; wiring `skill` to reuse it (and adding `fs.ReadFileLimit`) is a deliberate step toward the shared filesystem-safety owner so future consumers do not re-roll path/size handling.
