### PR TITLE
feat(cli): add a terminal-UX kit (theming, output, progress, prompts, signals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **prompt**: a `Prompter` over a `Terminal` seam with a cooked-stdio `LineTerminal`, a
     deterministic `ScriptedTerminal` test double, validators, and a non-interactive fallback.
   - **signal**: graceful-shutdown helper mapping SIGINT/SIGTERM onto `context.Context`
-    cancelation via `signal.NotifyContext`.
+    cancellation via `signal.NotifyContext`.
   - **live**: a bounded multi-region console for concurrent streaming output.
 - Raw-mode rich TUI widgets are intentionally rskit-only.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OpenAI-compatible `/v1/completions` SSE helper (`OAICompatPredictStream`) with proper context
   cancellation and terminal error events.
 
+### Added — Terminal-UX cli kit
+- **cli** (NEW package, light mirror of rskit-cli): a parser-agnostic terminal-UX toolkit that
+  writes to injected `io.Writer`s and confines `fmt.Print*`/stdout to this package.
+  - **theme**: semantic `Palette` colors and `Glyphs`, resolving `NO_COLOR`, TTY, and UTF-8
+    locale capability with byte-clean ASCII fallbacks.
+  - **render**: `OutputTable`, `OutputKV`, `StatusReporter`, `OutputFormat`, and an
+    `ErrorRenderer`/`ExitCode` mapping RFC 9457 `AppError`s onto a CLI exit-code convention.
+  - **progress**: determinate `Bar` and indeterminate `Spinner`, caller-driven (no background
+    timer) so they render deterministically without a clock.
+  - **prompt**: a `Prompter` over a `Terminal` seam with a cooked-stdio `LineTerminal`, a
+    deterministic `ScriptedTerminal` test double, validators, and a non-interactive fallback.
+  - **signal**: graceful-shutdown helper mapping SIGINT/SIGTERM onto `context.Context`
+    cancelation via `signal.NotifyContext`.
+  - **live**: a bounded multi-region console for concurrent streaming output.
+- Raw-mode rich TUI widgets are intentionally rskit-only.
+
 ### Added — Foundational Parity (codec, fs)
 - **codec** (NEW module): generics-first `Codec` with `Encode[T]`/`Decode[T]` over a
   documented opaque `Value` tree; `JSONCodec` (pretty/compact), `TOMLCodec`,

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,8 +39,10 @@ import (
 )
 
 func main() {
-	// Resolve styling once against the output stream's capability.
-	palette := theme.PaletteForStream(theme.ColorAuto, isTTY(os.Stderr))
+	// Resolve styling once against the output stream's capability. TTY
+	// detection is the caller's concern; wire it to your terminal check.
+	stderrIsTTY := false
+	palette := theme.PaletteForStream(theme.ColorAuto, stderrIsTTY)
 	status := render.NewStatusReporter(os.Stderr, palette, theme.GlyphsFromEnv())
 
 	_ = status.Heading("Building")

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,8 +4,9 @@ A parser-agnostic terminal-UX toolkit for gokit command-line programs. It is not
 a flag parser; it owns the presentation, input, and cancellation concerns a CLI
 shares, so every gokit CLI renders and behaves consistently.
 
-`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and is
-dependency-free (standard library only). It is the **light** Go mirror of rskit's
+`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and leans on the
+standard library, with `go.yaml.in/yaml/v3` (for `render`'s YAML output) as its
+only external dependency. It is the **light** Go mirror of rskit's
 `rskit-cli`: theming, structured output, progress, prompts, signals, and a
 bounded live console. Heavy raw-mode rich widgets (arrow-key radio/checkbox
 lists) stay rskit-only by design.
@@ -18,7 +19,7 @@ lists) stay rskit-only by design.
 
 | Package | What it owns |
 |---|---|
-| [`theme`](theme) | Semantic color `Palette` and status `Glyphs`, honouring `NO_COLOR`, TTY, and UTF-8 capability |
+| [`theme`](theme) | Semantic color `Palette` and status `Glyphs`, honoring `NO_COLOR`, TTY, and UTF-8 capability |
 | [`render`](render) | `OutputTable`, `OutputKV`, `StatusReporter`, and `ErrorRenderer`/`ExitCode`/`OutputFormat` |
 | [`progress`](progress) | Deterministic `Bar` and `Spinner` over an injected writer |
 | [`prompt`](prompt) | `Prompter` with line + scripted terminals, non-interactive fallback, and validators |

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,70 @@
+# cli
+
+A parser-agnostic terminal-UX toolkit for gokit command-line programs. It is not
+a flag parser; it owns the presentation, input, and cancellation concerns a CLI
+shares, so every gokit CLI renders and behaves consistently.
+
+`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and is
+dependency-free (standard library only). It is the **light** Go mirror of rskit's
+`rskit-cli`: theming, structured output, progress, prompts, signals, and a
+bounded live console. Heavy raw-mode rich widgets (arrow-key radio/checkbox
+lists) stay rskit-only by design.
+
+> This is the one gokit module where writing to stdout/stderr is expected. Every
+> renderer takes an injected `io.Writer`; every other module uses the injected
+> logger.
+
+## Packages
+
+| Package | What it owns |
+|---|---|
+| [`theme`](theme) | Semantic color `Palette` and status `Glyphs`, honouring `NO_COLOR`, TTY, and UTF-8 capability |
+| [`render`](render) | `OutputTable`, `OutputKV`, `StatusReporter`, and `ErrorRenderer`/`ExitCode`/`OutputFormat` |
+| [`progress`](progress) | Deterministic `Bar` and `Spinner` over an injected writer |
+| [`prompt`](prompt) | `Prompter` with line + scripted terminals, non-interactive fallback, and validators |
+| [`signal`](signal) | Interrupt handling as `context.Context` cancellation |
+| [`live`](live) | A bounded multi-region live `Console` for concurrent streaming output |
+
+## Quick start
+
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/kbukum/gokit/cli/render"
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+func main() {
+	// Resolve styling once against the output stream's capability.
+	palette := theme.PaletteForStream(theme.ColorAuto, isTTY(os.Stderr))
+	status := render.NewStatusReporter(os.Stderr, palette, theme.GlyphsFromEnv())
+
+	_ = status.Heading("Building")
+	_ = status.Step(1, 2, "Compiling")
+	_ = status.Success("Done")
+
+	table := render.NewOutputTable("Name", "Count").
+		AddRow("real", "500").
+		AddRow("ai", "500")
+	os.Stdout.WriteString(table.String() + "\n")
+}
+```
+
+## Determinism
+
+Everything is testable without a real terminal:
+
+- `prompt.ScriptedTerminal` replays canned input and captures output.
+- `progress.Bar`/`progress.Spinner` advance only when the caller updates them —
+  no clock, no background goroutine.
+- `live.Console` redraws only on `Render()`, writing to an injected writer.
+
+## Capability split (light by design)
+
+gokit `cli` mirrors rskit's *surface* idiomatically but stays light: it lands
+theme/render/progress/prompt/signal plus a bounded live console. A full raw-mode
+rich TUI (live arrow-key navigation via a terminal driver dependency) stays
+rskit-only — the line-driven prompt path is always available and dependency-free.

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -1,0 +1,23 @@
+// Package cli is a parser-agnostic terminal-UX toolkit for building consistent
+// command-line experiences across gokit services.
+//
+// It is not a flag parser; it owns the presentation, input, and cancelation
+// concerns a CLI shares, split into focused sub-packages:
+//
+//   - [github.com/kbukum/gokit/cli/theme] — semantic color palette and status
+//     glyphs honoring NO_COLOR, TTY detection, and UTF-8 capability.
+//   - [github.com/kbukum/gokit/cli/render] — structured output: tables,
+//     key-value blocks, status lines, and error/exit-code rendering.
+//   - [github.com/kbukum/gokit/cli/progress] — deterministic progress bars and
+//     spinners over an injected writer.
+//   - [github.com/kbukum/gokit/cli/prompt] — interactive prompts (line terminal
+//     plus a scripted test terminal) with a non-interactive fallback.
+//   - [github.com/kbukum/gokit/cli/signal] — interrupt handling as
+//     [context.Context] cancelation.
+//   - [github.com/kbukum/gokit/cli/live] — a bounded multi-region live console
+//     for concurrent streaming output.
+//
+// Every renderer writes to an injected io.Writer; this is the one gokit module
+// where writing to stdout/stderr is expected — every other module uses the
+// injected logger.
+package cli

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -1,7 +1,7 @@
 // Package cli is a parser-agnostic terminal-UX toolkit for building consistent
 // command-line experiences across gokit services.
 //
-// It is not a flag parser; it owns the presentation, input, and cancelation
+// It is not a flag parser; it owns the presentation, input, and cancellation
 // concerns a CLI shares, split into focused sub-packages:
 //
 //   - [github.com/kbukum/gokit/cli/theme] — semantic color palette and status
@@ -13,11 +13,11 @@
 //   - [github.com/kbukum/gokit/cli/prompt] — interactive prompts (line terminal
 //     plus a scripted test terminal) with a non-interactive fallback.
 //   - [github.com/kbukum/gokit/cli/signal] — interrupt handling as
-//     [context.Context] cancelation.
+//     [context.Context] cancellation.
 //   - [github.com/kbukum/gokit/cli/live] — a bounded multi-region live console
 //     for concurrent streaming output.
 //
-// Every renderer writes to an injected io.Writer; this is the one gokit module
-// where writing to stdout/stderr is expected — every other module uses the
-// injected logger.
+// Rendering targets an injected io.Writer or returns a string the caller writes;
+// this is the one gokit module where writing to stdout/stderr is expected —
+// every other module uses the injected logger.
 package cli

--- a/cli/live/console.go
+++ b/cli/live/console.go
@@ -1,0 +1,125 @@
+package live
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/kbukum/gokit/cli/theme"
+	"github.com/kbukum/gokit/errors"
+)
+
+const (
+	// defaultMaxRegions bounds how many concurrent tiles a console shows.
+	defaultMaxRegions = 8
+	// defaultRegionHeight bounds how many recent lines each tile retains.
+	defaultRegionHeight = 5
+)
+
+// Config bounds a [Console]'s live area. The zero value is completed by
+// [NewConsole] with the package defaults.
+type Config struct {
+	// MaxRegions caps the number of concurrent regions; [Console.AddRegion]
+	// rejects further regions once reached (documented backpressure).
+	MaxRegions int
+	// RegionHeight caps the recent lines each region retains in the live view;
+	// older lines scroll out of the ephemeral peek (documented per-region bound).
+	RegionHeight int
+}
+
+func (c Config) withDefaults() Config {
+	if c.MaxRegions <= 0 {
+		c.MaxRegions = defaultMaxRegions
+	}
+	if c.RegionHeight <= 0 {
+		c.RegionHeight = defaultRegionHeight
+	}
+	return c
+}
+
+// Console is a bounded multi-region live console over an injected writer.
+//
+// It is safe for concurrent use: regions may be appended to from separate
+// goroutines while the owner periodically calls [Console.Render]. Ownership,
+// cancelation, and render cadence belong to the caller — the console itself
+// spawns no goroutines.
+type Console struct {
+	writer  io.Writer
+	palette theme.Palette
+	config  Config
+
+	mu        sync.Mutex
+	regions   []*Region
+	lastFrame int
+}
+
+// NewConsole creates a live console writing to w, bounded by config.
+func NewConsole(w io.Writer, config Config, palette theme.Palette) *Console {
+	return &Console{writer: w, palette: palette, config: config.withDefaults()}
+}
+
+// AddRegion appends a new tile titled title.
+//
+// It returns an error once the configured [Config.MaxRegions] bound is reached,
+// so callers apply backpressure rather than growing the live area without limit.
+func (c *Console) AddRegion(title string) (*Region, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.regions) >= c.config.MaxRegions {
+		return nil, errors.InvalidInput("live", fmt.Sprintf("region limit reached (max %d)", c.config.MaxRegions))
+	}
+	region := &Region{title: title, height: c.config.RegionHeight}
+	c.regions = append(c.regions, region)
+	return region, nil
+}
+
+// Render redraws the whole live area in place: it moves the cursor up over the
+// previous frame, clears it, and writes the current tiles.
+func (c *Console) Render() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var b strings.Builder
+	if c.lastFrame > 0 {
+		fmt.Fprintf(&b, "\x1b[%dA\x1b[0J", c.lastFrame)
+	}
+	lines := 0
+	for _, region := range c.regions {
+		b.WriteString(c.palette.Bold(region.title))
+		b.WriteByte('\n')
+		lines++
+		for _, line := range region.snapshot() {
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+			lines++
+		}
+	}
+	c.lastFrame = lines
+	if _, err := io.WriteString(c.writer, b.String()); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+// Finish clears the live area and writes each region's durable verdict to
+// scrollback, so the terminal retains signal rather than transient progress.
+func (c *Console) Finish() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var b strings.Builder
+	if c.lastFrame > 0 {
+		fmt.Fprintf(&b, "\x1b[%dA\x1b[0J", c.lastFrame)
+	}
+	c.lastFrame = 0
+	for _, region := range c.regions {
+		b.WriteString(region.verdictLine(c.palette))
+		b.WriteByte('\n')
+	}
+	if _, err := io.WriteString(c.writer, b.String()); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}

--- a/cli/live/console.go
+++ b/cli/live/console.go
@@ -42,11 +42,12 @@ func (c Config) withDefaults() Config {
 //
 // It is safe for concurrent use: regions may be appended to from separate
 // goroutines while the owner periodically calls [Console.Render]. Ownership,
-// cancelation, and render cadence belong to the caller — the console itself
+// cancellation, and render cadence belong to the caller — the console itself
 // spawns no goroutines.
 type Console struct {
 	writer  io.Writer
 	palette theme.Palette
+	glyphs  theme.Glyphs
 	config  Config
 
 	mu        sync.Mutex
@@ -54,9 +55,11 @@ type Console struct {
 	lastFrame int
 }
 
-// NewConsole creates a live console writing to w, bounded by config.
-func NewConsole(w io.Writer, config Config, palette theme.Palette) *Console {
-	return &Console{writer: w, palette: palette, config: config.withDefaults()}
+// NewConsole creates a live console writing to w, bounded by config. The glyph
+// set selects the verdict symbols so [Console.Finish] stays byte-clean on
+// non-UTF-8 terminals.
+func NewConsole(w io.Writer, config Config, palette theme.Palette, glyphs theme.Glyphs) *Console {
+	return &Console{writer: w, palette: palette, glyphs: glyphs, config: config.withDefaults()}
 }
 
 // AddRegion appends a new tile titled title.
@@ -115,7 +118,7 @@ func (c *Console) Finish() error {
 	}
 	c.lastFrame = 0
 	for _, region := range c.regions {
-		b.WriteString(region.verdictLine(c.palette))
+		b.WriteString(region.verdictLine(c.palette, c.glyphs))
 		b.WriteByte('\n')
 	}
 	if _, err := io.WriteString(c.writer, b.String()); err != nil {

--- a/cli/live/doc.go
+++ b/cli/live/doc.go
@@ -6,7 +6,7 @@
 // its most recent lines (a documented per-region bound), and the number of
 // regions is capped (a documented backpressure bound), so a flood of transient
 // progress never grows without limit. Durable signal — a region's final verdict
-// — is written to scrollback above the live area on [Region.Finish].
+// — is written to scrollback above the live area on [Console.Finish].
 //
 // Rendering is deterministic and clock-free: the console redraws only when the
 // caller calls [Console.Render], writing to an injected [io.Writer], so it is

--- a/cli/live/doc.go
+++ b/cli/live/doc.go
@@ -1,0 +1,14 @@
+// Package live provides a bounded, multi-region live console for streaming
+// several concurrent outputs as fixed-height tiles.
+//
+// [Console] stacks each [Region] as a bounded tile in a live area that is
+// redrawn in place. The tiles are an ephemeral peek: each region retains only
+// its most recent lines (a documented per-region bound), and the number of
+// regions is capped (a documented backpressure bound), so a flood of transient
+// progress never grows without limit. Durable signal — a region's final verdict
+// — is written to scrollback above the live area on [Region.Finish].
+//
+// Rendering is deterministic and clock-free: the console redraws only when the
+// caller calls [Console.Render], writing to an injected [io.Writer], so it is
+// fully testable without a real terminal.
+package live

--- a/cli/live/doc.go
+++ b/cli/live/doc.go
@@ -10,5 +10,7 @@
 //
 // Rendering is deterministic and clock-free: the console redraws only when the
 // caller calls [Console.Render], writing to an injected [io.Writer], so it is
-// fully testable without a real terminal.
+// fully testable without a real terminal. Redrawing emits ANSI cursor-movement
+// and clear sequences, so bind it to a terminal writer — a non-TTY sink (log or
+// pipe) receives raw escape codes.
 package live

--- a/cli/live/live_test.go
+++ b/cli/live/live_test.go
@@ -1,0 +1,156 @@
+package live_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kbukum/gokit/cli/live"
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+func newConsole(buf *bytes.Buffer, cfg live.Config) *live.Console {
+	return live.NewConsole(buf, cfg, theme.NewPalette(false))
+}
+
+func TestConsoleRendersRegionTilesAndLatestLines(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{MaxRegions: 4, RegionHeight: 3})
+	region, err := console.AddRegion("build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	region.Println("compiling")
+	region.Println("linking")
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "build") || !strings.Contains(out, "compiling") || !strings.Contains(out, "linking") {
+		t.Errorf("render missing content:\n%s", out)
+	}
+}
+
+func TestRegionRetainsOnlyRecentLines(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{MaxRegions: 2, RegionHeight: 2})
+	region, _ := console.AddRegion("task")
+	region.Println("one")
+	region.Println("two")
+	region.Println("three")
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "one") {
+		t.Errorf("scrolled-out line must drop from live view:\n%s", out)
+	}
+	if !strings.Contains(out, "two") || !strings.Contains(out, "three") {
+		t.Errorf("recent lines must be retained:\n%s", out)
+	}
+}
+
+func TestSecondRenderOverwritesPreviousFrame(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{MaxRegions: 2, RegionHeight: 3})
+	region, _ := console.AddRegion("task")
+	region.Println("first")
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	region.Println("second")
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	// Second frame must move the cursor up to overwrite the prior frame.
+	if !strings.Contains(out, "\x1b[") || !strings.Contains(out, "A") {
+		t.Errorf("second render must reposition cursor:\n%q", out)
+	}
+}
+
+func TestAddRegionEnforcesMaxRegionsBound(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{MaxRegions: 1, RegionHeight: 2})
+	if _, err := console.AddRegion("a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := console.AddRegion("b"); err == nil {
+		t.Error("exceeding MaxRegions must error (backpressure)")
+	}
+}
+
+func TestFinishWritesDurableVerdicts(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := live.NewConsole(&buf, live.Config{MaxRegions: 3, RegionHeight: 2}, theme.NewPalette(false))
+	ok, _ := console.AddRegion("build")
+	ok.Println("...")
+	ok.Done("passed")
+	bad, _ := console.AddRegion("test")
+	bad.Fail("2 failures")
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := console.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✓ build: passed") {
+		t.Errorf("done verdict missing:\n%s", out)
+	}
+	if !strings.Contains(out, "✗ test: 2 failures") {
+		t.Errorf("failed verdict missing:\n%s", out)
+	}
+}
+
+func TestConfigDefaultsApplied(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{})
+	// Defaults allow several regions; add a handful without error.
+	for range 8 {
+		if _, err := console.AddRegion("r"); err != nil {
+			t.Fatalf("default MaxRegions too small: %v", err)
+		}
+	}
+}
+
+func TestRegionConcurrentAppendsAreRaceFree(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := newConsole(&buf, live.Config{MaxRegions: 4, RegionHeight: 10})
+	region, _ := console.AddRegion("worker")
+
+	var wg sync.WaitGroup
+	for i := range 4 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := range 20 {
+				region.Println("line")
+				_ = n
+				_ = j
+			}
+		}(i)
+	}
+	// Render concurrently with appends to exercise the lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 10 {
+			_ = console.Render()
+		}
+	}()
+	wg.Wait()
+	if err := console.Render(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/live/live_test.go
+++ b/cli/live/live_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newConsole(buf *bytes.Buffer, cfg live.Config) *live.Console {
-	return live.NewConsole(buf, cfg, theme.NewPalette(false))
+	return live.NewConsole(buf, cfg, theme.NewPalette(false), theme.NewGlyphs(true))
 }
 
 func TestConsoleRendersRegionTilesAndLatestLines(t *testing.T) {
@@ -89,7 +89,7 @@ func TestAddRegionEnforcesMaxRegionsBound(t *testing.T) {
 func TestFinishWritesDurableVerdicts(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	console := live.NewConsole(&buf, live.Config{MaxRegions: 3, RegionHeight: 2}, theme.NewPalette(false))
+	console := live.NewConsole(&buf, live.Config{MaxRegions: 3, RegionHeight: 2}, theme.NewPalette(false), theme.NewGlyphs(true))
 	ok, _ := console.AddRegion("build")
 	ok.Println("...")
 	ok.Done("passed")
@@ -108,6 +108,26 @@ func TestFinishWritesDurableVerdicts(t *testing.T) {
 	}
 	if !strings.Contains(out, "✗ test: 2 failures") {
 		t.Errorf("failed verdict missing:\n%s", out)
+	}
+}
+
+func TestFinishUsesASCIIVerdictsWhenGlyphsDisabled(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	console := live.NewConsole(&buf, live.Config{MaxRegions: 2, RegionHeight: 1}, theme.NewPalette(false), theme.NewGlyphs(false))
+	ok, _ := console.AddRegion("build")
+	ok.Done("passed")
+	bad, _ := console.AddRegion("test")
+	bad.Fail("2 failures")
+	if err := console.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "v build: passed") || !strings.Contains(out, "x test: 2 failures") {
+		t.Errorf("ASCII verdicts missing:\n%s", out)
+	}
+	if strings.ContainsAny(out, "✓✗") {
+		t.Errorf("unicode glyphs leaked into ASCII output:\n%s", out)
 	}
 }
 

--- a/cli/live/region.go
+++ b/cli/live/region.go
@@ -68,7 +68,7 @@ func (r *Region) snapshot() []string {
 }
 
 // verdictLine renders the region's durable one-line verdict for scrollback.
-func (r *Region) verdictLine(palette theme.Palette) string {
+func (r *Region) verdictLine(palette theme.Palette, glyphs theme.Glyphs) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	label := r.title
@@ -77,10 +77,10 @@ func (r *Region) verdictLine(palette theme.Palette) string {
 	}
 	switch r.status {
 	case statusDone:
-		return palette.Success("✓ " + label)
+		return palette.Success(glyphs.Success() + " " + label)
 	case statusFailed:
-		return palette.Error("✗ " + label)
+		return palette.Error(glyphs.Error() + " " + label)
 	default:
-		return palette.Dim("… " + label)
+		return palette.Dim(glyphs.Ellipsis() + " " + label)
 	}
 }

--- a/cli/live/region.go
+++ b/cli/live/region.go
@@ -1,0 +1,86 @@
+package live
+
+import (
+	"sync"
+
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+// regionStatus is a region's terminal verdict.
+type regionStatus int
+
+const (
+	statusRunning regionStatus = iota
+	statusDone
+	statusFailed
+)
+
+// Region is a single bounded tile within a [Console].
+//
+// It retains only its most recent lines (up to the console's configured height);
+// older lines scroll out of the live peek. A region is safe to append to from a
+// goroutine separate from the one rendering the console.
+type Region struct {
+	title  string
+	height int
+
+	mu     sync.Mutex
+	lines  []string
+	status regionStatus
+	reason string
+}
+
+// Println appends a line to the region, dropping the oldest retained line once
+// the height bound is exceeded (the ephemeral-peek bound).
+func (r *Region) Println(line string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lines = append(r.lines, line)
+	if len(r.lines) > r.height {
+		r.lines = r.lines[len(r.lines)-r.height:]
+	}
+}
+
+// Done marks the region complete with a short summary shown on
+// [Console.Finish].
+func (r *Region) Done(summary string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = statusDone
+	r.reason = summary
+}
+
+// Fail marks the region failed with a reason shown on [Console.Finish].
+func (r *Region) Fail(reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = statusFailed
+	r.reason = reason
+}
+
+// snapshot returns a copy of the currently retained live lines.
+func (r *Region) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.lines))
+	copy(out, r.lines)
+	return out
+}
+
+// verdictLine renders the region's durable one-line verdict for scrollback.
+func (r *Region) verdictLine(palette theme.Palette) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	label := r.title
+	if r.reason != "" {
+		label = r.title + ": " + r.reason
+	}
+	switch r.status {
+	case statusDone:
+		return palette.Success("✓ " + label)
+	case statusFailed:
+		return palette.Error("✗ " + label)
+	default:
+		return palette.Dim("… " + label)
+	}
+}

