### PR TITLE
ci(dependabot): use build prefix for Go module bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
       time: "09:00"
       timezone: "Etc/UTC"
     commit-message:
-      prefix: "deps"
+      prefix: "build"
       include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
## Description

Corrects the Conventional Commit type Dependabot uses for Go module bumps so its PR titles pass the repository's PR-title validation gate. Dependabot was configured to prefix gomod commits with `deps`, but the title check only accepts the standard Conventional Commit types, so every Go dependency PR failed the "Conventional Commit title" check.

## Motivation

The PR-title validation workflow allows `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test`. Dependabot's gomod config used `prefix: "deps"`, producing titles like `deps(deps): bump ...` that the gate rejects (see the failing check on https://github.com/kbukum/gokit/pull/231). `build` is the Conventional Commits type for build-system and external-dependency changes, so switching to it makes titles both valid and semantically accurate.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Module(s) Affected

- CI configuration (`.github/dependabot.yml`) — no Go modules

## Changes Made

- Change the gomod `commit-message.prefix` from `deps` to `build`; with `include: "scope"`, future Go dependency PRs are titled `build(deps): ...`, which passes the title gate.

## Testing

Configuration-only change; no build/test gates apply.

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md

## Additional Notes

This only affects newly opened Dependabot PRs. Existing open PRs (e.g. #231) keep their `deps(...)` title and need a manual title edit to go green.
