### PR TITLE
fix(ci): suppress GO-2026-5932 for the dataset module

### DIFF
--- a/.github/govulncheck-suppressions.json
+++ b/.github/govulncheck-suppressions.json
@@ -19,6 +19,7 @@
         "database",
         "database/sqlite",
         "database/testutil",
+        "dataset",
         "discovery",
         "discovery/testutil",
         "embedding",


### PR DESCRIPTION
## Description

Adds the `dataset` module to the existing `GO-2026-5932` suppression so the Security (govulncheck)
job passes. Every other module already suppresses this advisory; `dataset` was the only one missing
from the list, which failed the `Security` job on `main`.

## Motivation

`dataset` transitively links `golang.org/x/crypto` (through the root module and
`github.com/go-playground/validator/v10`), so govulncheck reports `GO-2026-5932` at the
**import** level. `go mod why golang.org/x/crypto` in `dataset` returns *"main module does not need
package golang.org/x/crypto"* — the vulnerable `openpgp` subpackage is never imported or called, so
the finding is not reachable. This is exactly the case the existing suppression documents; the entry
simply omitted `dataset`.

Failing run: https://github.com/kbukum/gokit/actions/runs/29653743122/job/88104367905

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Module(s) Affected

- `dataset` (CI Security/govulncheck configuration only; no code change)

## Changes Made

- Added `"dataset"` to `GO-2026-5932`'s `modules` list in
  `.github/govulncheck-suppressions.json`.

## Testing

- [x] `./scripts/govulncheck.py --module dataset -- ./...` passes (advisory now suppressed, exit 0)

### Test Evidence

```
$ ./scripts/govulncheck.py --module dataset -- ./...
=== govulncheck report (module: dataset) ===
  total advisories: 1
  suppressed:       1
  unsuppressed:     0
```

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (CI/security config change)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] No new dependencies

## Additional Notes

Same rationale and `expires` date as the existing entry; the suppression covers an unreachable,
import-level finding in the deprecated `golang.org/x/crypto/openpgp` package.