--- a/cli/progress/bar.go
+++ b/cli/progress/bar.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/kbukum/gokit/cli/theme"
@@ -88,10 +89,15 @@ func (b *Bar) Finish() error {
 
 // Percent returns the completion percentage in [0, 100].
 func (b *Bar) Percent() int {
-	if b.total <= 0 {
+	if b.total <= 0 || b.pos >= b.total {
 		return 100
 	}
-	return int(b.pos * 100 / b.total)
+	// Integer math is exact for realistic totals; fall back to float64 (percent
+	// is coarse) only when pos*100 would overflow int64.
+	if b.pos <= math.MaxInt64/100 {
+		return int(b.pos * 100 / b.total)
+	}
+	return int(float64(b.pos) / float64(b.total) * 100)
 }
 
 func (b *Bar) render() error {

--- a/cli/progress/bar.go
+++ b/cli/progress/bar.go
@@ -53,6 +53,9 @@ func WithBarPalette(palette theme.Palette) BarOption {
 // NewBar creates a bar for total units of work writing to w. A non-positive
 // total renders as an immediately complete bar.
 func NewBar(w io.Writer, total int64, opts ...BarOption) *Bar {
+	if total < 0 {
+		total = 0
+	}
 	b := &Bar{writer: w, palette: theme.NewPalette(false), width: defaultBarWidth, total: total}
 	for _, opt := range opts {
 		opt(b)

--- a/cli/progress/bar.go
+++ b/cli/progress/bar.go
@@ -1,0 +1,124 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kbukum/gokit/cli/theme"
+	"github.com/kbukum/gokit/errors"
+)
+
+// defaultBarWidth is the character width of the filled/empty gauge.
+const defaultBarWidth = 20
+
+// Bar is a determinate progress bar over an injected writer.
+//
+// Each render overwrites the current terminal line (a leading carriage return),
+// so successive updates animate in place; [Bar.Finish] moves to a fresh line.
+// The bar only advances when the caller moves its position, so it is fully
+// deterministic without a clock.
+type Bar struct {
+	writer  io.Writer
+	palette theme.Palette
+	prefix  string
+	width   int
+	total   int64
+	pos     int64
+}
+
+// BarOption configures a [Bar].
+type BarOption func(*Bar)
+
+// WithBarPrefix sets a label rendered before the gauge.
+func WithBarPrefix(prefix string) BarOption {
+	return func(b *Bar) { b.prefix = prefix }
+}
+
+// WithBarWidth sets the character width of the gauge (values below 1 are
+// ignored).
+func WithBarWidth(width int) BarOption {
+	return func(b *Bar) {
+		if width > 0 {
+			b.width = width
+		}
+	}
+}
+
+// WithBarPalette styles the filled gauge and percentage with a palette.
+func WithBarPalette(palette theme.Palette) BarOption {
+	return func(b *Bar) { b.palette = palette }
+}
+
+// NewBar creates a bar for total units of work writing to w. A non-positive
+// total renders as an immediately complete bar.
+func NewBar(w io.Writer, total int64, opts ...BarOption) *Bar {
+	b := &Bar{writer: w, palette: theme.NewPalette(false), width: defaultBarWidth, total: total}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// SetPosition sets the current position, clamped to [0, total], and renders.
+func (b *Bar) SetPosition(pos int64) error {
+	b.pos = clamp(pos, 0, b.total)
+	return b.render()
+}
+
+// Inc advances the position by delta (clamped) and renders.
+func (b *Bar) Inc(delta int64) error {
+	return b.SetPosition(b.pos + delta)
+}
+
+// Finish fills the bar and moves to a fresh line.
+func (b *Bar) Finish() error {
+	b.pos = b.total
+	if err := b.render(); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(b.writer, "\n"); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+// Percent returns the completion percentage in [0, 100].
+func (b *Bar) Percent() int {
+	if b.total <= 0 {
+		return 100
+	}
+	return int(b.pos * 100 / b.total)
+}
+
+func (b *Bar) render() error {
+	pct := b.Percent()
+	filled := b.width * pct / 100
+	gauge := b.palette.Success(strings.Repeat("#", filled)) + strings.Repeat("-", b.width-filled)
+	line := fmt.Sprintf("\r%s[%s] %d/%d %s",
+		prefixSpace(b.prefix), gauge, b.pos, b.total, b.palette.Bold(fmt.Sprintf("%d%%", pct)))
+	if _, err := io.WriteString(b.writer, line); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+func prefixSpace(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return prefix + " "
+}
+
+func clamp(v, lo, hi int64) int64 {
+	if hi < lo {
+		return lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/cli/progress/doc.go
+++ b/cli/progress/doc.go
@@ -1,0 +1,10 @@
+// Package progress renders progress bars and spinners over an injected writer.
+//
+// It is the light, dependency-free counterpart to a full progress library: a
+// [Bar] shows determinate work ("[####----] 4/10 40%") and a [Spinner] shows
+// indeterminate work by cycling frames. Both write to an injected [io.Writer]
+// and advance only when the caller updates them — position for the bar, an
+// explicit tick for the spinner — so rendering is deterministic and needs no
+// real clock or background goroutine. Styling flows through an optional
+// [github.com/kbukum/gokit/cli/theme.Palette].
+package progress

--- a/cli/progress/progress_test.go
+++ b/cli/progress/progress_test.go
@@ -2,6 +2,7 @@ package progress_test
 
 import (
 	"bytes"
+	"math"
 	"strings"
 	"testing"
 
@@ -219,6 +220,25 @@ func TestBarNegativeTotalRendersComplete(t *testing.T) {
 	}
 	if bar.Percent() != 100 {
 		t.Errorf("negative-total bar percent = %d, want 100", bar.Percent())
+	}
+}
+
+func TestBarPercentHandlesHugeTotalsWithoutOverflow(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	const huge = math.MaxInt64
+	bar := progress.NewBar(&buf, huge)
+	if err := bar.SetPosition(huge / 2); err != nil {
+		t.Fatal(err)
+	}
+	if got := bar.Percent(); got < 49 || got > 51 {
+		t.Errorf("percent at half of MaxInt64 = %d, want ~50 (no overflow)", got)
+	}
+	if err := bar.SetPosition(huge); err != nil {
+		t.Fatal(err)
+	}
+	if got := bar.Percent(); got != 100 {
+		t.Errorf("percent at full MaxInt64 = %d, want 100", got)
 	}
 }
 

--- a/cli/progress/progress_test.go
+++ b/cli/progress/progress_test.go
@@ -1,0 +1,257 @@
+package progress_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/cli/progress"
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+func TestBarRendersPositionAndPercent(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 10, progress.WithBarWidth(10), progress.WithBarPrefix("build"))
+	if err := bar.SetPosition(4); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "build") {
+		t.Errorf("bar missing prefix: %q", out)
+	}
+	if !strings.Contains(out, "4/10") || !strings.Contains(out, "40%") {
+		t.Errorf("bar counters wrong: %q", out)
+	}
+	if !strings.HasPrefix(out, "\r") {
+		t.Errorf("bar must lead with carriage return: %q", out)
+	}
+	if !strings.Contains(out, "####------") {
+		t.Errorf("bar gauge wrong: %q", out)
+	}
+}
+
+func TestBarIncAccumulates(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 4, progress.WithBarWidth(4))
+	for range 4 {
+		if err := bar.Inc(1); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if bar.Percent() != 100 {
+		t.Errorf("percent = %d, want 100", bar.Percent())
+	}
+}
+
+func TestBarClampsOutOfRange(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 10)
+	if err := bar.SetPosition(-5); err != nil {
+		t.Fatal(err)
+	}
+	if bar.Percent() != 0 {
+		t.Errorf("negative clamps to 0, got %d", bar.Percent())
+	}
+	if err := bar.SetPosition(100); err != nil {
+		t.Fatal(err)
+	}
+	if bar.Percent() != 100 {
+		t.Errorf("over-total clamps to 100, got %d", bar.Percent())
+	}
+}
+
+func TestBarZeroTotalIsComplete(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 0)
+	if bar.Percent() != 100 {
+		t.Errorf("zero-total bar percent = %d, want 100", bar.Percent())
+	}
+}
+
+func TestBarFinishEndsOnFreshLine(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 10)
+	if err := bar.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("finish must end with newline: %q", buf.String())
+	}
+}
+
+func TestBarPaletteEmitsColor(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, 10, progress.WithBarPalette(theme.NewPalette(true)))
+	if err := bar.SetPosition(5); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "\x1b") {
+		t.Errorf("colored bar must emit escapes: %q", buf.String())
+	}
+}
+
+func TestSpinnerTickAdvancesFramesDeterministically(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	spin := progress.NewSpinner(&buf, progress.WithSpinnerMessage("working"))
+	for range 5 {
+		if err := spin.Tick(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := buf.String()
+	// ASCII frames cycle |, /, -, \, then wrap to | again.
+	frames := strings.Count(out, "\r")
+	if frames != 5 {
+		t.Errorf("expected 5 rendered frames, got %d: %q", frames, out)
+	}
+	if !strings.Contains(out, "working") {
+		t.Errorf("spinner missing message: %q", out)
+	}
+	if strings.Contains(out, "⠋") {
+		t.Errorf("ascii spinner must stay byte-clean: %q", out)
+	}
+}
+
+func TestSpinnerUnicodeFrames(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	spin := progress.NewSpinner(&buf, progress.WithSpinnerGlyphs(theme.NewGlyphs(true)))
+	if err := spin.Tick(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "⠋") {
+		t.Errorf("unicode spinner must use braille frames: %q", buf.String())
+	}
+}
+
+func TestSpinnerFinishWritesSuccessGlyphAfterSetMessage(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	spin := progress.NewSpinner(&buf, progress.WithSpinnerGlyphs(theme.NewGlyphs(true)))
+	spin.SetMessage("working")
+	if err := spin.Tick(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "working") {
+		t.Errorf("tick must render the set message: %q", buf.String())
+	}
+	if err := spin.Finish("done"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "done") {
+		t.Errorf("finish line = %q", out)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("finish must end on a fresh line: %q", out)
+	}
+}
+
+func TestSpinnerPaletteEmitsColor(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	spin := progress.NewSpinner(&buf, progress.WithSpinnerPalette(theme.NewPalette(true)))
+	if err := spin.Tick(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "\x1b") {
+		t.Errorf("colored spinner must emit escapes: %q", buf.String())
+	}
+}
+
+func TestSpinnerASCIIGlyphsUseFallbackFrames(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	spin := progress.NewSpinner(&buf, progress.WithSpinnerGlyphs(theme.NewGlyphs(false)))
+	if err := spin.Tick(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "⠋") {
+		t.Errorf("ascii glyph set must stay byte-clean: %q", buf.String())
+	}
+}
+
+func TestSpinnerTickPropagatesWriteError(t *testing.T) {
+	t.Parallel()
+	spin := progress.NewSpinner(failWriter{})
+	if err := spin.Tick(); err == nil {
+		t.Error("tick must surface a write failure")
+	}
+}
+
+func TestSpinnerFinishPropagatesWriteError(t *testing.T) {
+	t.Parallel()
+	spin := progress.NewSpinner(failWriter{})
+	if err := spin.Finish("done"); err == nil {
+		t.Error("finish must surface a write failure")
+	}
+}
+
+func TestBarRenderPropagatesWriteError(t *testing.T) {
+	t.Parallel()
+	bar := progress.NewBar(failWriter{}, 10)
+	if err := bar.SetPosition(5); err == nil {
+		t.Error("render must surface a write failure")
+	}
+}
+
+func TestBarFinishPropagatesWriteError(t *testing.T) {
+	t.Parallel()
+	bar := progress.NewBar(failWriter{}, 10)
+	if err := bar.Finish(); err == nil {
+		t.Error("finish must surface a write failure")
+	}
+}
+
+func TestBarNegativeTotalRendersComplete(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	bar := progress.NewBar(&buf, -1)
+	if err := bar.SetPosition(5); err != nil {
+		t.Fatal(err)
+	}
+	if bar.Percent() != 100 {
+		t.Errorf("negative-total bar percent = %d, want 100", bar.Percent())
+	}
+}
+
+func TestBarFinishPropagatesNewlineWriteError(t *testing.T) {
+	t.Parallel()
+	// Succeed on the gauge render, fail on the trailing newline write.
+	bar := progress.NewBar(&flakyWriter{failAfter: 1}, 10)
+	if err := bar.Finish(); err == nil {
+		t.Error("finish must surface the trailing-newline write failure")
+	}
+}
+
+// failWriter always fails, so error propagation through the renderers is
+// deterministic without a real terminal.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errString("write failed") }
+
+// flakyWriter succeeds for the first failAfter writes, then fails, exercising
+// error paths that only trigger on a later write.
+type flakyWriter struct {
+	failAfter int
+	count     int
+}
+
+func (w *flakyWriter) Write(p []byte) (int, error) {
+	w.count++
+	if w.count > w.failAfter {
+		return 0, errString("write failed")
+	}
+	return len(p), nil
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/cli/progress/spinner.go
+++ b/cli/progress/spinner.go
@@ -1,0 +1,92 @@
+package progress
+
+import (
+	"io"
+
+	"github.com/kbukum/gokit/cli/theme"
+	"github.com/kbukum/gokit/errors"
+)
+
+// asciiSpinnerFrames is the pipe-clean fallback frame sequence.
+var asciiSpinnerFrames = []string{"|", "/", "-", "\\"}
+
+// unicodeSpinnerFrames is the braille spinner used on UTF-8 terminals.
+var unicodeSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Spinner is an indeterminate progress indicator over an injected writer.
+//
+// It advances one frame per [Spinner.Tick], so animation is driven by the caller
+// rather than a background timer — deterministic and clock-free. Each tick
+// overwrites the current line (leading carriage return); [Spinner.Finish]
+// replaces the spinner with a final glyph and message on a fresh line.
+type Spinner struct {
+	writer  io.Writer
+	palette theme.Palette
+	glyphs  theme.Glyphs
+	frames  []string
+	message string
+	index   int
+}
+
+// SpinnerOption configures a [Spinner].
+type SpinnerOption func(*Spinner)
+
+// WithSpinnerMessage sets the message rendered beside the spinner frame.
+func WithSpinnerMessage(message string) SpinnerOption {
+	return func(s *Spinner) { s.message = message }
+}
+
+// WithSpinnerPalette styles the spinner frame with a palette.
+func WithSpinnerPalette(palette theme.Palette) SpinnerOption {
+	return func(s *Spinner) { s.palette = palette }
+}
+
+// WithSpinnerGlyphs selects Unicode braille frames when the glyph set supports
+// Unicode, else the ASCII fallback, and sets the completion glyph.
+func WithSpinnerGlyphs(glyphs theme.Glyphs) SpinnerOption {
+	return func(s *Spinner) {
+		s.glyphs = glyphs
+		if glyphs.Unicode() {
+			s.frames = unicodeSpinnerFrames
+		} else {
+			s.frames = asciiSpinnerFrames
+		}
+	}
+}
+
+// NewSpinner creates a spinner writing to w.
+func NewSpinner(w io.Writer, opts ...SpinnerOption) *Spinner {
+	s := &Spinner{
+		writer:  w,
+		palette: theme.NewPalette(false),
+		glyphs:  theme.NewGlyphs(false),
+		frames:  asciiSpinnerFrames,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// SetMessage updates the message shown beside the spinner.
+func (s *Spinner) SetMessage(message string) { s.message = message }
+
+// Tick advances to the next frame and renders it in place.
+func (s *Spinner) Tick() error {
+	frame := s.palette.Info(s.frames[s.index%len(s.frames)])
+	s.index++
+	return s.write("\r" + frame + " " + s.message)
+}
+
+// Finish clears the spinner and writes a success glyph plus final message on a
+// fresh line.
+func (s *Spinner) Finish(message string) error {
+	return s.write("\r" + s.palette.Success(s.glyphs.Success()) + " " + message + "\n")
+}
+
+func (s *Spinner) write(text string) error {
+	if _, err := io.WriteString(s.writer, text); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}

--- a/cli/progress/spinner.go
+++ b/cli/progress/spinner.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kbukum/gokit/errors"
 )
 
-// asciiSpinnerFrames is the pipe-clean fallback frame sequence.
+// asciiSpinnerFrames is the ASCII fallback frame sequence.
 var asciiSpinnerFrames = []string{"|", "/", "-", "\\"}
 
 // unicodeSpinnerFrames is the braille spinner used on UTF-8 terminals.

--- a/cli/prompt/choice.go
+++ b/cli/prompt/choice.go
@@ -1,0 +1,50 @@
+package prompt
+
+// ChoiceID is the stable identifier a caller uses to recognize a chosen
+// [Choice].
+//
+// It is opaque data (not a closure): the caller maps it back to domain meaning
+// after the prompt returns.
+type ChoiceID string
+
+// Choice is a single selectable option: pure data carrying an id, a human label,
+// an optional annotation line, and whether it is the recommended default.
+type Choice struct {
+	id          ChoiceID
+	label       string
+	annotation  string
+	recommended bool
+}
+
+// NewChoice creates a choice from an id and human-readable label.
+func NewChoice(id ChoiceID, label string) Choice {
+	return Choice{id: id, label: label}
+}
+
+// WithAnnotation attaches a secondary annotation line (for example "detected in
+// go.mod") and returns the choice.
+func (c Choice) WithAnnotation(annotation string) Choice {
+	c.annotation = annotation
+	return c
+}
+
+// Recommended marks this choice as the recommended default and returns it.
+//
+// In [ModeNonInteractive] a select resolves to the recommended choice, and an
+// interactive prompt offers it when the answer is left blank.
+func (c Choice) Recommended() Choice {
+	c.recommended = true
+	return c
+}
+
+// ID returns the stable identifier of this choice.
+func (c Choice) ID() ChoiceID { return c.id }
+
+// Label returns the human-readable label.
+func (c Choice) Label() string { return c.label }
+
+// Annotation returns the optional annotation line ("" when unset).
+func (c Choice) Annotation() string { return c.annotation }
+
+// IsRecommended reports whether this choice is the recommended default.
+func (c Choice) IsRecommended() bool { return c.recommended }

--- a/cli/prompt/confirm.go
+++ b/cli/prompt/confirm.go
@@ -1,0 +1,48 @@
+package prompt
+
+import "strings"
+
+// runConfirm asks a yes/no question with an explicit default.
+//
+// In non-interactive mode it resolves to default without touching the terminal;
+// otherwise it prints the prompt and parses y/yes/n/no (blank accepts the
+// default), re-asking on unrecognized input.
+func runConfirm(term Terminal, style Style, mode PromptMode, prompt string, def bool) (bool, error) {
+	if !mode.IsInteractive() {
+		return def, nil
+	}
+	for {
+		if err := term.Write(heading(style, prompt) + " " + confirmSuffix(def) + ": "); err != nil {
+			return false, err
+		}
+		if err := term.Flush(); err != nil {
+			return false, err
+		}
+		line, ok, err := term.ReadLine()
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, closedInput(prompt)
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "":
+			return def, nil
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			if err := notice(term, style, "please answer 'y' or 'n'"); err != nil {
+				return false, err
+			}
+		}
+	}
+}
+
+func confirmSuffix(def bool) string {
+	if def {
+		return "[Y/n]"
+	}
+	return "[y/N]"
+}

--- a/cli/prompt/doc.go
+++ b/cli/prompt/doc.go
@@ -1,0 +1,22 @@
+// Package prompt provides interactive prompts for guided CLI flows.
+//
+// It asks a question — a yes/no confirm, freeform text, a single [Choice], or a
+// multi-select — and returns a typed answer, reusing the theme layer so styling
+// honors NO_COLOR, TTY, and UTF-8 detection like the rest of the CLI kit.
+//
+// Prompts speak through a [Terminal] seam rather than raw stdio, so the same
+// question renders as a numbered list over a pipe ([LineTerminal]) or replays a
+// canned sequence in a test ([ScriptedTerminal]) without the calling code
+// changing.
+//
+// # Non-interactive fallback
+//
+// A [Prompter] resolves its behavior once from a [PromptMode]:
+//
+//   - [ModeInteractive] renders prompts and reads answers.
+//   - [ModeNonInteractive] never blocks: each question resolves to its declared
+//     default (the recommended [Choice] for a selection, the supplied default
+//     for a confirm/text). A required question with no default returns a typed
+//     [github.com/kbukum/gokit/errors.AppError] rather than an invented answer or
+//     a hang.
+package prompt

--- a/cli/prompt/kind.go
+++ b/cli/prompt/kind.go
@@ -1,0 +1,18 @@
+package prompt
+
+import (
+	"fmt"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// nonInteractiveError is returned when a non-interactive prompt has no usable
+// default.
+func nonInteractiveError(prompt string) *errors.AppError {
+	return errors.InvalidInput("prompt", fmt.Sprintf("non-interactive mode requires a default for: %s", prompt))
+}
+
+// closedInput is returned when input closes before the prompt is answered.
+func closedInput(prompt string) *errors.AppError {
+	return errors.InvalidInput("prompt", fmt.Sprintf("input closed before answering: %s", prompt))
+}

--- a/cli/prompt/mode.go
+++ b/cli/prompt/mode.go
@@ -1,0 +1,40 @@
+package prompt
+
+// PromptMode is how a [Prompter] sources answers, resolved once up front.
+//
+// The decision models interactive stdio: prompts are read from stdin but
+// rendered to stderr, so a session is interactive only when both streams are
+// terminals. If stderr is redirected (cmd 2>log) the user would never see the
+// question, so the mode falls back to [ModeNonInteractive] even when stdin is a
+// TTY.
+//
+//nolint:revive // "PromptMode" reads clearly at call sites across sub-packages.
+type PromptMode int
+
+const (
+	// ModeInteractive reads live, typed answers (both stdin and stderr are
+	// terminals). It is the zero value only nominally; callers resolve the mode
+	// explicitly via [ModeFromStdio] or [ModeFromEnv].
+	ModeInteractive PromptMode = iota
+	// ModeNonInteractive never blocks (CI, piped, or a redirected prompt sink):
+	// each question resolves to its declared default.
+	ModeNonInteractive
+)
+
+// ModeFromStdio resolves the mode from already-known stream TTY statuses, so it
+// is environment-free and testable.
+//
+// Interactive only when both the input (stdin) and the prompt sink (stderr) are
+// terminals, so a redirected sink never leaves the user blocked behind an
+// invisible prompt.
+func ModeFromStdio(stdinIsTTY, stderrIsTTY bool) PromptMode {
+	if stdinIsTTY && stderrIsTTY {
+		return ModeInteractive
+	}
+	return ModeNonInteractive
+}
+
+// IsInteractive reports whether this mode reads live answers.
+func (m PromptMode) IsInteractive() bool {
+	return m == ModeInteractive
+}

--- a/cli/prompt/mode.go
+++ b/cli/prompt/mode.go
@@ -14,7 +14,7 @@ type PromptMode int
 const (
 	// ModeInteractive reads live, typed answers (both stdin and stderr are
 	// terminals). It is the zero value only nominally; callers resolve the mode
-	// explicitly via [ModeFromStdio] or [ModeFromEnv].
+	// explicitly via [ModeFromStdio].
 	ModeInteractive PromptMode = iota
 	// ModeNonInteractive never blocks (CI, piped, or a redirected prompt sink):
 	// each question resolves to its declared default.

--- a/cli/prompt/multiselect.go
+++ b/cli/prompt/multiselect.go
@@ -1,0 +1,107 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// recommendedIndices returns the indices of every recommended choice, in order.
+func recommendedIndices(choices []Choice) []int {
+	var indices []int
+	for i, c := range choices {
+		if c.IsRecommended() {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+// ids maps choice indices to their [ChoiceID]s.
+func ids(choices []Choice, indices []int) []ChoiceID {
+	out := make([]ChoiceID, len(indices))
+	for i, index := range indices {
+		out[i] = choices[index].ID()
+	}
+	return out
+}
+
+// runMultiSelect asks for zero or more choices.
+//
+// In non-interactive mode it resolves to the set of recommended choices (which
+// may be empty). Interactively it prints a numbered list and reads a
+// comma-separated list of one-based numbers; a blank answer accepts the
+// recommended defaults.
+func runMultiSelect(term Terminal, style Style, mode PromptMode, prompt string, choices []Choice) ([]ChoiceID, error) {
+	if len(choices) == 0 {
+		return nil, errors.InvalidInput("prompt", fmt.Sprintf("multi-select requires at least one choice: %s", prompt))
+	}
+	defaults := recommendedIndices(choices)
+
+	if !mode.IsInteractive() {
+		return ids(choices, defaults), nil
+	}
+
+	if err := term.WriteLine(heading(style, prompt)); err != nil {
+		return nil, err
+	}
+	for _, row := range numberedRows(style, choices) {
+		if err := term.WriteLine(row); err != nil {
+			return nil, err
+		}
+	}
+	for {
+		if err := writeAnswer(term, style, multiHint(defaults)); err != nil {
+			return nil, err
+		}
+		line, ok, err := term.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, closedInput(prompt)
+		}
+		answer := strings.TrimSpace(line)
+		if answer == "" {
+			return ids(choices, defaults), nil
+		}
+		if indices, valid := parseIndices(answer, len(choices)); valid {
+			return ids(choices, indices), nil
+		}
+		if err := notice(term, style, fmt.Sprintf("enter comma-separated numbers between 1 and %d", len(choices))); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// multiHint renders the default-selection hint (e.g. "[1,3]" or "[none]").
+func multiHint(defaults []int) string {
+	if len(defaults) == 0 {
+		return "[none]"
+	}
+	parts := make([]string, len(defaults))
+	for i, index := range defaults {
+		parts[i] = fmt.Sprintf("%d", index+1)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// parseIndices parses a comma-separated list of one-based numbers into distinct
+// zero-based indices; the second return value is false when any token is out of
+// range or unparsable.
+func parseIndices(input string, length int) ([]int, bool) {
+	var indices []int
+	seen := make(map[int]bool)
+	for _, token := range strings.Split(input, ",") {
+		index, valid := parseIndex(token, length)
+		if !valid {
+			return nil, false
+		}
+		if !seen[index] {
+			seen[index] = true
+			indices = append(indices, index)
+		}
+	}
+	return indices, true
+}

--- a/cli/prompt/prompt_test.go
+++ b/cli/prompt/prompt_test.go
@@ -1,0 +1,691 @@
+package prompt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/cli/prompt"
+	"github.com/kbukum/gokit/cli/theme"
+	"github.com/kbukum/gokit/errors"
+)
+
+func plainChoices() []prompt.Choice {
+	return []prompt.Choice{
+		prompt.NewChoice("go", "Go"),
+		prompt.NewChoice("rust", "Rust").Recommended(),
+		prompt.NewChoice("node", "Node.js"),
+	}
+}
+
+func noDefaultChoices() []prompt.Choice {
+	return []prompt.Choice{
+		prompt.NewChoice("go", "Go"),
+		prompt.NewChoice("rust", "Rust"),
+	}
+}
+
+func linePrompter(term prompt.Terminal, mode prompt.PromptMode) *prompt.Prompter {
+	return prompt.New(term, mode, theme.NewPalette(false))
+}
+
+// --- Choice ---
+
+func TestChoiceAccessors(t *testing.T) {
+	t.Parallel()
+	c := prompt.NewChoice("rust", "Rust").WithAnnotation("detected").Recommended()
+	if c.ID() != "rust" || c.Label() != "Rust" || c.Annotation() != "detected" || !c.IsRecommended() {
+		t.Errorf("choice accessors wrong: %+v", c)
+	}
+	plain := prompt.NewChoice("go", "Go")
+	if plain.Annotation() != "" || plain.IsRecommended() {
+		t.Errorf("plain choice wrong: %+v", plain)
+	}
+}
+
+// --- Mode ---
+
+func TestModeFromStdio(t *testing.T) {
+	t.Parallel()
+	if prompt.ModeFromStdio(true, true) != prompt.ModeInteractive {
+		t.Error("both TTY must be interactive")
+	}
+	for _, c := range [][2]bool{{true, false}, {false, true}, {false, false}} {
+		if prompt.ModeFromStdio(c[0], c[1]) != prompt.ModeNonInteractive {
+			t.Errorf("stdio %v must be non-interactive", c)
+		}
+	}
+	if !prompt.ModeInteractive.IsInteractive() || prompt.ModeNonInteractive.IsInteractive() {
+		t.Error("IsInteractive wrong")
+	}
+}
+
+// --- Validators ---
+
+func TestNonEmptyValidator(t *testing.T) {
+	t.Parallel()
+	v := prompt.NonEmpty("required")
+	if err := v.Validate("value"); err != nil {
+		t.Errorf("non-empty accepts value: %v", err)
+	}
+	if err := v.Validate("   "); err == nil || err.Error() != "required" {
+		t.Errorf("blank must be rejected with message, got %v", err)
+	}
+}
+
+func TestValidatorFuncAdapter(t *testing.T) {
+	t.Parallel()
+	v := prompt.ValidatorFunc(func(s string) error {
+		if len(s) < 2 {
+			return errString("too short")
+		}
+		return nil
+	})
+	if err := v.Validate("ok"); err != nil {
+		t.Errorf("valid rejected: %v", err)
+	}
+	if err := v.Validate("x"); err == nil {
+		t.Error("short must be rejected")
+	}
+}
+
+// --- LineTerminal ---
+
+func TestLineTerminalReadsTrimmedLinesThenEOF(t *testing.T) {
+	t.Parallel()
+	var out strings.Builder
+	term := prompt.NewLineTerminal(strings.NewReader("hello\nworld\n"), &out)
+	for _, want := range []string{"hello", "world"} {
+		line, ok, err := term.ReadLine()
+		if err != nil || !ok || line != want {
+			t.Fatalf("read = %q ok=%v err=%v, want %q", line, ok, err, want)
+		}
+	}
+	if _, ok, _ := term.ReadLine(); ok {
+		t.Error("expected EOF")
+	}
+}
+
+func TestLineTerminalFinalLineWithoutNewline(t *testing.T) {
+	t.Parallel()
+	var out strings.Builder
+	term := prompt.NewLineTerminal(strings.NewReader("tail"), &out)
+	line, ok, err := term.ReadLine()
+	if err != nil || !ok || line != "tail" {
+		t.Fatalf("read = %q ok=%v err=%v", line, ok, err)
+	}
+}
+
+func TestLineTerminalWrites(t *testing.T) {
+	t.Parallel()
+	var out strings.Builder
+	term := prompt.NewLineTerminal(strings.NewReader(""), &out)
+	if err := term.Write("a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := term.WriteLine("b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := term.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "ab\n" {
+		t.Errorf("writes = %q", out.String())
+	}
+}
+
+// --- ScriptedTerminal ---
+
+func TestScriptedTerminalReplaysLinesThenEOF(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("one", "two")
+	for _, want := range []string{"one", "two"} {
+		line, ok, _ := term.ReadLine()
+		if !ok || line != want {
+			t.Fatalf("read = %q ok=%v, want %q", line, ok, want)
+		}
+	}
+	if _, ok, _ := term.ReadLine(); ok {
+		t.Error("expected EOF after script exhausted")
+	}
+}
+
+func TestScriptedTerminalCapturesOutput(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal()
+	_ = term.Write("x")
+	_ = term.WriteLine("y")
+	if term.Output() != "xy\n" {
+		t.Errorf("output = %q", term.Output())
+	}
+}
+
+// --- Confirm ---
+
+func TestConfirmNonInteractiveUsesDefault(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	got, err := p.Confirm("proceed?", true)
+	if err != nil || !got {
+		t.Errorf("non-interactive confirm = %v err=%v", got, err)
+	}
+}
+
+func TestConfirmParsesAnswers(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{"y": true, "yes": true, "n": false, "no": false, "": true}
+	for input, want := range cases {
+		term := prompt.NewScriptedTerminal().WithLine(input)
+		p := linePrompter(term, prompt.ModeInteractive)
+		got, err := p.Confirm("proceed?", true)
+		if err != nil || got != want {
+			t.Errorf("confirm(%q) = %v err=%v, want %v", input, got, err, want)
+		}
+	}
+}
+
+func TestConfirmReAsksOnGarbage(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("maybe", "y")
+	p := linePrompter(term, prompt.ModeInteractive)
+	got, err := p.Confirm("proceed?", false)
+	if err != nil || !got {
+		t.Fatalf("confirm = %v err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "'y' or 'n'") {
+		t.Errorf("must warn on garbage: %q", term.Output())
+	}
+}
+
+func TestConfirmClosedInputIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeInteractive)
+	if _, err := p.Confirm("proceed?", true); err == nil {
+		t.Error("closed input must error")
+	}
+}
+
+// --- Text ---
+
+func TestTextNonInteractiveResolvesDefault(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	def := "fallback"
+	got, err := p.Text("name?", &def)
+	if err != nil || got != "fallback" {
+		t.Errorf("text = %q err=%v", got, err)
+	}
+}
+
+func TestTextNonInteractiveNoDefaultIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	if _, err := p.Text("name?", nil); err == nil {
+		t.Error("no default must error in non-interactive mode")
+	}
+}
+
+func TestTextInteractiveReadsAndDefaults(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLine("typed")
+	got, err := linePrompter(term, prompt.ModeInteractive).Text("name?", nil)
+	if err != nil || got != "typed" {
+		t.Errorf("text = %q err=%v", got, err)
+	}
+
+	def := "def"
+	term2 := prompt.NewScriptedTerminal().WithLine("")
+	got2, err := linePrompter(term2, prompt.ModeInteractive).Text("name?", &def)
+	if err != nil || got2 != "def" {
+		t.Errorf("blank must accept default, got %q err=%v", got2, err)
+	}
+}
+
+func TestTextRequiredReAsksUntilNonEmpty(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("", "finally")
+	got, err := linePrompter(term, prompt.ModeInteractive).Text("name?", nil)
+	if err != nil || got != "finally" {
+		t.Errorf("text = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "a value is required") {
+		t.Errorf("must warn required: %q", term.Output())
+	}
+}
+
+func TestTextWithValidatorReAsks(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("x", "long-enough")
+	got, err := linePrompter(term, prompt.ModeInteractive).
+		TextWith("name?", nil, prompt.ValidatorFunc(func(s string) error {
+			if len(s) < 3 {
+				return errString("too short")
+			}
+			return nil
+		}))
+	if err != nil || got != "long-enough" {
+		t.Errorf("text = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "too short") {
+		t.Errorf("must show rejection: %q", term.Output())
+	}
+}
+
+func TestTextWithNonInteractiveRejectedDefaultIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	def := ""
+	_, err := p.TextWith("name?", &def, prompt.NonEmpty("required"))
+	if err == nil {
+		t.Error("rejected default must be a typed error")
+	}
+	if _, ok := errors.AsAppError(err); !ok {
+		t.Errorf("error must be AppError, got %T", err)
+	}
+}
+
+// --- Select ---
+
+func TestSelectNonInteractiveUsesRecommended(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	got, err := p.Select("lang?", plainChoices())
+	if err != nil || got != "rust" {
+		t.Errorf("select = %q err=%v", got, err)
+	}
+}
+
+func TestSelectNonInteractiveNoRecommendedIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	if _, err := p.Select("lang?", noDefaultChoices()); err == nil {
+		t.Error("no recommended default must error")
+	}
+}
+
+func TestSelectEmptyChoicesIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeInteractive)
+	if _, err := p.Select("lang?", nil); err == nil {
+		t.Error("empty choices must error")
+	}
+}
+
+func TestSelectInteractiveParsesNumberAndDefault(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLine("1")
+	got, err := linePrompter(term, prompt.ModeInteractive).Select("lang?", plainChoices())
+	if err != nil || got != "go" {
+		t.Errorf("select = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "1) Go") || !strings.Contains(term.Output(), "(recommended)") {
+		t.Errorf("numbered list wrong: %q", term.Output())
+	}
+
+	term2 := prompt.NewScriptedTerminal().WithLine("")
+	got2, _ := linePrompter(term2, prompt.ModeInteractive).Select("lang?", plainChoices())
+	if got2 != "rust" {
+		t.Errorf("blank must accept recommended default, got %q", got2)
+	}
+}
+
+func TestSelectReAsksOnInvalidNumber(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("9", "2")
+	got, err := linePrompter(term, prompt.ModeInteractive).Select("lang?", plainChoices())
+	if err != nil || got != "rust" {
+		t.Errorf("select = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "between 1 and 3") {
+		t.Errorf("must warn out of range: %q", term.Output())
+	}
+}
+
+func TestSelectRequiredWhenNoDefault(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("", "1")
+	got, err := linePrompter(term, prompt.ModeInteractive).Select("lang?", noDefaultChoices())
+	if err != nil || got != "go" {
+		t.Errorf("select = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "a choice is required") {
+		t.Errorf("must warn required: %q", term.Output())
+	}
+}
+
+func TestSelectRendersChoiceAnnotation(t *testing.T) {
+	t.Parallel()
+	choices := []prompt.Choice{
+		prompt.NewChoice("go", "Go").WithAnnotation("detected"),
+		prompt.NewChoice("rust", "Rust").Recommended(),
+	}
+	term := prompt.NewScriptedTerminal().WithLine("1")
+	got, err := linePrompter(term, prompt.ModeInteractive).Select("lang?", choices)
+	if err != nil || got != "go" {
+		t.Fatalf("select = %q err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "detected") {
+		t.Errorf("annotation must render beside the label: %q", term.Output())
+	}
+}
+
+// --- MultiSelect ---
+
+func TestMultiSelectNonInteractiveUsesRecommended(t *testing.T) {
+	t.Parallel()
+	choices := []prompt.Choice{
+		prompt.NewChoice("a", "A").Recommended(),
+		prompt.NewChoice("b", "B"),
+		prompt.NewChoice("c", "C").Recommended(),
+	}
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeNonInteractive)
+	got, err := p.MultiSelect("pick?", choices)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Errorf("multi = %v", got)
+	}
+}
+
+func TestMultiSelectInteractiveParsesList(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLine("1,3,3")
+	choices := []prompt.Choice{
+		prompt.NewChoice("a", "A"),
+		prompt.NewChoice("b", "B"),
+		prompt.NewChoice("c", "C"),
+	}
+	got, err := linePrompter(term, prompt.ModeInteractive).MultiSelect("pick?", choices)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Errorf("multi = %v (must dedupe)", got)
+	}
+}
+
+func TestMultiSelectBlankAcceptsDefaults(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLine("")
+	choices := []prompt.Choice{
+		prompt.NewChoice("a", "A").Recommended(),
+		prompt.NewChoice("b", "B"),
+	}
+	got, err := linePrompter(term, prompt.ModeInteractive).MultiSelect("pick?", choices)
+	if err != nil || len(got) != 1 || got[0] != "a" {
+		t.Errorf("multi = %v err=%v", got, err)
+	}
+}
+
+func TestMultiSelectReAsksOnInvalid(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal().WithLines("9", "2")
+	choices := []prompt.Choice{
+		prompt.NewChoice("a", "A"),
+		prompt.NewChoice("b", "B"),
+	}
+	got, err := linePrompter(term, prompt.ModeInteractive).MultiSelect("pick?", choices)
+	if err != nil || len(got) != 1 || got[0] != "b" {
+		t.Errorf("multi = %v err=%v", got, err)
+	}
+	if !strings.Contains(term.Output(), "comma-separated") {
+		t.Errorf("must warn: %q", term.Output())
+	}
+}
+
+func TestMultiSelectEmptyChoicesIsError(t *testing.T) {
+	t.Parallel()
+	p := linePrompter(prompt.NewScriptedTerminal(), prompt.ModeInteractive)
+	if _, err := p.MultiSelect("pick?", nil); err == nil {
+		t.Error("empty choices must error")
+	}
+}
+
+// --- Prompter wiring ---
+
+func TestPrompterExposesModeAndTerminal(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewScriptedTerminal()
+	p := linePrompter(term, prompt.ModeNonInteractive).WithGlyphs(theme.NewGlyphs(true))
+	if p.Mode() != prompt.ModeNonInteractive {
+		t.Error("mode wrong")
+	}
+	if p.Terminal() != term {
+		t.Error("terminal wrong")
+	}
+}
+
+func TestFromEnvNonInteractiveWhenNotTTY(t *testing.T) {
+	t.Parallel()
+	p := prompt.FromEnv(theme.ColorNever, false, false)
+	if p.Mode() != prompt.ModeNonInteractive {
+		t.Errorf("non-TTY env must be non-interactive")
+	}
+}
+
+func TestStyleExposesPaletteAndGlyphs(t *testing.T) {
+	t.Parallel()
+	style := prompt.NewStyle(theme.NewPalette(true), theme.NewGlyphs(true))
+	if !style.Palette().Enabled() {
+		t.Error("style must expose its palette")
+	}
+	if !style.Glyphs().Unicode() {
+		t.Error("style must expose its glyph set")
+	}
+}
+
+func TestLineTerminalWritePropagatesError(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewLineTerminal(strings.NewReader(""), failWriter{})
+	if err := term.Write("x"); err == nil {
+		t.Error("Write must surface a writer failure")
+	}
+	if err := term.WriteLine("x"); err == nil {
+		t.Error("WriteLine must surface a writer failure")
+	}
+}
+
+func TestLineTerminalFlushPropagatesError(t *testing.T) {
+	t.Parallel()
+	term := prompt.NewLineTerminal(strings.NewReader(""), flushErrWriter{})
+	if err := term.Flush(); err == nil {
+		t.Error("Flush must surface a flusher failure")
+	}
+}
+
+func TestLineTerminalReadPropagatesError(t *testing.T) {
+	t.Parallel()
+	var out strings.Builder
+	term := prompt.NewLineTerminal(failReader{}, &out)
+	if _, _, err := term.ReadLine(); err == nil {
+		t.Error("ReadLine must surface a reader failure")
+	}
+}
+
+func TestPromptsSurfaceReadErrors(t *testing.T) {
+	t.Parallel()
+	newErr := func() *prompt.Prompter {
+		return linePrompter(&readErrTerminal{}, prompt.ModeInteractive)
+	}
+	if _, err := newErr().Confirm("go?", true); err == nil {
+		t.Error("confirm must surface a read error")
+	}
+	def := "d"
+	if _, err := newErr().Text("name?", &def); err == nil {
+		t.Error("text must surface a read error")
+	}
+	if _, err := newErr().Select("pick?", plainChoices()); err == nil {
+		t.Error("select must surface a read error")
+	}
+	if _, err := newErr().MultiSelect("pick?", plainChoices()); err == nil {
+		t.Error("multi-select must surface a read error")
+	}
+}
+
+func TestPromptsSurfaceWriteErrors(t *testing.T) {
+	t.Parallel()
+	newErr := func() *prompt.Prompter {
+		return linePrompter(&writeErrTerminal{}, prompt.ModeInteractive)
+	}
+	if _, err := newErr().Confirm("go?", true); err == nil {
+		t.Error("confirm must surface a write error")
+	}
+	def := "d"
+	if _, err := newErr().Text("name?", &def); err == nil {
+		t.Error("text must surface a write error")
+	}
+	if _, err := newErr().Select("pick?", plainChoices()); err == nil {
+		t.Error("select must surface a write error")
+	}
+	if _, err := newErr().MultiSelect("pick?", plainChoices()); err == nil {
+		t.Error("multi-select must surface a write error")
+	}
+}
+
+func TestPromptsSurfaceFlushErrorsAtAnswerMarker(t *testing.T) {
+	t.Parallel()
+	// Heading/list writes succeed; the answer-marker Flush (first flush) fails.
+	if _, err := linePrompter(&gateTerminal{flushAt: 1}, prompt.ModeInteractive).
+		Confirm("go?", true); err == nil {
+		t.Error("confirm must surface the flush failure")
+	}
+	def := "d"
+	if _, err := linePrompter(&gateTerminal{flushAt: 1}, prompt.ModeInteractive).
+		Text("name?", &def); err == nil {
+		t.Error("text must surface the answer-marker flush failure")
+	}
+	if _, err := linePrompter(&gateTerminal{flushAt: 1}, prompt.ModeInteractive).
+		Select("pick?", plainChoices()); err == nil {
+		t.Error("select must surface the answer-marker flush failure")
+	}
+	if _, err := linePrompter(&gateTerminal{flushAt: 1}, prompt.ModeInteractive).
+		MultiSelect("pick?", plainChoices()); err == nil {
+		t.Error("multi-select must surface the answer-marker flush failure")
+	}
+}
+
+func TestPromptsSurfaceNoticeWriteErrors(t *testing.T) {
+	t.Parallel()
+	// A garbage answer drives the re-ask notice; that WriteLine is gated to fail.
+	confirm := &gateTerminal{lines: []string{"maybe"}, writeLnAt: 1}
+	if _, err := linePrompter(confirm, prompt.ModeInteractive).Confirm("go?", true); err == nil {
+		t.Error("confirm must surface the notice write error")
+	}
+	// select/multi print heading + one WriteLine per choice, so the notice is the
+	// (2+len(choices))th WriteLine.
+	noticeAt := 2 + len(plainChoices())
+	sel := &gateTerminal{lines: []string{"99"}, writeLnAt: noticeAt}
+	if _, err := linePrompter(sel, prompt.ModeInteractive).Select("pick?", plainChoices()); err == nil {
+		t.Error("select must surface the notice write error")
+	}
+	multi := &gateTerminal{lines: []string{"99"}, writeLnAt: noticeAt}
+	if _, err := linePrompter(multi, prompt.ModeInteractive).MultiSelect("pick?", plainChoices()); err == nil {
+		t.Error("multi-select must surface the notice write error")
+	}
+	// text prints the heading then the required notice: the 2nd WriteLine.
+	txt := &gateTerminal{lines: []string{""}, writeLnAt: 2}
+	if _, err := linePrompter(txt, prompt.ModeInteractive).Text("name?", nil); err == nil {
+		t.Error("text must surface the required-notice write error")
+	}
+}
+
+func TestPromptsSurfaceRowWriteErrors(t *testing.T) {
+	t.Parallel()
+	// Heading WriteLine succeeds; the first choice-row WriteLine (2nd) fails.
+	sel := &gateTerminal{lines: []string{"1"}, writeLnAt: 2}
+	if _, err := linePrompter(sel, prompt.ModeInteractive).Select("pick?", plainChoices()); err == nil {
+		t.Error("select must surface a row write error")
+	}
+	multi := &gateTerminal{lines: []string{"1"}, writeLnAt: 2}
+	if _, err := linePrompter(multi, prompt.ModeInteractive).MultiSelect("pick?", plainChoices()); err == nil {
+		t.Error("multi-select must surface a row write error")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// failWriter always fails writes.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errString("write failed") }
+
+// flushErrWriter accepts writes but fails Flush, driving the flush error path.
+type flushErrWriter struct{}
+
+func (flushErrWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (flushErrWriter) Flush() error { return errString("flush failed") }
+
+// failReader always fails reads.
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) { return 0, errString("read failed") }
+
+// readErrTerminal fails on ReadLine but succeeds on writes, so prompts reach
+// their read step before failing.
+type readErrTerminal struct{}
+
+func (readErrTerminal) ReadLine() (line string, ok bool, err error) {
+	return "", false, errString("read failed")
+}
+func (readErrTerminal) Write(string) error     { return nil }
+func (readErrTerminal) WriteLine(string) error { return nil }
+func (readErrTerminal) Flush() error           { return nil }
+
+// writeErrTerminal fails on the first write, so prompts surface a write failure
+// before any input is read.
+type writeErrTerminal struct{}
+
+func (writeErrTerminal) ReadLine() (line string, ok bool, err error) { return "", false, nil }
+func (writeErrTerminal) Write(string) error                          { return errString("write failed") }
+func (writeErrTerminal) WriteLine(string) error                      { return errString("write failed") }
+func (writeErrTerminal) Flush() error                                { return errString("flush failed") }
+
+// gateTerminal replays scripted input and fails a chosen write family on its
+// Nth call, so deep write-error branches (choice rows, the answer-marker flush,
+// and re-ask notices) can be reached deterministically. A zero target never
+// fails.
+type gateTerminal struct {
+	lines      []string
+	cursor     int
+	writeAt    int
+	writeLnAt  int
+	flushAt    int
+	writes     int
+	writeLines int
+	flushes    int
+}
+
+func (t *gateTerminal) ReadLine() (line string, ok bool, err error) {
+	if t.cursor >= len(t.lines) {
+		return "", false, nil
+	}
+	line = t.lines[t.cursor]
+	t.cursor++
+	return line, true, nil
+}
+
+func (t *gateTerminal) Write(string) error {
+	t.writes++
+	return failAt(t.writeAt, t.writes)
+}
+
+func (t *gateTerminal) WriteLine(string) error {
+	t.writeLines++
+	return failAt(t.writeLnAt, t.writeLines)
+}
+
+func (t *gateTerminal) Flush() error {
+	t.flushes++
+	return failAt(t.flushAt, t.flushes)
+}
+
+// failAt fails once the call count reaches a non-zero target.
+func failAt(target, count int) error {
+	if target != 0 && count >= target {
+		return errString("gated")
+	}
+	return nil
+}

--- a/cli/prompt/prompt_test.go
+++ b/cli/prompt/prompt_test.go
@@ -682,7 +682,7 @@ func (t *gateTerminal) Flush() error {
 	return failAt(t.flushAt, t.flushes)
 }
 
-// failAt fails once the call count reaches a non-zero target.
+// failAt fails once the call count reaches a non-zero target, and on every call after.
 func failAt(target, count int) error {
 	if target != 0 && count >= target {
 		return errString("gated")

--- a/cli/prompt/prompter.go
+++ b/cli/prompt/prompter.go
@@ -1,0 +1,103 @@
+package prompt
+
+import (
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+// Prompter is a terminal-agnostic prompt driver.
+//
+// It binds a [Terminal], a resolved [PromptMode], and a rendering [Style], and
+// exposes one method per question type. The same call works over cooked stdio or
+// a scripted test double. Build one from explicit parts with [New] (deterministic
+// tests) or from the environment with [FromEnv].
+type Prompter struct {
+	terminal Terminal
+	mode     PromptMode
+	style    Style
+}
+
+// New builds a prompter from an explicit terminal, mode, and palette.
+//
+// Glyphs default to the ASCII fallback for byte-clean, deterministic tests;
+// override with [Prompter.WithGlyphs].
+func New(terminal Terminal, mode PromptMode, palette theme.Palette) *Prompter {
+	return &Prompter{
+		terminal: terminal,
+		mode:     mode,
+		style:    NewStyle(palette, theme.NewGlyphs(false)),
+	}
+}
+
+// FromEnv builds a prompter bound to process stdin/stderr.
+//
+// The [PromptMode] follows whether both stdin and stderr are terminals, and the
+// [theme.Palette] follows color against stderr, so interactivity and styling
+// both honor redirection and NO_COLOR. Prompts render to stderr, so a
+// redirected stderr forces [ModeNonInteractive] rather than blocking on input
+// behind an invisible prompt.
+func FromEnv(color theme.ColorChoice, stdinIsTTY, stderrIsTTY bool) *Prompter {
+	mode := ModeFromStdio(stdinIsTTY, stderrIsTTY)
+	palette := theme.PaletteForStream(color, stderrIsTTY)
+	p := New(NewStdioTerminal(), mode, palette)
+	p.style = NewStyle(palette, theme.GlyphsFromEnv())
+	return p
+}
+
+// WithGlyphs overrides the glyph set (Unicode symbols vs ASCII fallback) and
+// returns the receiver.
+func (p *Prompter) WithGlyphs(glyphs theme.Glyphs) *Prompter {
+	p.style = NewStyle(p.style.Palette(), glyphs)
+	return p
+}
+
+// Mode returns the resolved interaction mode.
+func (p *Prompter) Mode() PromptMode { return p.mode }
+
+// Terminal returns the bound terminal, for inspecting captured output in tests.
+func (p *Prompter) Terminal() Terminal { return p.terminal }
+
+// Select asks for exactly one choice.
+//
+// In [ModeNonInteractive] it resolves to the recommended choice; with none it is
+// a typed error. Interactively it shows a numbered list.
+func (p *Prompter) Select(prompt string, choices []Choice) (ChoiceID, error) {
+	return runSelect(p.terminal, p.style, p.mode, prompt, choices)
+}
+
+// MultiSelect asks for zero or more choices.
+//
+// The default answer is the set of recommended choices, which may be empty.
+// Interactively it accepts a comma-separated list of numbers.
+func (p *Prompter) MultiSelect(prompt string, choices []Choice) ([]ChoiceID, error) {
+	return runMultiSelect(p.terminal, p.style, p.mode, prompt, choices)
+}
+
+// Confirm asks a yes/no question with an explicit default.
+func (p *Prompter) Confirm(prompt string, def bool) (bool, error) {
+	return runConfirm(p.terminal, p.style, p.mode, prompt, def)
+}
+
+// Text asks for freeform text with an optional default.
+//
+// A nil def means no default: in [ModeNonInteractive] that is a typed error.
+func (p *Prompter) Text(prompt string, def *string) (string, error) {
+	value, has := deref(def)
+	return runText(p.terminal, p.style, p.mode, prompt, value, has, nil)
+}
+
+// TextWith asks for freeform text validated by validator, re-asking on
+// rejection.
+//
+// In [ModeNonInteractive] a rejected default is a typed error rather than a
+// silent bad value.
+func (p *Prompter) TextWith(prompt string, def *string, validator Validator) (string, error) {
+	value, has := deref(def)
+	return runText(p.terminal, p.style, p.mode, prompt, value, has, validator)
+}
+
+func deref(s *string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	return *s, true
+}

--- a/cli/prompt/render.go
+++ b/cli/prompt/render.go
@@ -70,7 +70,7 @@ func writeAnswer(term Terminal, style Style, hint string) error {
 	return term.Flush()
 }
 
-// notice writes a dimmed warning notice line beneath a line prompt.
+// notice writes a warning notice line beneath a line prompt.
 func notice(term Terminal, style Style, text string) error {
 	return term.WriteLine("  " + style.palette.Warn(text))
 }

--- a/cli/prompt/render.go
+++ b/cli/prompt/render.go
@@ -1,0 +1,86 @@
+package prompt
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+// Style bundles the color [theme.Palette] and [theme.Glyphs] set a prompt uses
+// to render, so every frame honors NO_COLOR and UTF-8 capability.
+type Style struct {
+	palette theme.Palette
+	glyphs  theme.Glyphs
+}
+
+// NewStyle bundles a palette and glyph set into a rendering style.
+func NewStyle(palette theme.Palette, glyphs theme.Glyphs) Style {
+	return Style{palette: palette, glyphs: glyphs}
+}
+
+// Palette returns the color palette.
+func (s Style) Palette() theme.Palette { return s.palette }
+
+// Glyphs returns the glyph set.
+func (s Style) Glyphs() theme.Glyphs { return s.glyphs }
+
+// heading returns the bold heading line shown above a prompt's choices or input.
+func heading(style Style, prompt string) string {
+	return style.palette.Bold(prompt)
+}
+
+// decorate renders a choice label plus its annotation and the recommended
+// marker.
+func decorate(style Style, choice Choice) string {
+	var b strings.Builder
+	b.WriteString(choice.Label())
+	if choice.Annotation() != "" {
+		b.WriteByte(' ')
+		b.WriteString(style.palette.Dim(choice.Annotation()))
+	}
+	if choice.IsRecommended() {
+		b.WriteByte(' ')
+		b.WriteString(style.palette.Info("(recommended)"))
+	}
+	return b.String()
+}
+
+// numberedRows builds the static, one-based choice list a line-driven terminal
+// prints.
+func numberedRows(style Style, choices []Choice) []string {
+	rows := make([]string, len(choices))
+	for i, choice := range choices {
+		rows[i] = fmt.Sprintf("  %d) %s", i+1, decorate(style, choice))
+	}
+	return rows
+}
+
+// writeAnswer writes the inline answer marker ("  » [hint]: ") and flushes.
+func writeAnswer(term Terminal, style Style, hint string) error {
+	marker := style.glyphs.Answer()
+	text := "  " + marker + " "
+	if hint != "" {
+		text = "  " + marker + " " + hint + ": "
+	}
+	if err := term.Write(text); err != nil {
+		return err
+	}
+	return term.Flush()
+}
+
+// notice writes a dimmed warning notice line beneath a line prompt.
+func notice(term Terminal, style Style, text string) error {
+	return term.WriteLine("  " + style.palette.Warn(text))
+}
+
+// parseIndex parses a one-based choice number into a zero-based index within
+// [0, length); the second return value is false when out of range or unparsable.
+func parseIndex(input string, length int) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(input))
+	if err != nil || n < 1 || n > length {
+		return 0, false
+	}
+	return n - 1, true
+}

--- a/cli/prompt/scripted.go
+++ b/cli/prompt/scripted.go
@@ -1,0 +1,69 @@
+package prompt
+
+import "strings"
+
+// ScriptedTerminal is a deterministic in-memory [Terminal] for tests and
+// examples.
+//
+// It is a first-class injectable double, not a test-only escape hatch: it
+// replays a canned sequence of input lines and records everything written, so
+// the line-driven prompt path can be exercised without a real terminal. Queue
+// input with [ScriptedTerminal.WithLine] / [ScriptedTerminal.WithLines], then
+// read back rendered output via [ScriptedTerminal.Output].
+type ScriptedTerminal struct {
+	inputs []string
+	cursor int
+	output strings.Builder
+}
+
+// NewScriptedTerminal creates an empty scripted terminal.
+func NewScriptedTerminal() *ScriptedTerminal {
+	return &ScriptedTerminal{}
+}
+
+// WithLine queues one input line and returns the receiver.
+func (t *ScriptedTerminal) WithLine(line string) *ScriptedTerminal {
+	t.inputs = append(t.inputs, line)
+	return t
+}
+
+// WithLines queues several input lines in order and returns the receiver.
+func (t *ScriptedTerminal) WithLines(lines ...string) *ScriptedTerminal {
+	t.inputs = append(t.inputs, lines...)
+	return t
+}
+
+// Output returns everything written to the terminal so far, for assertions.
+func (t *ScriptedTerminal) Output() string {
+	return t.output.String()
+}
+
+// ReadLine returns the next queued line; ok is false once the script is
+// exhausted (end of input).
+func (t *ScriptedTerminal) ReadLine() (line string, ok bool, err error) {
+	if t.cursor >= len(t.inputs) {
+		return "", false, nil
+	}
+	line = t.inputs[t.cursor]
+	t.cursor++
+	return line, true, nil
+}
+
+// Write records text verbatim.
+func (t *ScriptedTerminal) Write(text string) error {
+	t.output.WriteString(text)
+	return nil
+}
+
+// WriteLine records text followed by a newline.
+func (t *ScriptedTerminal) WriteLine(text string) error {
+	t.output.WriteString(text)
+	t.output.WriteByte('\n')
+	return nil
+}
+
+// Flush is a no-op for the in-memory terminal.
+func (t *ScriptedTerminal) Flush() error { return nil }
+
+// compile-time assurance the double satisfies the seam.
+var _ Terminal = (*ScriptedTerminal)(nil)

--- a/cli/prompt/select.go
+++ b/cli/prompt/select.go
@@ -1,0 +1,78 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// recommendedIndex returns the index of the first recommended choice, or -1.
+func recommendedIndex(choices []Choice) int {
+	for i, c := range choices {
+		if c.IsRecommended() {
+			return i
+		}
+	}
+	return -1
+}
+
+// runSelect asks for exactly one choice.
+//
+// In non-interactive mode it resolves to the recommended choice (a typed error
+// when none is marked). Interactively it prints a numbered list and reads a
+// one-based number; a blank answer accepts the default when present.
+func runSelect(term Terminal, style Style, mode PromptMode, prompt string, choices []Choice) (ChoiceID, error) {
+	if len(choices) == 0 {
+		return "", errors.InvalidInput("prompt", fmt.Sprintf("select requires at least one choice: %s", prompt))
+	}
+	def := recommendedIndex(choices)
+
+	if !mode.IsInteractive() {
+		if def < 0 {
+			return "", nonInteractiveError(prompt)
+		}
+		return choices[def].ID(), nil
+	}
+
+	if err := term.WriteLine(heading(style, prompt)); err != nil {
+		return "", err
+	}
+	for _, row := range numberedRows(style, choices) {
+		if err := term.WriteLine(row); err != nil {
+			return "", err
+		}
+	}
+	for {
+		hint := ""
+		if def >= 0 {
+			hint = fmt.Sprintf("[%d]", def+1)
+		}
+		if err := writeAnswer(term, style, hint); err != nil {
+			return "", err
+		}
+		line, ok, err := term.ReadLine()
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", closedInput(prompt)
+		}
+		answer := strings.TrimSpace(line)
+		if answer == "" {
+			if def >= 0 {
+				return choices[def].ID(), nil
+			}
+			if err := notice(term, style, "a choice is required"); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if index, valid := parseIndex(answer, len(choices)); valid {
+			return choices[index].ID(), nil
+		}
+		if err := notice(term, style, fmt.Sprintf("enter a number between 1 and %d", len(choices))); err != nil {
+			return "", err
+		}
+	}
+}

--- a/cli/prompt/terminal.go
+++ b/cli/prompt/terminal.go
@@ -1,0 +1,93 @@
+package prompt
+
+import (
+	"bufio"
+	stderrors "errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// Terminal is the interactive medium a [Prompter] reads from and renders to.
+//
+// It abstracts how a prompt reads a line of input and writes output — decoupled
+// from what a prompt asks — so one set of prompt-kind logic drives both real
+// cooked stdio ([LineTerminal]) and a deterministic test double
+// ([ScriptedTerminal]).
+type Terminal interface {
+	// ReadLine reads one whole line. The second return value is false at end of
+	// input, so callers surface a typed "input closed" error instead of hanging.
+	ReadLine() (line string, ok bool, err error)
+	// Write writes text verbatim (no trailing newline).
+	Write(text string) error
+	// WriteLine writes text followed by a newline.
+	WriteLine(text string) error
+	// Flush flushes any buffered output.
+	Flush() error
+}
+
+// LineTerminal is a cooked-stdio [Terminal] over an injected reader and writer.
+//
+// The user types a whole line and presses Enter; it never enters raw mode, works
+// over pipes, and needs no extra dependencies, so it is the default terminal.
+// Bind it to real streams with [NewStdioTerminal], or to in-memory buffers with
+// [NewLineTerminal].
+type LineTerminal struct {
+	reader *bufio.Reader
+	writer io.Writer
+}
+
+// NewLineTerminal builds a line terminal from an explicit reader and writer.
+func NewLineTerminal(r io.Reader, w io.Writer) *LineTerminal {
+	return &LineTerminal{reader: bufio.NewReader(r), writer: w}
+}
+
+// NewStdioTerminal builds a line terminal bound to process stdin and stderr,
+// following the "prompts to stderr" convention so piped stdout stays clean.
+func NewStdioTerminal() *LineTerminal {
+	return NewLineTerminal(os.Stdin, os.Stderr)
+}
+
+// ReadLine reads a line, trimming the trailing newline; ok is false at EOF.
+func (t *LineTerminal) ReadLine() (line string, ok bool, err error) {
+	raw, err := t.reader.ReadString('\n')
+	if err != nil {
+		if stderrors.Is(err, io.EOF) {
+			if raw == "" {
+				return "", false, nil
+			}
+			// A final line without a trailing newline is still a valid answer.
+			return strings.TrimRight(raw, "\r\n"), true, nil
+		}
+		return "", false, errors.Internal(err)
+	}
+	return strings.TrimRight(raw, "\r\n"), true, nil
+}
+
+// Write writes text with no trailing newline.
+func (t *LineTerminal) Write(text string) error {
+	if _, err := io.WriteString(t.writer, text); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+// WriteLine writes text followed by a newline.
+func (t *LineTerminal) WriteLine(text string) error {
+	if _, err := io.WriteString(t.writer, text+"\n"); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+// Flush flushes the underlying writer when it supports flushing.
+func (t *LineTerminal) Flush() error {
+	if f, ok := t.writer.(interface{ Flush() error }); ok {
+		if err := f.Flush(); err != nil {
+			return errors.Internal(err)
+		}
+	}
+	return nil
+}

--- a/cli/prompt/text.go
+++ b/cli/prompt/text.go
@@ -1,0 +1,75 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// runText asks for freeform text with an optional default and optional
+// validation.
+//
+// In non-interactive mode it resolves to the default (a typed error when absent
+// or rejected by the validator). Interactively it prints the prompt and reads a
+// line; a blank answer accepts the default, and a validator rejection is shown
+// before re-asking. hasDefault distinguishes "" (a real empty default) from no
+// default at all.
+func runText(term Terminal, style Style, mode PromptMode, prompt, def string, hasDefault bool, validator Validator) (string, error) {
+	if !mode.IsInteractive() {
+		if !hasDefault {
+			return "", nonInteractiveError(prompt)
+		}
+		if validator != nil {
+			if err := validator.Validate(def); err != nil {
+				return "", errors.InvalidInput("prompt", fmt.Sprintf("default for %s is invalid: %s", prompt, err))
+			}
+		}
+		return def, nil
+	}
+
+	if err := term.WriteLine(heading(style, prompt)); err != nil {
+		return "", err
+	}
+	for {
+		hint := ""
+		if hasDefault && def != "" {
+			hint = "[" + def + "]"
+		}
+		if err := writeAnswer(term, style, hint); err != nil {
+			return "", err
+		}
+		line, ok, err := term.ReadLine()
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", closedInput(prompt)
+		}
+		value, accepted, reason := acceptText(strings.TrimSpace(line), def, hasDefault, validator)
+		if accepted {
+			return value, nil
+		}
+		if err := notice(term, style, reason); err != nil {
+			return "", err
+		}
+	}
+}
+
+// acceptText resolves a raw answer against the default and validator, returning
+// the accepted value or a rejection reason to display before re-asking.
+func acceptText(value, def string, hasDefault bool, validator Validator) (resolved string, accepted bool, reason string) {
+	resolved = value
+	if value == "" {
+		if !hasDefault {
+			return "", false, "a value is required"
+		}
+		resolved = def
+	}
+	if validator != nil {
+		if err := validator.Validate(resolved); err != nil {
+			return "", false, err.Error()
+		}
+	}
+	return resolved, true, ""
+}

--- a/cli/prompt/validate.go
+++ b/cli/prompt/validate.go
@@ -1,0 +1,38 @@
+package prompt
+
+import "strings"
+
+// Validator inspects a candidate answer, accepting it or explaining why it is
+// rejected.
+//
+// In an interactive prompt a rejection reason is shown and the question is
+// re-asked; in [ModeNonInteractive] a rejected default is a typed error rather
+// than a silent bad value.
+type Validator interface {
+	// Validate returns nil to accept input or an error whose message is the
+	// human-readable rejection reason.
+	Validate(input string) error
+}
+
+// ValidatorFunc adapts a plain function into a [Validator].
+type ValidatorFunc func(input string) error
+
+// Validate calls the underlying function.
+func (f ValidatorFunc) Validate(input string) error { return f(input) }
+
+// NonEmpty returns a validator that rejects empty or whitespace-only input with
+// message.
+func NonEmpty(message string) Validator {
+	return ValidatorFunc(func(input string) error {
+		if strings.TrimSpace(input) == "" {
+			return rejection(message)
+		}
+		return nil
+	})
+}
+
+// rejection is a lightweight error carrying only a human-readable reason, used
+// as a validator's rejection signal.
+type rejection string
+
+func (r rejection) Error() string { return string(r) }

--- a/cli/render/doc.go
+++ b/cli/render/doc.go
@@ -1,0 +1,19 @@
+// Package render is the structured, non-interactive terminal display layer of
+// the CLI kit.
+//
+// It covers everything a command emits when it is reporting rather than
+// prompting:
+//
+//   - [OutputTable] — aligned tables for row/column data.
+//   - [OutputKV] — key-value blocks for headers and summaries.
+//   - [OutputFormat], the shared [ExitCode] convention, and an [ErrorRenderer]
+//     that turns an [github.com/kbukum/gokit/errors.AppError] into consistent
+//     text/JSON/YAML.
+//   - [StatusReporter] — one-off feedback lines (success/warn/step/heading) for
+//     guided, multi-step flows.
+//
+// Every renderer writes to an injected [io.Writer] and composes the theme layer
+// ([github.com/kbukum/gokit/cli/theme.Palette] and
+// [github.com/kbukum/gokit/cli/theme.Glyphs]), so color and symbols honor
+// NO_COLOR, TTY detection, and UTF-8 capability uniformly.
+package render

--- a/cli/render/doc.go
+++ b/cli/render/doc.go
@@ -14,8 +14,11 @@
 //     guided, multi-step flows, written to an injected [io.Writer].
 //
 // The pure builders ([OutputTable], [OutputKV], [ErrorRenderer]) return strings
-// the caller writes; [StatusReporter] writes to an injected [io.Writer]. All
-// compose the theme layer ([github.com/kbukum/gokit/cli/theme.Palette] and
-// [github.com/kbukum/gokit/cli/theme.Glyphs]), so color and symbols honor
-// NO_COLOR, TTY detection, and UTF-8 capability uniformly.
+// the caller writes; [StatusReporter] writes to an injected [io.Writer]. Theme
+// use is per renderer: [StatusReporter] applies the palette and glyphs
+// ([github.com/kbukum/gokit/cli/theme.Palette],
+// [github.com/kbukum/gokit/cli/theme.Glyphs]) so color and symbols honor
+// NO_COLOR, TTY detection, and UTF-8 capability; [OutputTable] selects its
+// border charset from glyph capability; [OutputKV] and [ErrorRenderer] emit
+// plain text.
 package render

--- a/cli/render/doc.go
+++ b/cli/render/doc.go
@@ -4,16 +4,18 @@
 // It covers everything a command emits when it is reporting rather than
 // prompting:
 //
-//   - [OutputTable] — aligned tables for row/column data.
-//   - [OutputKV] — key-value blocks for headers and summaries.
+//   - [OutputTable] — aligned tables for row/column data, returned as a string.
+//   - [OutputKV] — key-value blocks for headers and summaries, returned as a
+//     string.
 //   - [OutputFormat], the shared [ExitCode] convention, and an [ErrorRenderer]
 //     that turns an [github.com/kbukum/gokit/errors.AppError] into consistent
 //     text/JSON/YAML.
 //   - [StatusReporter] — one-off feedback lines (success/warn/step/heading) for
-//     guided, multi-step flows.
+//     guided, multi-step flows, written to an injected [io.Writer].
 //
-// Every renderer writes to an injected [io.Writer] and composes the theme layer
-// ([github.com/kbukum/gokit/cli/theme.Palette] and
+// The pure builders ([OutputTable], [OutputKV], [ErrorRenderer]) return strings
+// the caller writes; [StatusReporter] writes to an injected [io.Writer]. All
+// compose the theme layer ([github.com/kbukum/gokit/cli/theme.Palette] and
 // [github.com/kbukum/gokit/cli/theme.Glyphs]), so color and symbols honor
 // NO_COLOR, TTY detection, and UTF-8 capability uniformly.
 package render

--- a/cli/render/error.go
+++ b/cli/render/error.go
@@ -31,8 +31,8 @@ const (
 	ExitRateLimited ExitCode = 75
 	// ExitTimeout is a command that timed out.
 	ExitTimeout ExitCode = 124
-	// ExitCancelled is a command that was canceled.
-	ExitCancelled ExitCode = 130
+	// ExitCanceled is a command that was canceled.
+	ExitCanceled ExitCode = 130
 )
 
 // Int returns the exit code as an integer suitable for os.Exit.
@@ -73,7 +73,7 @@ func exitCodeForCode(code errors.ErrorCode) ExitCode {
 	case errors.ErrCodeTimeout:
 		return ExitTimeout
 	case errors.ErrCodeCanceled:
-		return ExitCancelled
+		return ExitCanceled
 	default:
 		return ExitFailure
 	}

--- a/cli/render/error.go
+++ b/cli/render/error.go
@@ -107,6 +107,9 @@ type errorEnvelope struct {
 // any format and still exit consistently. A non-AppError is first wrapped as an
 // internal AppError so every error renders through the same envelope.
 func (r ErrorRenderer) Render(err error) (string, ExitCode) {
+	if err == nil {
+		return "", ExitSuccess
+	}
 	appErr := errors.Wrap(err)
 	exit := exitCodeForCode(appErr.Code)
 	switch r.format {

--- a/cli/render/error.go
+++ b/cli/render/error.go
@@ -1,0 +1,163 @@
+package render
+
+import (
+	"encoding/json"
+	"fmt"
+
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/kbukum/gokit/errors"
+)
+
+// ExitCode is the process exit-code convention shared by gokit CLIs.
+type ExitCode int
+
+const (
+	// ExitSuccess is a successful command.
+	ExitSuccess ExitCode = 0
+	// ExitFailure is an unclassified failure.
+	ExitFailure ExitCode = 1
+	// ExitUsage is invalid command input or configuration.
+	ExitUsage ExitCode = 2
+	// ExitPermission is an authentication or authorization failure.
+	ExitPermission ExitCode = 3
+	// ExitNotFound is a requested resource that was not found.
+	ExitNotFound ExitCode = 4
+	// ExitConflict is a conflict with the current state.
+	ExitConflict ExitCode = 5
+	// ExitUnavailable is a remote dependency or service failure.
+	ExitUnavailable ExitCode = 69
+	// ExitRateLimited is a rate-limited command.
+	ExitRateLimited ExitCode = 75
+	// ExitTimeout is a command that timed out.
+	ExitTimeout ExitCode = 124
+	// ExitCancelled is a command that was canceled.
+	ExitCancelled ExitCode = 130
+)
+
+// Int returns the exit code as an integer suitable for os.Exit.
+func (c ExitCode) Int() int { return int(c) }
+
+// ExitCodeForError maps an error's code onto the CLI exit-code convention.
+//
+// It resolves the underlying [github.com/kbukum/gokit/errors.AppError] via
+// errors.As; a nil error maps to [ExitSuccess] and any non-AppError to
+// [ExitFailure].
+func ExitCodeForError(err error) ExitCode {
+	if err == nil {
+		return ExitSuccess
+	}
+	appErr, ok := errors.AsAppError(err)
+	if !ok {
+		return ExitFailure
+	}
+	return exitCodeForCode(appErr.Code)
+}
+
+func exitCodeForCode(code errors.ErrorCode) ExitCode {
+	switch code {
+	case errors.ErrCodeInvalidInput, errors.ErrCodeInvalidFormat, errors.ErrCodeMissingField:
+		return ExitUsage
+	case errors.ErrCodeUnauthorized, errors.ErrCodeForbidden,
+		errors.ErrCodeTokenExpired, errors.ErrCodeInvalidToken:
+		return ExitPermission
+	case errors.ErrCodeNotFound:
+		return ExitNotFound
+	case errors.ErrCodeConflict, errors.ErrCodeAlreadyExists:
+		return ExitConflict
+	case errors.ErrCodeServiceUnavailable, errors.ErrCodeConnectionFailed,
+		errors.ErrCodeExternalService:
+		return ExitUnavailable
+	case errors.ErrCodeRateLimited:
+		return ExitRateLimited
+	case errors.ErrCodeTimeout:
+		return ExitTimeout
+	case errors.ErrCodeCanceled:
+		return ExitCancelled
+	default:
+		return ExitFailure
+	}
+}
+
+// ErrorRenderer renders [github.com/kbukum/gokit/errors.AppError] values
+// consistently for command-line applications.
+type ErrorRenderer struct {
+	format OutputFormat
+}
+
+// NewErrorRenderer creates a renderer for the requested output format.
+func NewErrorRenderer(format OutputFormat) ErrorRenderer {
+	return ErrorRenderer{format: format}
+}
+
+// errorEnvelope is the machine-readable projection of an error, shared by the
+// JSON and YAML formats.
+type errorEnvelope struct {
+	Code       errors.ErrorCode `json:"code" yaml:"code"`
+	Message    string           `json:"message" yaml:"message"`
+	Retryable  bool             `json:"retryable" yaml:"retryable"`
+	HTTPStatus int              `json:"http_status" yaml:"http_status"`
+	ExitCode   int              `json:"exit_code" yaml:"exit_code"`
+	Details    map[string]any   `json:"details,omitempty" yaml:"details,omitempty"`
+}
+
+// Render renders an error and returns the matching CLI exit code.
+//
+// The same exit code is returned regardless of format, so callers can render in
+// any format and still exit consistently. A non-AppError is first wrapped as an
+// internal AppError so every error renders through the same envelope.
+func (r ErrorRenderer) Render(err error) (string, ExitCode) {
+	appErr := errors.Wrap(err)
+	exit := exitCodeForCode(appErr.Code)
+	switch r.format {
+	case FormatJSON:
+		envelope := newEnvelope(appErr, exit)
+		encoded, marshalErr := json.Marshal(envelope)
+		if marshalErr != nil {
+			return fallbackJSON(appErr, exit), exit
+		}
+		return string(encoded), exit
+	case FormatYAML:
+		envelope := newEnvelope(appErr, exit)
+		encoded, marshalErr := yaml.Marshal(envelope)
+		if marshalErr != nil {
+			return fallbackYAML(appErr, exit), exit
+		}
+		return string(encoded), exit
+	default:
+		return fmt.Sprintf("error[%s]: %s", appErr.Code, appErr.Message), exit
+	}
+}
+
+func newEnvelope(err *errors.AppError, exit ExitCode) errorEnvelope {
+	return errorEnvelope{
+		Code:       err.Code,
+		Message:    err.Message,
+		Retryable:  err.Retryable,
+		HTTPStatus: err.HTTPStatus,
+		ExitCode:   exit.Int(),
+		Details:    err.Details,
+	}
+}
+
+// fallbackJSON renders a Details-free envelope when the full envelope fails to
+// marshal (an unmarshalable detail value). Dropping Details leaves only
+// JSON-safe scalars; the final string is a defensive last resort.
+func fallbackJSON(err *errors.AppError, exit ExitCode) string {
+	envelope := newEnvelope(err, exit)
+	envelope.Details = nil
+	if encoded, marshalErr := json.Marshal(envelope); marshalErr == nil {
+		return string(encoded)
+	}
+	return fmt.Sprintf(`{"code":%q,"exit_code":%d}`, err.Code, exit.Int())
+}
+
+// fallbackYAML mirrors [fallbackJSON] for the YAML format.
+func fallbackYAML(err *errors.AppError, exit ExitCode) string {
+	envelope := newEnvelope(err, exit)
+	envelope.Details = nil
+	if encoded, marshalErr := yaml.Marshal(envelope); marshalErr == nil {
+		return string(encoded)
+	}
+	return fmt.Sprintf("code: %s\nexit_code: %d\n", err.Code, exit.Int())
+}

--- a/cli/render/format.go
+++ b/cli/render/format.go
@@ -1,0 +1,46 @@
+package render
+
+import "fmt"
+
+// OutputFormat is a machine-readable output format for CLI renderers.
+type OutputFormat int
+
+const (
+	// FormatText is human-readable terminal text (the zero value).
+	FormatText OutputFormat = iota
+	// FormatJSON is a JSON object or array.
+	FormatJSON
+	// FormatYAML is a YAML document.
+	FormatYAML
+)
+
+// String returns the canonical lowercase name of the format.
+func (f OutputFormat) String() string {
+	switch f {
+	case FormatText:
+		return "text"
+	case FormatJSON:
+		return "json"
+	case FormatYAML:
+		return "yaml"
+	default:
+		return fmt.Sprintf("OutputFormat(%d)", int(f))
+	}
+}
+
+// ParseOutputFormat parses a format from its lowercase name (text/json/yaml).
+//
+// The second return value is false for any other value, so the caller can raise
+// its own typed usage error naming the accepted values.
+func ParseOutputFormat(name string) (OutputFormat, bool) {
+	switch name {
+	case "text":
+		return FormatText, true
+	case "json":
+		return FormatJSON, true
+	case "yaml":
+		return FormatYAML, true
+	default:
+		return FormatText, false
+	}
+}

--- a/cli/render/keyvalue.go
+++ b/cli/render/keyvalue.go
@@ -1,0 +1,49 @@
+package render
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// OutputKV is a key-value display block for headers and summaries.
+//
+// Keys are right-aligned to the widest key so values line up in a column.
+// Construct one with [NewOutputKV]; rendering is pure via [OutputKV.String].
+type OutputKV struct {
+	keys   []string
+	values []string
+}
+
+// NewOutputKV creates an empty key-value output block.
+func NewOutputKV() *OutputKV {
+	return &OutputKV{}
+}
+
+// Add appends a key-value pair and returns the receiver.
+func (k *OutputKV) Add(key, value string) *OutputKV {
+	k.keys = append(k.keys, key)
+	k.values = append(k.values, value)
+	return k
+}
+
+// String renders each pair as an indented, right-aligned "key:  value" line.
+func (k *OutputKV) String() string {
+	maxKey := 0
+	for _, key := range k.keys {
+		maxKey = max(maxKey, utf8.RuneCountInString(key))
+	}
+	var b strings.Builder
+	for i, key := range k.keys {
+		pad := maxKey - utf8.RuneCountInString(key)
+		if pad < 0 {
+			pad = 0
+		}
+		b.WriteString("  ")
+		b.WriteString(strings.Repeat(" ", pad))
+		b.WriteString(key)
+		b.WriteString(":  ")
+		b.WriteString(k.values[i])
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/cli/render/render_test.go
+++ b/cli/render/render_test.go
@@ -9,6 +9,7 @@ import (
 	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/kbukum/gokit/cli/render"
+	"github.com/kbukum/gokit/cli/theme"
 	"github.com/kbukum/gokit/errors"
 )
 
@@ -20,6 +21,20 @@ func TestOutputTableRenders(t *testing.T) {
 	out := table.String()
 	if !strings.Contains(out, "Name") || !strings.Contains(out, "500") {
 		t.Errorf("table missing content:\n%s", out)
+	}
+}
+
+func TestOutputTableASCIIBorders(t *testing.T) {
+	t.Parallel()
+	out := render.NewOutputTable("A", "B").
+		WithGlyphs(theme.NewGlyphs(false)).
+		AddRow("x", "y").
+		String()
+	if strings.ContainsAny(out, "─│┌┬┐├┼┤└┴┘") {
+		t.Errorf("ASCII table must not contain box-drawing runes:\n%s", out)
+	}
+	if !strings.Contains(out, "+") || !strings.Contains(out, "|") {
+		t.Errorf("ASCII table must use +/| borders:\n%s", out)
 	}
 }
 

--- a/cli/render/render_test.go
+++ b/cli/render/render_test.go
@@ -92,7 +92,7 @@ func TestExitCodeForErrorMapsCodes(t *testing.T) {
 		errors.Conflict("dup"):             render.ExitConflict,
 		errors.RateLimited():               render.ExitRateLimited,
 		errors.Timeout("op"):               render.ExitTimeout,
-		errors.Canceled("op"):              render.ExitCancelled,
+		errors.Canceled("op"):              render.ExitCanceled,
 		errors.ServiceUnavailable("svc"):   render.ExitUnavailable,
 		errors.Internal(nil):               render.ExitFailure,
 	}

--- a/cli/render/render_test.go
+++ b/cli/render/render_test.go
@@ -1,0 +1,219 @@
+package render_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/kbukum/gokit/cli/render"
+	"github.com/kbukum/gokit/errors"
+)
+
+func TestOutputTableRenders(t *testing.T) {
+	t.Parallel()
+	table := render.NewOutputTable("Name", "Count").
+		AddRow("real", "500").
+		AddRow("ai", "500")
+	out := table.String()
+	if !strings.Contains(out, "Name") || !strings.Contains(out, "500") {
+		t.Errorf("table missing content:\n%s", out)
+	}
+}
+
+func TestOutputTableNormalizesRowWidth(t *testing.T) {
+	t.Parallel()
+	table := render.NewOutputTable("A", "B").
+		AddRow("only-one").
+		AddRow("x", "y", "extra")
+	out := table.String()
+	var width int
+	for i, line := range strings.Split(out, "\n") {
+		w := utf8.RuneCountInString(line)
+		if i == 0 {
+			width = w
+			continue
+		}
+		if w != width {
+			t.Errorf("ragged line %d width=%d want=%d:\n%s", i, w, width, out)
+		}
+	}
+	if strings.Contains(out, "extra") {
+		t.Error("overflow cell must be truncated")
+	}
+}
+
+func TestOutputTableTitle(t *testing.T) {
+	t.Parallel()
+	out := render.NewOutputTable("X").WithTitle("Report").AddRow("v").String()
+	if !strings.HasPrefix(out, "\nReport\n") {
+		t.Errorf("title must lead the table:\n%s", out)
+	}
+}
+
+func TestOutputKVRenders(t *testing.T) {
+	t.Parallel()
+	out := render.NewOutputKV().
+		Add("Output", "/tmp/dataset").
+		Add("Preset", "image").
+		String()
+	if !strings.Contains(out, "Output") || !strings.Contains(out, "/tmp/dataset") {
+		t.Errorf("kv missing content:\n%s", out)
+	}
+	// Keys are right-aligned, so the shorter key gets leading padding.
+	if !strings.Contains(out, " Preset:  image") {
+		t.Errorf("kv must right-align keys:\n%s", out)
+	}
+}
+
+func TestExitCodeForErrorMapsCodes(t *testing.T) {
+	t.Parallel()
+	cases := map[error]render.ExitCode{
+		errors.NotFound("repo", "missing"): render.ExitNotFound,
+		errors.InvalidInput("f", "bad"):    render.ExitUsage,
+		errors.Unauthorized(""):            render.ExitPermission,
+		errors.Conflict("dup"):             render.ExitConflict,
+		errors.RateLimited():               render.ExitRateLimited,
+		errors.Timeout("op"):               render.ExitTimeout,
+		errors.Canceled("op"):              render.ExitCancelled,
+		errors.ServiceUnavailable("svc"):   render.ExitUnavailable,
+		errors.Internal(nil):               render.ExitFailure,
+	}
+	for err, want := range cases {
+		if got := render.ExitCodeForError(err); got != want {
+			t.Errorf("ExitCodeForError(%v) = %d, want %d", err, got, want)
+		}
+	}
+	if render.ExitCodeForError(nil) != render.ExitSuccess {
+		t.Error("nil error must be ExitSuccess")
+	}
+	if render.ExitCodeForError(errTest("raw")) != render.ExitFailure {
+		t.Error("non-AppError must map to ExitFailure")
+	}
+}
+
+func TestErrorRendererSameExitAcrossFormats(t *testing.T) {
+	t.Parallel()
+	err := errors.NotFound("repo", "missing")
+	for _, format := range []render.OutputFormat{render.FormatText, render.FormatJSON, render.FormatYAML} {
+		rendered, code := render.NewErrorRenderer(format).Render(err)
+		if code != render.ExitNotFound {
+			t.Errorf("format %v exit = %d, want %d", format, code, render.ExitNotFound)
+		}
+		if !strings.Contains(rendered, "not found") && !strings.Contains(rendered, "NOT_FOUND") {
+			t.Errorf("format %v rendered missing error: %q", format, rendered)
+		}
+	}
+}
+
+func TestErrorRendererTextFormat(t *testing.T) {
+	t.Parallel()
+	rendered, _ := render.NewErrorRenderer(render.FormatText).Render(errors.Internal(nil))
+	if !strings.HasPrefix(rendered, "error[INTERNAL_ERROR]:") {
+		t.Errorf("text render = %q", rendered)
+	}
+}
+
+func TestErrorRendererJSONIsValidAndEscaped(t *testing.T) {
+	t.Parallel()
+	err := errors.Validation(`boom "quoted"`)
+	rendered, exit := render.NewErrorRenderer(render.FormatJSON).Render(err)
+	var payload map[string]any
+	if e := json.Unmarshal([]byte(rendered), &payload); e != nil {
+		t.Fatalf("invalid json %q: %v", rendered, e)
+	}
+	if payload["code"] != "INVALID_INPUT" {
+		t.Errorf("code = %v", payload["code"])
+	}
+	if payload["message"] != `boom "quoted"` {
+		t.Errorf("message = %v", payload["message"])
+	}
+	if int(payload["exit_code"].(float64)) != exit.Int() {
+		t.Errorf("exit_code = %v, want %d", payload["exit_code"], exit.Int())
+	}
+}
+
+func TestErrorRendererYAMLCarriesFields(t *testing.T) {
+	t.Parallel()
+	rendered, _ := render.NewErrorRenderer(render.FormatYAML).Render(errors.Internal(nil))
+	var payload map[string]any
+	if e := yaml.Unmarshal([]byte(rendered), &payload); e != nil {
+		t.Fatalf("invalid yaml %q: %v", rendered, e)
+	}
+	if payload["code"] != "INTERNAL_ERROR" {
+		t.Errorf("code = %v", payload["code"])
+	}
+	if payload["exit_code"] != 1 {
+		t.Errorf("exit_code = %v", payload["exit_code"])
+	}
+}
+
+func TestErrorRendererWrapsNonAppError(t *testing.T) {
+	t.Parallel()
+	rendered, code := render.NewErrorRenderer(render.FormatText).Render(errTest("raw"))
+	if code != render.ExitFailure {
+		t.Errorf("non-app error exit = %d", code)
+	}
+	if !strings.Contains(rendered, "INTERNAL_ERROR") {
+		t.Errorf("non-app error render = %q", rendered)
+	}
+}
+
+func TestOutputFormatRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, f := range []render.OutputFormat{render.FormatText, render.FormatJSON, render.FormatYAML} {
+		got, ok := render.ParseOutputFormat(f.String())
+		if !ok || got != f {
+			t.Errorf("round trip %v: got %v ok=%v", f, got, ok)
+		}
+	}
+	if _, ok := render.ParseOutputFormat("xml"); ok {
+		t.Error("unknown format must not parse")
+	}
+}
+
+func TestOutputFormatStringForUnknown(t *testing.T) {
+	t.Parallel()
+	if got := render.OutputFormat(99).String(); !strings.Contains(got, "99") {
+		t.Errorf("unknown format string = %q", got)
+	}
+}
+
+func TestErrorRendererFallsBackOnUnmarshalableDetails(t *testing.T) {
+	t.Parallel()
+	// A detail value whose marshalers fail forces the marshal-error fallback
+	// path in both structured formats without panicking the encoder.
+	err := errors.Internal(nil).WithDetail("bad", failMarshal{})
+	for _, format := range []render.OutputFormat{render.FormatJSON, render.FormatYAML} {
+		rendered, code := render.NewErrorRenderer(format).Render(err)
+		if code != render.ExitFailure {
+			t.Errorf("format %v exit = %d, want %d", format, code, render.ExitFailure)
+		}
+		if !strings.Contains(rendered, "INTERNAL_ERROR") {
+			t.Errorf("format %v fallback missing code: %q", format, rendered)
+		}
+	}
+}
+
+func TestOutputKVClampsWiderValueKey(t *testing.T) {
+	t.Parallel()
+	// A single key needs no padding; assert the pad-clamp branch renders cleanly.
+	out := render.NewOutputKV().Add("k", "v").String()
+	if out != "  k:  v\n" {
+		t.Errorf("kv single line = %q", out)
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
+// failMarshal fails both structured encoders so the renderer's marshal-error
+// fallback is exercised deterministically.
+type failMarshal struct{}
+
+func (failMarshal) MarshalJSON() ([]byte, error) { return nil, errTest("json fail") }
+
+func (failMarshal) MarshalYAML() (any, error) { return nil, errTest("yaml fail") }

--- a/cli/render/status.go
+++ b/cli/render/status.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/kbukum/gokit/cli/theme"
+	"github.com/kbukum/gokit/errors"
+)
+
+// StatusReporter emits one-off status feedback lines for guided, multi-step CLI
+// flows over an injected writer, palette, and glyph set.
+//
+// Where progress animates ongoing work and prompt reads input, this renders the
+// short, one-shot status lines a flow emits between steps: a green "✓ Detected
+// Go", a "[1/4]" step counter, a section heading, or a warn/error notice. It
+// composes a [theme.Palette] for color and a [theme.Glyphs] set for the leading
+// symbol, so every line honors NO_COLOR, TTY detection, and UTF-8 capability.
+type StatusReporter struct {
+	writer  io.Writer
+	palette theme.Palette
+	glyphs  theme.Glyphs
+}
+
+// NewStatusReporter builds a reporter from an explicit writer, palette, and
+// glyph set. Callers bind the writer to a real stream (typically stderr, the
+// "diagnostics to stderr" convention) while tests pass an in-memory buffer.
+func NewStatusReporter(w io.Writer, palette theme.Palette, glyphs theme.Glyphs) *StatusReporter {
+	return &StatusReporter{writer: w, palette: palette, glyphs: glyphs}
+}
+
+// Success emits a success line: a green check glyph followed by message.
+func (r *StatusReporter) Success(message string) error {
+	return r.writeLine(r.palette.Success(r.glyphs.Success()), message)
+}
+
+// Error emits an error line: a red cross glyph followed by message.
+func (r *StatusReporter) Error(message string) error {
+	return r.writeLine(r.palette.Error(r.glyphs.Error()), message)
+}
+
+// Warn emits a warning line: a yellow warning glyph followed by message.
+func (r *StatusReporter) Warn(message string) error {
+	return r.writeLine(r.palette.Warn(r.glyphs.Warning()), message)
+}
+
+// Info emits an informational line: a cyan info glyph followed by message.
+func (r *StatusReporter) Info(message string) error {
+	return r.writeLine(r.palette.Info(r.glyphs.Info()), message)
+}
+
+// Bullet emits an indented bullet line: a dimmed bullet glyph followed by
+// message.
+func (r *StatusReporter) Bullet(message string) error {
+	return r.writeLine("  "+r.palette.Dim(r.glyphs.Bullet()), message)
+}
+
+// Step emits a step line prefixed with a dimmed "[current/total]" counter.
+func (r *StatusReporter) Step(current, total int, message string) error {
+	counter := r.palette.Dim(fmt.Sprintf("[%d/%d]", current, total))
+	return r.writeLine(counter, message)
+}
+
+// Heading emits a bold section heading preceded by a blank line.
+func (r *StatusReporter) Heading(title string) error {
+	if _, err := fmt.Fprintf(r.writer, "\n%s\n", r.palette.Bold(title)); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}
+
+func (r *StatusReporter) writeLine(prefix, message string) error {
+	if _, err := fmt.Fprintf(r.writer, "%s %s\n", prefix, message); err != nil {
+		return errors.Internal(err)
+	}
+	return nil
+}

--- a/cli/render/status_test.go
+++ b/cli/render/status_test.go
@@ -1,0 +1,117 @@
+package render_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/cli/render"
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+func reporter(buf *bytes.Buffer, color, unicode bool) *render.StatusReporter {
+	return render.NewStatusReporter(buf, theme.NewPalette(color), theme.NewGlyphs(unicode))
+}
+
+func TestStatusSuccessCarriesGlyphAndMessage(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, true).Success("Detected Go"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "Detected Go") {
+		t.Errorf("success line = %q", out)
+	}
+}
+
+func TestStatusStepRendersCounter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, true).Step(1, 4, "Selecting ecosystems"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[1/4]") || !strings.Contains(out, "Selecting ecosystems") {
+		t.Errorf("step line = %q", out)
+	}
+}
+
+func TestStatusHeadingPrecededByBlankLine(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, true).Heading("Configuration"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "\n") || !strings.Contains(out, "Configuration") {
+		t.Errorf("heading = %q", out)
+	}
+}
+
+func TestStatusASCIIFallbackAvoidsUnicode(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, false).Warn("no toolchain found"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "!") || strings.Contains(out, "⚠") {
+		t.Errorf("ascii fallback = %q", out)
+	}
+}
+
+func TestStatusDisabledPaletteIsByteClean(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, true).Info("nothing to do"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "\x1b") {
+		t.Errorf("no-color must be byte-clean: %q", buf.String())
+	}
+}
+
+func TestStatusEnabledPaletteEmitsEscapes(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, true, true).Error("build failed"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "\x1b") {
+		t.Errorf("color must emit SGR escapes: %q", buf.String())
+	}
+}
+
+func TestStatusBulletIsIndented(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := reporter(&buf, false, true).Bullet("cached module"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "  ") || !strings.Contains(out, "•") || !strings.Contains(out, "cached module") {
+		t.Errorf("bullet line = %q", out)
+	}
+}
+
+func TestStatusWriteErrorSurfaces(t *testing.T) {
+	t.Parallel()
+	r := render.NewStatusReporter(failWriter{}, theme.NewPalette(false), theme.NewGlyphs(false))
+	if err := r.Success("x"); err == nil {
+		t.Error("write failure must surface")
+	}
+	if err := r.Heading("x"); err == nil {
+		t.Error("heading write failure must surface")
+	}
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errWrite }
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+const errWrite errString = "write failed"

--- a/cli/render/table.go
+++ b/cli/render/table.go
@@ -3,24 +3,68 @@ package render
 import (
 	"strings"
 	"unicode/utf8"
+
+	"github.com/kbukum/gokit/cli/theme"
 )
+
+// tableBorder is the rune set used to draw a table's frame.
+type tableBorder struct {
+	horizontal, vertical   string
+	topLeft, topMid, topRt string
+	midLeft, midMid, midRt string
+	botLeft, botMid, botRt string
+}
+
+// unicodeBorder draws box-drawing frames; asciiBorder is the byte-clean fallback
+// for terminals that cannot display Unicode.
+func unicodeBorder() tableBorder {
+	return tableBorder{
+		horizontal: "─", vertical: "│",
+		topLeft: "┌", topMid: "┬", topRt: "┐",
+		midLeft: "├", midMid: "┼", midRt: "┤",
+		botLeft: "└", botMid: "┴", botRt: "┘",
+	}
+}
+
+func asciiBorder() tableBorder {
+	return tableBorder{
+		horizontal: "-", vertical: "|",
+		topLeft: "+", topMid: "+", topRt: "+",
+		midLeft: "+", midMid: "+", midRt: "+",
+		botLeft: "+", botMid: "+", botRt: "+",
+	}
+}
 
 // OutputTable is a formatted table for terminal output.
 //
 // The zero value is not usable; construct one with [NewOutputTable]. Rendering
 // is pure — [OutputTable.String] builds the whole table as a string — so callers
-// choose where to write it.
+// choose where to write it. Borders default to Unicode box-drawing; pass an
+// ASCII-only [theme.Glyphs] via [OutputTable.WithGlyphs] to stay byte-clean on
+// non-UTF-8 terminals.
 type OutputTable struct {
 	title   string
 	columns []string
 	rows    [][]string
+	border  tableBorder
 }
 
 // NewOutputTable creates a table with the given column headings.
 func NewOutputTable(columns ...string) *OutputTable {
 	cols := make([]string, len(columns))
 	copy(cols, columns)
-	return &OutputTable{columns: cols}
+	return &OutputTable{columns: cols, border: unicodeBorder()}
+}
+
+// WithGlyphs selects the border charset from a glyph set's Unicode capability:
+// box-drawing when Unicode is enabled, ASCII (+-|) otherwise.
+func (t *OutputTable) WithGlyphs(glyphs theme.Glyphs) *OutputTable {
+	if glyphs.Unicode() {
+		t.border = unicodeBorder()
+	} else {
+		t.border = asciiBorder()
+	}
+	return t
 }
 
 // WithTitle sets a human-readable table title and returns the receiver.
@@ -62,31 +106,31 @@ func (t *OutputTable) String() string {
 		b.WriteByte('\n')
 	}
 
-	b.WriteString(border(widths, "┌", "┬", "┐"))
+	b.WriteString(t.borderLine(widths, t.border.topLeft, t.border.topMid, t.border.topRt))
 	b.WriteByte('\n')
-	b.WriteString(cellsLine(t.columns, widths))
+	b.WriteString(t.cellsLine(t.columns, widths))
 	b.WriteByte('\n')
-	b.WriteString(border(widths, "├", "┼", "┤"))
+	b.WriteString(t.borderLine(widths, t.border.midLeft, t.border.midMid, t.border.midRt))
 	b.WriteByte('\n')
 	for _, row := range t.rows {
-		b.WriteString(cellsLine(row, widths))
+		b.WriteString(t.cellsLine(row, widths))
 		b.WriteByte('\n')
 	}
-	b.WriteString(border(widths, "└", "┴", "┘"))
+	b.WriteString(t.borderLine(widths, t.border.botLeft, t.border.botMid, t.border.botRt))
 	return b.String()
 }
 
-// border builds a horizontal rule with the given corner/junction runes.
-func border(widths []int, left, mid, right string) string {
+// borderLine builds a horizontal rule with the given corner/junction runes.
+func (t *OutputTable) borderLine(widths []int, left, mid, right string) string {
 	segments := make([]string, len(widths))
 	for i, w := range widths {
-		segments[i] = strings.Repeat("─", w+2)
+		segments[i] = strings.Repeat(t.border.horizontal, w+2)
 	}
 	return left + strings.Join(segments, mid) + right
 }
 
-// cellsLine renders one padded, pipe-separated row.
-func cellsLine(cells []string, widths []int) string {
+// cellsLine renders one padded, vertical-bar-separated row.
+func (t *OutputTable) cellsLine(cells []string, widths []int) string {
 	parts := make([]string, len(widths))
 	for i := range widths {
 		cell := ""
@@ -99,5 +143,5 @@ func cellsLine(cells []string, widths []int) string {
 		}
 		parts[i] = " " + cell + strings.Repeat(" ", pad) + " "
 	}
-	return "│" + strings.Join(parts, "│") + "│"
+	return t.border.vertical + strings.Join(parts, t.border.vertical) + t.border.vertical
 }

--- a/cli/render/table.go
+++ b/cli/render/table.go
@@ -1,0 +1,103 @@
+package render
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// OutputTable is a formatted table for terminal output.
+//
+// The zero value is not usable; construct one with [NewOutputTable]. Rendering
+// is pure — [OutputTable.String] builds the whole table as a string — so callers
+// choose where to write it.
+type OutputTable struct {
+	title   string
+	columns []string
+	rows    [][]string
+}
+
+// NewOutputTable creates a table with the given column headings.
+func NewOutputTable(columns ...string) *OutputTable {
+	cols := make([]string, len(columns))
+	copy(cols, columns)
+	return &OutputTable{columns: cols}
+}
+
+// WithTitle sets a human-readable table title and returns the receiver.
+func (t *OutputTable) WithTitle(title string) *OutputTable {
+	t.title = title
+	return t
+}
+
+// AddRow appends a row of cell values.
+//
+// The row is normalized to the column count: extra cells are dropped and
+// missing cells are padded with empty strings, so every rendered row lines up
+// with the header and borders regardless of the caller's cell count.
+func (t *OutputTable) AddRow(cells ...string) *OutputTable {
+	row := make([]string, len(t.columns))
+	copy(row, cells)
+	t.rows = append(t.rows, row)
+	return t
+}
+
+// String renders the table as a bordered, column-aligned block.
+func (t *OutputTable) String() string {
+	widths := make([]int, len(t.columns))
+	for i, c := range t.columns {
+		widths[i] = utf8.RuneCountInString(c)
+	}
+	for _, row := range t.rows {
+		for i, cell := range row {
+			if i < len(widths) {
+				widths[i] = max(widths[i], utf8.RuneCountInString(cell))
+			}
+		}
+	}
+
+	var b strings.Builder
+	if t.title != "" {
+		b.WriteByte('\n')
+		b.WriteString(t.title)
+		b.WriteByte('\n')
+	}
+
+	b.WriteString(border(widths, "┌", "┬", "┐"))
+	b.WriteByte('\n')
+	b.WriteString(cellsLine(t.columns, widths))
+	b.WriteByte('\n')
+	b.WriteString(border(widths, "├", "┼", "┤"))
+	b.WriteByte('\n')
+	for _, row := range t.rows {
+		b.WriteString(cellsLine(row, widths))
+		b.WriteByte('\n')
+	}
+	b.WriteString(border(widths, "└", "┴", "┘"))
+	return b.String()
+}
+
+// border builds a horizontal rule with the given corner/junction runes.
+func border(widths []int, left, mid, right string) string {
+	segments := make([]string, len(widths))
+	for i, w := range widths {
+		segments[i] = strings.Repeat("─", w+2)
+	}
+	return left + strings.Join(segments, mid) + right
+}
+
+// cellsLine renders one padded, pipe-separated row.
+func cellsLine(cells []string, widths []int) string {
+	parts := make([]string, len(widths))
+	for i := range widths {
+		cell := ""
+		if i < len(cells) {
+			cell = cells[i]
+		}
+		pad := widths[i] - utf8.RuneCountInString(cell)
+		if pad < 0 {
+			pad = 0
+		}
+		parts[i] = " " + cell + strings.Repeat(" ", pad) + " "
+	}
+	return "│" + strings.Join(parts, "│") + "│"
+}

--- a/cli/signal/doc.go
+++ b/cli/signal/doc.go
@@ -1,0 +1,9 @@
+// Package signal maps interactive interrupts (Ctrl+C / SIGTERM) onto cooperative
+// [context.Context] cancelation.
+//
+// Where rskit standardizes on a cancelation token, Go's idiom is a cancelable
+// context threaded through every remote call and goroutine. This package builds
+// that context from OS signals so a CLI winds down gracefully on the first
+// interrupt: spawned work observes ctx.Done() and drains, and a second interrupt
+// restores the default behavior (immediate termination).
+package signal

--- a/cli/signal/doc.go
+++ b/cli/signal/doc.go
@@ -1,7 +1,7 @@
 // Package signal maps interactive interrupts (Ctrl+C / SIGTERM) onto cooperative
-// [context.Context] cancelation.
+// [context.Context] cancellation.
 //
-// Where rskit standardizes on a cancelation token, Go's idiom is a cancelable
+// Where rskit standardizes on a cancellation token, Go's idiom is a cancelable
 // context threaded through every remote call and goroutine. This package builds
 // that context from OS signals so a CLI winds down gracefully on the first
 // interrupt: spawned work observes ctx.Done() and drains, and a second interrupt

--- a/cli/signal/doc.go
+++ b/cli/signal/doc.go
@@ -4,6 +4,7 @@
 // Where rskit standardizes on a cancellation token, Go's idiom is a cancelable
 // context threaded through every remote call and goroutine. This package builds
 // that context from OS signals so a CLI winds down gracefully on the first
-// interrupt: spawned work observes ctx.Done() and drains, and a second interrupt
-// restores the default behavior (immediate termination).
+// interrupt: spawned work observes ctx.Done() and drains. Calling the returned
+// stop function restores default signal handling, so a later interrupt
+// terminates the process immediately.
 package signal

--- a/cli/signal/signal.go
+++ b/cli/signal/signal.go
@@ -1,0 +1,38 @@
+package signal
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// InterruptSignals returns the OS signals treated as a graceful-shutdown
+// request: SIGINT (Ctrl+C) and SIGTERM.
+//
+// It returns a fresh slice on each call so callers cannot mutate shared state.
+func InterruptSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+// NotifyContext returns a copy of parent that is canceled when one of sigs is
+// delivered.
+//
+// It wraps [signal/NotifyContext]: the first matching signal cancels the
+// returned context, and the returned stop function releases the signal handler
+// (restoring the default disposition, so a second signal terminates the
+// process). Callers must invoke stop, typically via defer, to avoid leaking the
+// handler. With no sigs the context is only canceled when parent is.
+func NotifyContext(parent context.Context, sigs ...os.Signal) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, sigs...)
+}
+
+// OnInterrupt returns a context canceled on the first interrupt or termination
+// signal (SIGINT / SIGTERM).
+//
+// It is the common case of [NotifyContext]: hand the returned context to
+// spawned tasks and remote calls so they wind down on Ctrl+C, and call the
+// returned stop function on shutdown to release the handler.
+func OnInterrupt(parent context.Context) (context.Context, context.CancelFunc) {
+	return NotifyContext(parent, InterruptSignals()...)
+}

--- a/cli/signal/signal.go
+++ b/cli/signal/signal.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"syscall"
 )
 
 // InterruptSignals returns the OS signals treated as a graceful-shutdown
-// request: SIGINT (Ctrl+C) and SIGTERM.
+// request: [os.Interrupt] (Ctrl+C) everywhere, plus SIGTERM on platforms that
+// deliver it (Windows has no SIGTERM analog).
 //
 // It returns a fresh slice on each call so callers cannot mutate shared state.
 func InterruptSignals() []os.Signal {
-	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+	extra := terminationSignals()
+	sigs := make([]os.Signal, 0, 1+len(extra))
+	sigs = append(sigs, os.Interrupt)
+	return append(sigs, extra...)
 }
 
 // NotifyContext returns a copy of parent that is canceled when one of sigs is

--- a/cli/signal/signal.go
+++ b/cli/signal/signal.go
@@ -23,10 +23,11 @@ func InterruptSignals() []os.Signal {
 //
 // It wraps [signal.NotifyContext]: the first matching signal cancels the
 // returned context, and the returned stop function both releases the signal
-// handler (restoring the default disposition, so a second signal terminates the
-// process) and cancels the context. Callers must invoke stop, typically via
-// defer, to avoid leaking the handler. With no sigs the context is canceled only
-// by stop or when parent is.
+// handler and cancels the context. Until stop runs the handler stays installed,
+// so a second signal is absorbed rather than terminating; call stop once
+// shutdown begins to let a later interrupt force-exit, and always call it to
+// avoid leaking the handler. With no sigs the context is canceled only by stop
+// or when parent is.
 func NotifyContext(parent context.Context, sigs ...os.Signal) (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(parent, sigs...)
 }

--- a/cli/signal/signal.go
+++ b/cli/signal/signal.go
@@ -18,11 +18,12 @@ func InterruptSignals() []os.Signal {
 // NotifyContext returns a copy of parent that is canceled when one of sigs is
 // delivered.
 //
-// It wraps [signal/NotifyContext]: the first matching signal cancels the
-// returned context, and the returned stop function releases the signal handler
-// (restoring the default disposition, so a second signal terminates the
-// process). Callers must invoke stop, typically via defer, to avoid leaking the
-// handler. With no sigs the context is only canceled when parent is.
+// It wraps [signal.NotifyContext]: the first matching signal cancels the
+// returned context, and the returned stop function both releases the signal
+// handler (restoring the default disposition, so a second signal terminates the
+// process) and cancels the context. Callers must invoke stop, typically via
+// defer, to avoid leaking the handler. With no sigs the context is canceled only
+// by stop or when parent is.
 func NotifyContext(parent context.Context, sigs ...os.Signal) (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(parent, sigs...)
 }

--- a/cli/signal/signal_test.go
+++ b/cli/signal/signal_test.go
@@ -3,12 +3,23 @@ package signal_test
 import (
 	"context"
 	"errors"
-	"syscall"
+	"os"
 	"testing"
 	"time"
 
 	clisignal "github.com/kbukum/gokit/cli/signal"
 )
+
+func signalSelf(t *testing.T) {
+	t.Helper()
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("find process: %v", err)
+	}
+	if err := proc.Signal(os.Interrupt); err != nil {
+		t.Fatalf("signal self: %v", err)
+	}
+}
 
 func TestOnInterruptCancelsOnSignal(t *testing.T) {
 	ctx, stop := clisignal.OnInterrupt(context.Background())
@@ -18,9 +29,7 @@ func TestOnInterruptCancelsOnSignal(t *testing.T) {
 		t.Fatalf("context must start live, got %v", err)
 	}
 
-	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
-		t.Fatalf("kill: %v", err)
-	}
+	signalSelf(t)
 
 	select {
 	case <-ctx.Done():
@@ -28,12 +37,12 @@ func TestOnInterruptCancelsOnSignal(t *testing.T) {
 			t.Errorf("err = %v, want Canceled", ctx.Err())
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("context was not canceled after SIGTERM")
+		t.Fatal("context was not canceled after interrupt")
 	}
 }
 
 func TestNotifyContextStopReleasesHandler(t *testing.T) {
-	ctx, stop := clisignal.NotifyContext(context.Background(), syscall.SIGUSR1)
+	ctx, stop := clisignal.NotifyContext(context.Background(), os.Interrupt)
 	stop()
 	// After stop, canceling the parent still propagates; the handler is gone.
 	select {
@@ -49,7 +58,7 @@ func TestNotifyContextStopReleasesHandler(t *testing.T) {
 func TestNotifyContextFollowsParentCancellation(t *testing.T) {
 	t.Parallel()
 	parent, cancelParent := context.WithCancel(context.Background())
-	ctx, stop := clisignal.NotifyContext(parent, syscall.SIGUSR2)
+	ctx, stop := clisignal.NotifyContext(parent, os.Interrupt)
 	defer stop()
 
 	cancelParent()
@@ -60,15 +69,17 @@ func TestNotifyContextFollowsParentCancellation(t *testing.T) {
 	}
 }
 
-func TestInterruptSignalsIncludeSIGINTAndSIGTERM(t *testing.T) {
+func TestInterruptSignalsIncludeInterrupt(t *testing.T) {
 	t.Parallel()
 	sigs := clisignal.InterruptSignals()
-	has := map[string]bool{}
+	found := false
 	for _, s := range sigs {
-		has[s.String()] = true
+		if s == os.Interrupt {
+			found = true
+		}
 	}
-	if !has[syscall.SIGINT.String()] || !has[syscall.SIGTERM.String()] {
-		t.Errorf("InterruptSignals = %v, want SIGINT and SIGTERM", sigs)
+	if !found {
+		t.Errorf("InterruptSignals = %v, want os.Interrupt", sigs)
 	}
 }
 

--- a/cli/signal/signal_test.go
+++ b/cli/signal/signal_test.go
@@ -44,7 +44,7 @@ func TestOnInterruptCancelsOnSignal(t *testing.T) {
 func TestNotifyContextStopReleasesHandler(t *testing.T) {
 	ctx, stop := clisignal.NotifyContext(context.Background(), os.Interrupt)
 	stop()
-	// After stop, canceling the parent still propagates; the handler is gone.
+	// stop cancels the returned context and releases the signal handler.
 	select {
 	case <-ctx.Done():
 		if !errors.Is(ctx.Err(), context.Canceled) {

--- a/cli/signal/signal_test.go
+++ b/cli/signal/signal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 
 func signalSelf(t *testing.T) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Interrupt cannot be sent to a process on Windows")
+	}
 	proc, err := os.FindProcess(os.Getpid())
 	if err != nil {
 		t.Fatalf("find process: %v", err)

--- a/cli/signal/signal_test.go
+++ b/cli/signal/signal_test.go
@@ -1,0 +1,82 @@
+package signal_test
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+
+	clisignal "github.com/kbukum/gokit/cli/signal"
+)
+
+func TestOnInterruptCancelsOnSignal(t *testing.T) {
+	ctx, stop := clisignal.OnInterrupt(context.Background())
+	defer stop()
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context must start live, got %v", err)
+	}
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("err = %v, want Canceled", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("context was not canceled after SIGTERM")
+	}
+}
+
+func TestNotifyContextStopReleasesHandler(t *testing.T) {
+	ctx, stop := clisignal.NotifyContext(context.Background(), syscall.SIGUSR1)
+	stop()
+	// After stop, canceling the parent still propagates; the handler is gone.
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("err = %v, want Canceled", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("context must be canceled after stop")
+	}
+}
+
+func TestNotifyContextFollowsParentCancellation(t *testing.T) {
+	t.Parallel()
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := clisignal.NotifyContext(parent, syscall.SIGUSR2)
+	defer stop()
+
+	cancelParent()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("child context must follow parent cancelation")
+	}
+}
+
+func TestInterruptSignalsIncludeSIGINTAndSIGTERM(t *testing.T) {
+	t.Parallel()
+	sigs := clisignal.InterruptSignals()
+	has := map[string]bool{}
+	for _, s := range sigs {
+		has[s.String()] = true
+	}
+	if !has[syscall.SIGINT.String()] || !has[syscall.SIGTERM.String()] {
+		t.Errorf("InterruptSignals = %v, want SIGINT and SIGTERM", sigs)
+	}
+}
+
+func TestInterruptSignalsReturnsFreshSlice(t *testing.T) {
+	t.Parallel()
+	first := clisignal.InterruptSignals()
+	first[0] = nil
+	if clisignal.InterruptSignals()[0] == nil {
+		t.Error("InterruptSignals must return a fresh slice, not shared state")
+	}
+}

--- a/cli/signal/signal_test.go
+++ b/cli/signal/signal_test.go
@@ -56,7 +56,7 @@ func TestNotifyContextFollowsParentCancellation(t *testing.T) {
 	select {
 	case <-ctx.Done():
 	case <-time.After(2 * time.Second):
-		t.Fatal("child context must follow parent cancelation")
+		t.Fatal("child context must follow parent cancellation")
 	}
 }
 

--- a/cli/signal/signal_unix.go
+++ b/cli/signal/signal_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package signal
+
+import (
+	"os"
+	"syscall"
+)
+
+// terminationSignals adds SIGTERM, the conventional graceful-shutdown signal on
+// Unix-like platforms.
+func terminationSignals() []os.Signal {
+	return []os.Signal{syscall.SIGTERM}
+}

--- a/cli/signal/signal_windows.go
+++ b/cli/signal/signal_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package signal
+
+import "os"
+
+// terminationSignals adds nothing on Windows: the OS has no SIGTERM analog, so
+// [os.Interrupt] (Ctrl+C / Ctrl+Break) is the only signal Go delivers.
+func terminationSignals() []os.Signal {
+	return nil
+}

--- a/cli/theme/color.go
+++ b/cli/theme/color.go
@@ -1,0 +1,147 @@
+package theme
+
+import (
+	"fmt"
+	"os"
+)
+
+// NoColorEnv is the environment variable that, when present (regardless of
+// value), disables color regardless of any explicit choice. See the NO_COLOR
+// standard: https://no-color.org.
+const NoColorEnv = "NO_COLOR"
+
+// ColorChoice is a user's requested color policy, before environment/TTY
+// resolution.
+type ColorChoice int
+
+const (
+	// ColorAuto enables color only when writing to a terminal and NO_COLOR is
+	// unset. It is the zero value, so an unset choice defaults to auto.
+	ColorAuto ColorChoice = iota
+	// ColorAlways forces color on (still overridden by NO_COLOR).
+	ColorAlways
+	// ColorNever forces color off.
+	ColorNever
+)
+
+// String returns the canonical lowercase name of the choice.
+func (c ColorChoice) String() string {
+	switch c {
+	case ColorAuto:
+		return "auto"
+	case ColorAlways:
+		return "always"
+	case ColorNever:
+		return "never"
+	default:
+		return fmt.Sprintf("ColorChoice(%d)", int(c))
+	}
+}
+
+// ParseColorChoice parses a choice from its lowercase name (auto/always/never).
+//
+// The second return value is false for any other value, so the caller can raise
+// its own typed usage error naming the accepted values.
+func ParseColorChoice(name string) (ColorChoice, bool) {
+	switch name {
+	case "auto":
+		return ColorAuto, true
+	case "always":
+		return ColorAlways, true
+	case "never":
+		return ColorNever, true
+	default:
+		return ColorAuto, false
+	}
+}
+
+// NoColorEnvSet reports whether the NO_COLOR environment variable is present.
+//
+// Per the NO_COLOR standard (https://no-color.org) any presence disables color,
+// so an empty value (NO_COLOR=) still counts.
+func NoColorEnvSet() bool {
+	_, ok := os.LookupEnv(NoColorEnv)
+	return ok
+}
+
+// ResolveColor resolves a [ColorChoice] into an effective on/off decision.
+//
+// Resolution order (the NO_COLOR standard takes precedence over an explicit
+// request): if NO_COLOR is set the result is off; otherwise ColorAlways is on,
+// ColorNever is off, and ColorAuto follows isTerminal. It reads the process
+// environment for NO_COLOR; use [ResolveColorWith] for a fully injected,
+// environment-free decision.
+func ResolveColor(choice ColorChoice, isTerminal bool) bool {
+	return ResolveColorWith(choice, NoColorEnvSet(), isTerminal)
+}
+
+// ResolveColorWith is the pure resolver core: it folds an explicit NO_COLOR
+// presence and TTY detection into an effective on/off decision, so it is
+// environment-free and unit-testable.
+//
+// NO_COLOR wins over every choice; otherwise ColorAlways/ColorNever are absolute
+// and ColorAuto follows isTerminal.
+func ResolveColorWith(choice ColorChoice, noColor, isTerminal bool) bool {
+	if noColor {
+		return false
+	}
+	switch choice {
+	case ColorAlways:
+		return true
+	case ColorNever:
+		return false
+	default: // ColorAuto
+		return isTerminal
+	}
+}
+
+// Palette is a resolved, semantic color palette.
+//
+// When disabled every style is the identity function, so callers render the
+// same way regardless of terminal capability. Construct it from a resolved
+// boolean via [NewPalette], or resolve a [ColorChoice] against a stream's TTY
+// status via [PaletteForStream].
+type Palette struct {
+	enabled bool
+}
+
+// NewPalette returns a palette with color explicitly enabled or disabled.
+func NewPalette(enabled bool) Palette {
+	return Palette{enabled: enabled}
+}
+
+// PaletteForStream resolves a palette for a specific output stream by folding
+// NO_COLOR, the choice, and the stream's TTY status via [ResolveColor].
+func PaletteForStream(choice ColorChoice, isTerminal bool) Palette {
+	return NewPalette(ResolveColor(choice, isTerminal))
+}
+
+// Enabled reports whether this palette emits color.
+func (p Palette) Enabled() bool { return p.enabled }
+
+// Success paints text green — successful/complete status.
+func (p Palette) Success(text string) string { return p.paint("32", text) }
+
+// Error paints text red — failure/error status.
+func (p Palette) Error(text string) string { return p.paint("31", text) }
+
+// Warn paints text yellow — warnings and attention.
+func (p Palette) Warn(text string) string { return p.paint("33", text) }
+
+// Info paints text cyan — informational/neutral highlight.
+func (p Palette) Info(text string) string { return p.paint("36", text) }
+
+// Dim paints text dimmed — secondary detail (cache/skip).
+func (p Palette) Dim(text string) string { return p.paint("2", text) }
+
+// Bold paints text bold — emphasis (headings, totals).
+func (p Palette) Bold(text string) string { return p.paint("1", text) }
+
+// paint wraps text in an SGR code plus reset when enabled, else returns it
+// verbatim so callers on pipes or redirects stay byte-clean.
+func (p Palette) paint(code, text string) string {
+	if !p.enabled {
+		return text
+	}
+	return "\x1b[" + code + "m" + text + "\x1b[0m"
+}

--- a/cli/theme/doc.go
+++ b/cli/theme/doc.go
@@ -1,0 +1,16 @@
+// Package theme is the visual vocabulary shared by every CLI renderer: color and
+// status glyphs.
+//
+// The theme layer resolves how output looks against the environment and user
+// preference, independent of what is being rendered:
+//
+//   - [Palette] — a semantic color set (success/error/warn/info/dim/bold) that
+//     honors the NO_COLOR standard and TTY detection.
+//   - [Glyphs] — a semantic symbol set (✓ ✗ ⚠ ℹ • → …) with a pure-ASCII
+//     fallback for terminals without UTF-8 support.
+//
+// Both resolve from a single boolean so callers render identically regardless of
+// terminal capability, and both expose an environment-free constructor
+// ([NewPalette], [NewGlyphs]) for deterministic tests alongside the
+// environment-driven resolvers ([ResolveColor], [GlyphsFromEnv]).
+package theme

--- a/cli/theme/glyph.go
+++ b/cli/theme/glyph.go
@@ -1,0 +1,101 @@
+package theme
+
+import (
+	"os"
+	"strings"
+)
+
+// UTF8LocaleEnvs are the locale environment variables consulted, in precedence
+// order, to decide whether the terminal encoding is UTF-8.
+var UTF8LocaleEnvs = [...]string{"LC_ALL", "LC_CTYPE", "LANG"}
+
+// UnicodeEnvEnabled reports whether the process locale advertises a UTF-8
+// encoding.
+//
+// It consults [UTF8LocaleEnvs] in order and reports true when any is set to a
+// value naming UTF-8 (case-insensitive, "utf-8" or "utf8"). When none is set the
+// result is false, so the ASCII fallback is the safe default.
+func UnicodeEnvEnabled() bool {
+	for _, key := range UTF8LocaleEnvs {
+		value, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+		lower := strings.ToLower(value)
+		if strings.Contains(lower, "utf-8") || strings.Contains(lower, "utf8") {
+			return true
+		}
+	}
+	return false
+}
+
+// Glyphs is a resolved set of semantic status glyphs.
+//
+// When Unicode is disabled every accessor returns its ASCII fallback, so the
+// same rendering code stays byte-clean on terminals that cannot display the
+// Unicode symbols. Construct it from a resolved boolean via [NewGlyphs], or from
+// the process locale via [GlyphsFromEnv].
+type Glyphs struct {
+	unicode bool
+}
+
+// NewGlyphs returns a glyph set with Unicode explicitly enabled or disabled.
+func NewGlyphs(unicode bool) Glyphs {
+	return Glyphs{unicode: unicode}
+}
+
+// GlyphsFromEnv resolves a glyph set from the process locale via
+// [UnicodeEnvEnabled].
+func GlyphsFromEnv() Glyphs {
+	return NewGlyphs(UnicodeEnvEnabled())
+}
+
+// Unicode reports whether this set emits Unicode glyphs.
+func (g Glyphs) Unicode() bool { return g.unicode }
+
+// Success returns the success/completed glyph — "✓" (ASCII "v").
+func (g Glyphs) Success() string { return g.pick("✓", "v") }
+
+// Error returns the failure/error glyph — "✗" (ASCII "x").
+func (g Glyphs) Error() string { return g.pick("✗", "x") }
+
+// Warning returns the warning/attention glyph — "⚠" (ASCII "!").
+func (g Glyphs) Warning() string { return g.pick("⚠", "!") }
+
+// Info returns the informational glyph — "ℹ" (ASCII "i").
+func (g Glyphs) Info() string { return g.pick("ℹ", "i") }
+
+// Bullet returns the list bullet glyph — "•" (ASCII "*").
+func (g Glyphs) Bullet() string { return g.pick("•", "*") }
+
+// Arrow returns the progression arrow glyph — "→" (ASCII "->").
+func (g Glyphs) Arrow() string { return g.pick("→", "->") }
+
+// Pointer returns the selection pointer glyph — "❯" (ASCII ">").
+func (g Glyphs) Pointer() string { return g.pick("❯", ">") }
+
+// Answer returns the inline answer/input marker — "»" (ASCII ">").
+func (g Glyphs) Answer() string { return g.pick("»", ">") }
+
+// RadioOn returns the selected radio option glyph — "◉" (ASCII "(*)").
+func (g Glyphs) RadioOn() string { return g.pick("◉", "(*)") }
+
+// RadioOff returns the unselected radio option glyph — "○" (ASCII "( )").
+func (g Glyphs) RadioOff() string { return g.pick("○", "( )") }
+
+// ArrowUp returns the upward navigation arrow glyph — "↑" (ASCII "^").
+func (g Glyphs) ArrowUp() string { return g.pick("↑", "^") }
+
+// ArrowDown returns the downward navigation arrow glyph — "↓" (ASCII "v").
+func (g Glyphs) ArrowDown() string { return g.pick("↓", "v") }
+
+// Ellipsis returns the truncation ellipsis glyph — "…" (ASCII "...").
+func (g Glyphs) Ellipsis() string { return g.pick("…", "...") }
+
+// pick chooses the Unicode glyph when enabled, else the ASCII fallback.
+func (g Glyphs) pick(unicode, ascii string) string {
+	if g.unicode {
+		return unicode
+	}
+	return ascii
+}

--- a/cli/theme/glyph.go
+++ b/cli/theme/glyph.go
@@ -5,18 +5,18 @@ import (
 	"strings"
 )
 
-// UTF8LocaleEnvs are the locale environment variables consulted, in precedence
+// utf8LocaleEnvs are the locale environment variables consulted, in precedence
 // order, to decide whether the terminal encoding is UTF-8.
-var UTF8LocaleEnvs = [...]string{"LC_ALL", "LC_CTYPE", "LANG"}
+var utf8LocaleEnvs = [...]string{"LC_ALL", "LC_CTYPE", "LANG"}
 
 // UnicodeEnvEnabled reports whether the process locale advertises a UTF-8
 // encoding.
 //
-// It consults [UTF8LocaleEnvs] in order and reports true when any is set to a
-// value naming UTF-8 (case-insensitive, "utf-8" or "utf8"). When none is set the
-// result is false, so the ASCII fallback is the safe default.
+// It consults LC_ALL, LC_CTYPE, then LANG in order and reports true when any is
+// set to a value naming UTF-8 (case-insensitive, "utf-8" or "utf8"). When none
+// is set the result is false, so the ASCII fallback is the safe default.
 func UnicodeEnvEnabled() bool {
-	for _, key := range UTF8LocaleEnvs {
+	for _, key := range utf8LocaleEnvs {
 		value, ok := os.LookupEnv(key)
 		if !ok {
 			continue

--- a/cli/theme/theme_test.go
+++ b/cli/theme/theme_test.go
@@ -1,0 +1,208 @@
+package theme_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/cli/theme"
+)
+
+func TestResolveColorNoColorOverridesAlways(t *testing.T) {
+	t.Parallel()
+	if theme.ResolveColorWith(theme.ColorAlways, true, true) {
+		t.Error("NO_COLOR must override ColorAlways")
+	}
+	if theme.ResolveColorWith(theme.ColorAlways, true, false) {
+		t.Error("NO_COLOR must override ColorAlways regardless of TTY")
+	}
+}
+
+func TestResolveColorAbsoluteChoices(t *testing.T) {
+	t.Parallel()
+	if !theme.ResolveColorWith(theme.ColorAlways, false, false) {
+		t.Error("ColorAlways without NO_COLOR must be on")
+	}
+	if theme.ResolveColorWith(theme.ColorNever, false, true) {
+		t.Error("ColorNever must be off even on a TTY")
+	}
+}
+
+func TestResolveColorAutoFollowsTerminal(t *testing.T) {
+	t.Parallel()
+	if !theme.ResolveColorWith(theme.ColorAuto, false, true) {
+		t.Error("ColorAuto must follow the terminal (on)")
+	}
+	if theme.ResolveColorWith(theme.ColorAuto, false, false) {
+		t.Error("ColorAuto must follow the terminal (off)")
+	}
+}
+
+func TestColorChoiceRoundTripsByName(t *testing.T) {
+	t.Parallel()
+	for _, choice := range []theme.ColorChoice{theme.ColorAuto, theme.ColorAlways, theme.ColorNever} {
+		got, ok := theme.ParseColorChoice(choice.String())
+		if !ok || got != choice {
+			t.Errorf("round trip failed for %v: got %v ok=%v", choice, got, ok)
+		}
+	}
+	if _, ok := theme.ParseColorChoice("bogus"); ok {
+		t.Error("bogus choice must not parse")
+	}
+}
+
+func TestDisabledPaletteIsIdentity(t *testing.T) {
+	t.Parallel()
+	plain := theme.NewPalette(false)
+	if plain.Success("ok") != "ok" || plain.Error("boom") != "boom" {
+		t.Error("disabled palette must be the identity function")
+	}
+	if plain.Enabled() {
+		t.Error("palette must report disabled")
+	}
+}
+
+func TestEnabledPaletteWrapsInSGRAndResets(t *testing.T) {
+	t.Parallel()
+	color := theme.NewPalette(true)
+	if got := color.Success("ok"); got != "\x1b[32mok\x1b[0m" {
+		t.Errorf("success = %q", got)
+	}
+	if got := color.Error("boom"); got != "\x1b[31mboom\x1b[0m" {
+		t.Errorf("error = %q", got)
+	}
+	if !color.Enabled() {
+		t.Error("palette must report enabled")
+	}
+}
+
+func TestResolveColorReadsEnv(t *testing.T) {
+	t.Setenv(theme.NoColorEnv, "")
+	// NO_COLOR present (even empty) disables color for any auto/always request.
+	if theme.ResolveColor(theme.ColorAlways, true) {
+		t.Error("NO_COLOR present must disable color via the env-aware resolver")
+	}
+	if !theme.NoColorEnvSet() {
+		t.Error("NoColorEnvSet must report presence of an empty NO_COLOR")
+	}
+}
+
+func TestPaletteForStreamResolvesAgainstTerminalFlag(t *testing.T) {
+	t.Parallel()
+	if theme.PaletteForStream(theme.ColorNever, true).Enabled() {
+		t.Error("ColorNever must keep the palette disabled")
+	}
+	if !theme.PaletteForStream(theme.ColorAlways, false).Enabled() {
+		t.Error("ColorAlways must enable the palette")
+	}
+}
+
+func TestGlyphsUnicodeSetEmitsSymbols(t *testing.T) {
+	t.Parallel()
+	g := theme.NewGlyphs(true)
+	if !g.Unicode() {
+		t.Fatal("glyphs must report unicode")
+	}
+	cases := map[string]string{
+		g.Success(): "✓", g.Error(): "✗", g.Warning(): "⚠", g.Info(): "ℹ",
+		g.Bullet(): "•", g.Arrow(): "→", g.Pointer(): "❯", g.Answer(): "»",
+		g.RadioOn(): "◉", g.RadioOff(): "○", g.ArrowUp(): "↑", g.ArrowDown(): "↓",
+		g.Ellipsis(): "…",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("glyph = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestGlyphsASCIIFallbackIsByteClean(t *testing.T) {
+	t.Parallel()
+	g := theme.NewGlyphs(false)
+	if g.Unicode() {
+		t.Fatal("glyphs must report ASCII")
+	}
+	for _, symbol := range []string{
+		g.Success(), g.Error(), g.Warning(), g.Info(), g.Bullet(), g.Arrow(),
+		g.Pointer(), g.Answer(), g.RadioOn(), g.RadioOff(), g.ArrowUp(),
+		g.ArrowDown(), g.Ellipsis(),
+	} {
+		for _, r := range symbol {
+			if r > 127 {
+				t.Errorf("fallback must be ASCII: %q", symbol)
+			}
+		}
+	}
+}
+
+func TestUnicodeEnvEnabledDetectsUTF8(t *testing.T) {
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
+	t.Setenv("LANG", "en_US.UTF-8")
+	if !theme.UnicodeEnvEnabled() {
+		t.Error("UTF-8 LANG must enable unicode")
+	}
+	if !theme.GlyphsFromEnv().Unicode() {
+		t.Error("GlyphsFromEnv must mirror UnicodeEnvEnabled")
+	}
+}
+
+func TestUnicodeEnvDisabledForNonUTF8Locale(t *testing.T) {
+	t.Setenv("LC_ALL", "C")
+	t.Setenv("LC_CTYPE", "POSIX")
+	t.Setenv("LANG", "en_US.ISO-8859-1")
+	if theme.UnicodeEnvEnabled() {
+		t.Error("non-UTF-8 locale must not enable unicode")
+	}
+}
+
+func TestColorChoiceStringForUnknown(t *testing.T) {
+	t.Parallel()
+	if got := theme.ColorChoice(99).String(); !strings.Contains(got, "99") {
+		t.Errorf("unknown choice string = %q", got)
+	}
+}
+
+func TestEnabledPaletteSecondaryColors(t *testing.T) {
+	t.Parallel()
+	color := theme.NewPalette(true)
+	cases := map[string]string{
+		color.Warn("w"): "\x1b[33mw\x1b[0m",
+		color.Info("i"): "\x1b[36mi\x1b[0m",
+		color.Dim("d"):  "\x1b[2md\x1b[0m",
+		color.Bold("b"): "\x1b[1mb\x1b[0m",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("paint = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestDisabledPaletteSecondaryColorsAreIdentity(t *testing.T) {
+	t.Parallel()
+	plain := theme.NewPalette(false)
+	if plain.Warn("w") != "w" || plain.Info("i") != "i" || plain.Dim("d") != "d" || plain.Bold("b") != "b" {
+		t.Error("disabled palette must not paint secondary colors")
+	}
+}
+
+func TestUnicodeEnvEnabledAcceptsDashlessUTF8(t *testing.T) {
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
+	t.Setenv("LANG", "ja_JP.utf8")
+	if !theme.UnicodeEnvEnabled() {
+		t.Error("a locale naming utf8 (no dash) must enable unicode")
+	}
+}
+
+func TestUnicodeEnvSkipsUnsetKeysBeforeMatch(t *testing.T) {
+	t.Setenv("LC_ALL", "")
+	os.Unsetenv("LC_ALL")
+	t.Setenv("LC_CTYPE", "")
+	os.Unsetenv("LC_CTYPE")
+	t.Setenv("LANG", "en_US.UTF-8")
+	if !theme.UnicodeEnvEnabled() {
+		t.Error("must skip unset locale keys and honor the first set UTF-8 key")
+	}
+}

--- a/docs/MODULE-INDEX.md
+++ b/docs/MODULE-INDEX.md
@@ -30,7 +30,7 @@ ai · llm · llm/providers · embedding · inference · inference/tgi · inferen
 media
 
 ## ⚙️ Infra  (`make check-infra`)
-workload · workload/testutil · bench · bench/storage · testutil
+workload · workload/testutil · cli · bench · bench/storage · testutil
 
 ## 📦 Devtools  (`make check-devtools`)
 git · git/testutil

--- a/domains.toml
+++ b/domains.toml
@@ -52,5 +52,5 @@ depends_on = ["core", "patterns", "crosscutting"]
 
 [domains.infra]
 description = "Workload management, CLI, benchmarking, dataset, test utilities, integration"
-modules = ["workload", "workload/testutil", "bench", "bench/storage", "testutil"]
+modules = ["workload", "workload/testutil", "cli", "bench", "bench/storage", "testutil"]
 depends_on = ["core", "patterns"]


### PR DESCRIPTION
## Description

Adds `cli`, a light, stdlib-only terminal-UX toolkit that mirrors the *shape* of rskit's
`rskit-cli`. It is a presentation kit, not a flag parser: it owns theming, structured output,
progress, interactive prompts with a non-interactive fallback, and cooperative shutdown. Every
renderer writes to an injected `io.Writer`, and this is the one package where `fmt.Print*`/stdout
writes are expected — nothing leaks into other modules.

The kit is intentionally *light*: raw-mode rich TUI widgets stay rskit-only, where the Rust
runtime is the stronger fit. It lives in the root module because its only third-party dependency
(`go.yaml.in/yaml/v3`, used by `render` for YAML error output) is already a direct root dependency,
so no new heavy dep is introduced.

## Motivation

gokit had no `cli` module while rskit ships `rskit-cli`. Services and tools built on gokit had no
canonical, testable way to render tables/status, drive progress, prompt interactively, or wind down
gracefully on Ctrl+C — each reinvented ad-hoc `fmt.Println` output. This fills that gap at parity
with the reference kit.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Module(s) Affected

- `cli` (new package: `theme`, `render`, `progress`, `prompt`, `signal`, `live`)

## Changes Made

- **theme** — semantic `Palette` colors and `Glyphs`, resolving `NO_COLOR`, TTY, and UTF-8 locale
  capability with byte-clean ASCII fallbacks.
- **render** — `OutputTable`, `OutputKV`, `StatusReporter`, `OutputFormat`, and an
  `ErrorRenderer`/`ExitCode` that maps RFC 9457 `AppError` codes onto a CLI exit-code convention.
- **progress** — caller-driven determinate `Bar` and indeterminate `Spinner` (no background timer),
  so they render deterministically without a clock.
- **prompt** — a `Prompter` over a `Terminal` seam: cooked-stdio `LineTerminal`, a deterministic
  `ScriptedTerminal` test double, validators, and a non-interactive fallback (default/typed-error).
- **signal** — graceful-shutdown helper mapping SIGINT/SIGTERM onto `context.Context` cancelation
  via `signal.NotifyContext`.
- **live** — a bounded multi-region console (documented `MaxRegions` backpressure) for concurrent
  streaming output.
- Wiring: `domains.toml` infra `modules` now lists `cli`; `docs/MODULE-INDEX.md` and the CHANGELOG
  are updated.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [x] `make lint` is clean (includes `vet` + `depguard` layering)
- [x] `make fmt` reports no diffs (`gofmt -s`; `gofumpt` also clean, enforced by lint)
- [x] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [x] Manual testing performed (describe below if applicable)

Deterministic tests use injected writers and the scripted terminal — no real TTY, no `time.Sleep`.
Per-package coverage: theme 100%, progress 100%, signal 100%, prompt 98.0%, render 97.0%,
live 95.8%.

### Test Evidence

```
$ go test -race -shuffle=on -count=1 ./cli/...
ok  github.com/kbukum/gokit/cli/live
ok  github.com/kbukum/gokit/cli/progress
ok  github.com/kbukum/gokit/cli/prompt
ok  github.com/kbukum/gokit/cli/render
ok  github.com/kbukum/gokit/cli/signal
ok  github.com/kbukum/gokit/cli/theme

$ make lint M=.
0 issues.

$ govulncheck ./cli/...
No vulnerabilities found.
```

## Breaking Changes

None — this is a purely additive new package.

## Sibling Parity

- [x] Sibling-parity tracked: rskit https://github.com/kbukum/rskit/tree/main/core/rskit-cli

Mirrors the `rskit-cli` surface as a light kit (theme/render/progress/prompt/signal + a bounded
live console; line + scripted prompt terminals with a non-interactive fallback). Raw-mode rich
widgets remain rskit-only. `docs/parity-matrix.md` already records the `cli` row as aligned (light).

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [ ] Bug fixes include a regression test that fails without the fix
- [x] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg)
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (writer/glyphs/palette) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] `make tidy` run so go.mod/go.sum are clean for affected modules (no dep manifest change)
- [x] CHANGELOG entry added under `[Unreleased]`
- [ ] New dependencies (if any) are justified, minimal, and pass `govulncheck` (no new deps)

## Additional Notes

`live` is the highest-risk area: `Console` spawns no goroutines (the caller owns render cadence),
holds a one-directional lock order (`console.mu` → `region.mu`), enforces `MaxRegions` as
documented backpressure, and has a race test for concurrent region appends.
