### PR TITLE
docs: refresh repository documentation prose

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,15 +53,11 @@ $ make test M=<module>
 
 ## Breaking Changes
 
-<!-- Pre-stable: breaking changes are allowed and preferred over compat shims. If this is breaking,
-describe the impact and the redesign (not a migration shim). -->
+<!-- Pre-stable: breaking changes are allowed and preferred over compat shims. If this is breaking, describe the impact and the redesign (not a migration shim). -->
 
 ## Sibling Parity
 
-<!-- gokit mirrors rskit (the reference kit) and pykit.
-If this change touches a public abstraction (error codes, Component lifecycle, Provider shapes, stream, etc.),
-confirm parity or link the corresponding sibling item as a full URL,
-e.g. https://github.com/kbukum/rskit/issues/123 -->
+<!-- gokit mirrors rskit (the reference kit) and pykit. If this change touches a public abstraction (error codes, Component lifecycle, Provider shapes, stream, etc.), confirm parity or link the corresponding sibling item as a full URL, e.g. https://github.com/kbukum/rskit/issues/123 -->
 
 - [ ] Sibling-parity not required (internal change)
 - [ ] Sibling-parity tracked: rskit <url>, pykit <url>
@@ -72,13 +68,10 @@ e.g. https://github.com/kbukum/rskit/issues/123 -->
 - [ ] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
 - [ ] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
 - [ ] Bug fixes include a regression test that fails without the fix
-- [ ] Suite is green under `-race -shuffle=on`;
-  coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing)
-  and the CI codecov gate (project 80% / patch 85%)
+- [ ] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI Codecov gate
 - [ ] No public `interface{}`/`any` (generics/typed); documented exceptions only
 - [ ] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
-- [ ] Dependencies (logger/tracer/policies/registries) injected — no globals
-  or `init()` side effects
+- [ ] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
 - [ ] Code split by concern into focused files — not piled into one file
 - [ ] Exported items have godoc; each package has a `doc.go`; docs updated
 - [ ] `make tidy` run so go.mod/go.sum are clean for affected modules

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,10 +1,6 @@
 # gokit development skills
 
-[Agent Skills](https://docs.github.com/copilot/concepts/agents/about-agent-skills) for developing **gokit itself**
-—
-loaded on demand by GitHub Copilot (CLI, coding agent, code review, IDEs) when a task matches a skill's description.
-These are **project skills** for contributors;
-they do not affect anyone who consumes gokit as a library.
+[Agent Skills](https://docs.github.com/copilot/concepts/agents/about-agent-skills) for developing **gokit itself** — loaded on demand by GitHub Copilot (CLI, coding agent, code review, IDEs) when a task matches a skill's description. These are **project skills** for contributors; they do not affect anyone who consumes gokit as a library.
 
 Each skill is a folder with a `SKILL.md` (YAML frontmatter + workflow)
 and optional bundled reference files loaded only when the skill activates (progressive disclosure).
@@ -32,10 +28,6 @@ and drive tasks through [`toven`](../../toven.toml), the repo's argv-first task 
 
 ## Conventions
 
-- Skills are discoverable in Copilot CLI via `/skills`;
-  project skills live under `.github/skills/` (also `.claude/skills` / `.agents/skills` are honored),
-  personal skills under `~/.copilot/skills`.
-- Run reviews (`review`) in a **fresh, clean-context agent**,
-  never inline in the session that wrote the code.
-- Validation is toven-first:
-  prefer `toven <task> --module go:<name>` / `toven affected <task> --base origin/main --merge-base` over hand-rolled `go`/`make` commands.
+- Skills are discoverable in Copilot CLI via `/skills`; project skills live under `.github/skills/` (also `.claude/skills` / `.agents/skills` are honored), personal skills under `~/.copilot/skills`.
+- Run reviews (`review`) in a **fresh, clean-context agent**, never inline in the session that wrote the code.
+- Validation is toven-first: prefer `toven <task> --module go:<name>` / `toven affected <task> --base origin/main --merge-base` over hand-rolled `go`/`make` commands.

--- a/.github/skills/apply-plan/SKILL.md
+++ b/.github/skills/apply-plan/SKILL.md
@@ -10,9 +10,7 @@ user-invocable: true
 
 # Applying a plan from its remaining steps
 
-`apply-plan` takes a plan folder (produced by the `create-plan` skill) and drives it to completion,
-**starting from the first step that is not yet done**
-so it can be run repeatedly to resume interrupted work.
+`apply-plan` takes a plan folder (produced by the `create-plan` skill) and drives it to completion, **starting from the first step that is not yet done** so it can be run repeatedly to resume interrupted work.
 
 ## Input
 
@@ -41,30 +39,19 @@ grep -n '\*\*Status:\*\*' tmp/<plan>/*.md
 
 ## 2. Apply each remaining step in order
 
-For each remaining step, in dependency order,
-run the **`apply-step` workflow** on that step file (read the README + all prior steps for context, apply the current step test-first, validate, then mark it done).
+For each remaining step, in dependency order, run the **`apply-step` workflow** on that step file (read the README + all prior steps for context, apply the current step test-first, validate, then mark it done).
 Do not skip ahead; do not batch several steps into one undifferentiated change —
 each step stays a standalone, reviewable unit.
 
 Between steps:
 
-- **Validate the affected modules** with the `validate` skill (toven, scoped) —
-  do not proceed to the next step on a red one.
-- If a step's acceptance criteria cannot be met as written, **stop**
-  and report the divergence rather than forcing a green; the plan may need a `create-plan` revision.
-  The baseline in [`../../copilot-instructions.md`](../../copilot-instructions.md) wins over the plan text.
+- **Validate the affected modules** with the `validate` skill (toven, scoped) — do not proceed to the next step on a red one.
+- If a step's acceptance criteria cannot be met as written, **stop** and report the divergence rather than forcing a green; the plan may need a `create-plan` revision. The baseline in [`../../copilot-instructions.md`](../../copilot-instructions.md) wins over the plan text.
 
 ## 3. Baseline and review
 
-Every step is executed against gokit's engineering baseline, not a looser plan-local standard.
-After a step (or a coherent group of steps) lands,
-run the `review` skill's passes over the diff in a fresh, clean-context agent.
-Treat a green `validate` run as necessary but not sufficient.
+Every step is executed against gokit's engineering baseline, not a looser plan-local standard. After a step (or a coherent group of steps) lands, run the `review` skill's passes over the diff in a fresh, clean-context agent. Treat a green `validate` run as necessary but not sufficient.
 
 ## Repo workflow
 
-Do the work on a branch —
-cut it with the `create-branch` skill (off an up-to-date main, named by the change, not by the plan or a step number).
-Apply steps and leave the edits **uncommitted**: the maintainer commits and pushes,
-and a PR is opened only when explicitly asked. Applying a plan never commits, pushes,
-or opens a PR on its own.
+Do the work on a branch — cut it with the `create-branch` skill (off an up-to-date main, named by the change, not by the plan or a step number). Apply steps and leave the edits **uncommitted**: the maintainer commits and pushes, and a PR is opened only when explicitly asked. Applying a plan never commits, pushes, or opens a PR on its own.

--- a/.github/skills/apply-step/SKILL.md
+++ b/.github/skills/apply-step/SKILL.md
@@ -10,9 +10,7 @@ user-invocable: true
 
 # Applying one plan step, in context
 
-`apply-step` implements exactly one step of a plan folder (from the `create-plan` skill).
-It is the unit of work that `apply-plan` calls per step,
-and it can also be run directly on a single step file.
+`apply-step` implements exactly one step of a plan folder (from the `create-plan` skill). It is the unit of work that `apply-plan` calls per step, and it can also be run directly on a single step file.
 
 ## Input
 
@@ -20,14 +18,10 @@ A path to one step file, e.g. `tmp/storage-gcs-backend/02-registry.md`.
 
 ## 1. Load full context before editing
 
-A step is not self-contained — earlier steps make naming, layering,
-and API decisions this step depends on. Read, in order:
+A step is not self-contained — earlier steps make naming, layering, and API decisions this step depends on. Read, in order:
 
-1. **`README.md`** of the plan folder — goal, dependency order,
-   and the cross-cutting baseline rules that bind every step.
-2. **Every previous step** (`NN-*.md` with a lower number) — for the decisions
-   and files they already established. Honor them; do not re-litigate
-   or contradict a completed step.
+1. **`README.md`** of the plan folder — goal, dependency order, and the cross-cutting baseline rules that bind every step.
+2. **Every previous step** (`NN-*.md` with a lower number) — for the decisions and files they already established. Honor them; do not re-litigate or contradict a completed step.
 3. **The current step** — its scope, numbered actions, files touched, and acceptance criteria.
 
 Confirm the current step's *Depends on* steps are `done` before starting.
@@ -35,9 +29,7 @@ If a dependency is unfinished, stop and say so.
 
 ## 2. Implement the step against the baseline
 
-Apply the current step's actions **test-first**, honoring gokit's engineering baseline —
-the plan does not override it,
-and the authority is [`../../copilot-instructions.md`](../../copilot-instructions.md):
+Apply the current step's actions **test-first**, honoring gokit's engineering baseline — the plan does not override it, and the authority is [`../../copilot-instructions.md`](../../copilot-instructions.md):
 
 - **TDD.** For each behavior: failing test → minimal code → refactor while green,
   failure paths included. Never write the production code first and add tests after.
@@ -52,17 +44,12 @@ Keep the edit scoped to *this* step's `Files touched`; if you discover the step 
 
 ## 3. Validate, review, and mark done
 
-- **Validate** the affected modules with the `validate` skill (toven, scoped),
-  green under `-race -shuffle`. A step does not land red.
-  Run `make structure` (declare-only aggregator guard) before marking the step done.
-- **Review** the step's diff with the relevant `review` passes (structure/placement, canonical reuse, principles, security, quality, tests, docs, comments)
-  — ideally in a fresh agent.
+- **Validate** the affected modules with the `validate` skill (toven, scoped), green under `-race -shuffle`. A step does not land red. Run `make structure` (declare-only aggregator guard) before marking the step done.
+- **Review** the step's diff with the relevant `review` passes (structure/placement, canonical reuse, principles, security, quality, tests, docs, comments) — ideally in a fresh agent.
 - Only when acceptance criteria are genuinely met, flip the step's progress signal
   so `apply-plan` can resume: set `**Status:** done` and check its `- [x]` boxes.
   Do not mark a step done on a partial or red result.
 
 ## Repo workflow
 
-Work on a branch (`create-branch` skill), leave edits **uncommitted** for the maintainer to commit
-and push; open a PR only when explicitly asked. When that change becomes a branch/PR,
-name it by the change — never `step-2` or a plan/batch number.
+Work on a branch (`create-branch` skill), leave edits **uncommitted** for the maintainer to commit and push; open a PR only when explicitly asked. When that change becomes a branch/PR, name it by the change — never `step-2` or a plan/batch number.

--- a/.github/skills/commit/SKILL.md
+++ b/.github/skills/commit/SKILL.md
@@ -9,10 +9,7 @@ user-invocable: true
 
 # Committing with a clean, developer-friendly message
 
-A commit message tells the next developer *what changed and why*, in as few words as it takes.
-This skill keeps gokit's history tidy: one focused change per commit,
-a message that reads like a maintainer wrote it, and **nothing extra** — no trailers,
-no attributions, no process log.
+A commit message tells the next developer *what changed and why*, in as few words as it takes. This skill keeps gokit's history tidy: one focused change per commit, a message that reads like a maintainer wrote it, and **nothing extra** — no trailers, no attributions, no process log.
 
 ## 1. Know what you're committing
 
@@ -35,12 +32,9 @@ Fix typos across skill docs
 Rename Resolve to MustResolve in di container
 ```
 
-- **Subject only** for small changes; keep it under ~72 chars.
-  Add a short body (blank line, then wrapped prose) **only** when the *why* isn't obvious from the subject.
-- Conventional-Commit prefixes (`feat:`, `fix:`, `docs:`) are fine when the repo/PR uses them —
-  match the surrounding history; don't force them.
-- Describe the current change, not the journey: no "previously we…", no "as requested in review",
-  no bug-and-fix retelling.
+- **Subject only** for small changes; keep it under ~72 chars. Add a short body (blank line, then wrapped prose) **only** when the *why* isn't obvious from the subject.
+- Conventional-Commit prefixes (`feat:`, `fix:`, `docs:`) are fine when the repo/PR uses them — match the surrounding history; don't force them.
+- Describe the current change, not the journey: no "previously we…", no "as requested in review", no bug-and-fix retelling.
 
 **Never include:**
 
@@ -60,6 +54,5 @@ Use a message file for a subject + body:
 git commit -F <path-to-message>
 ```
 
-Do **not** amend or rewrite already-pushed history,
-and do **not** run destructive git commands on uncommitted work.
+Do **not** amend or rewrite already-pushed history, and do **not** run destructive git commands on uncommitted work.
 Push only when asked (or when the task — e.g. resolving PR reviews — requires the commit to be on the branch).

--- a/.github/skills/create-branch/SKILL.md
+++ b/.github/skills/create-branch/SKILL.md
@@ -10,34 +10,25 @@ user-invocable: true
 
 # Creating a branch for gokit work
 
-A branch
-and its eventual PR must read as a **standalone unit of change** to a reviewer who has no knowledge of how the work was planned
-or sequenced. Two rules make that true: branch off the right, up-to-date base,
-and name the branch after the actual change — nothing else.
+A branch and its eventual PR must read as a **standalone unit of change** to a reviewer who has no knowledge of how the work was planned or sequenced. Two rules make that true: branch off the right, up-to-date base, and name the branch after the actual change — nothing else.
 
 ## Golden rule: branch off an up-to-date main
 
-Unless the request explicitly says to build on another branch,
-always base new work on the latest `origin/main`. Never branch off a stale local `main`
-or whatever happens to be checked out.
+Unless the request explicitly says to build on another branch, always base new work on the latest `origin/main`. Never branch off a stale local `main` or whatever happens to be checked out.
 
 ```bash
 git fetch origin                       # refresh remote refs first — always
 git switch -c <branch-name> origin/main
 ```
 
-If (and only if) the request says to stack on top of another branch, base on that branch instead
-and keep it current:
+If (and only if) the request says to stack on top of another branch, base on that branch instead and keep it current:
 
 ```bash
 git fetch origin
 git switch -c <branch-name> origin/<base-branch>   # explicit base, per the request
 ```
 
-Before switching, check the working tree with `git status`.
-Uncommitted changes follow you onto the new branch —
-that is usually what you want when you have already started editing,
-but confirm it is intentional rather than dragging along unrelated edits.
+Before switching, check the working tree with `git status`. Uncommitted changes follow you onto the new branch — that is usually what you want when you have already started editing, but confirm it is intentional rather than dragging along unrelated edits.
 
 ## Naming: describe the change, not the plumbing
 
@@ -50,19 +41,14 @@ or refactor a reviewer will see. It must not leak how the work was organized int
   and the outcome (`kbukum/typed-di-cycle-detection`, `kbukum/storage-gcs-backend`).
 - Keep it short, lowercase, hyphen-separated; no spaces, no `wip`, no trailing noise.
 
-**Never** put internal, sequencing, or local-only information in the name —
-it is meaningless to a reviewer and wrong once the work is split into standalone PRs:
+**Never** put internal, sequencing, or local-only information in the name — it is meaningless to a reviewer and wrong once the work is split into standalone PRs:
 
 - ❌ plan/batch/group numbers: `batch-5-storage`, `group7-cleanup`, `phase2`
 - ❌ task/ticket scaffolding that isn't the change itself, internal roadmap step numbers
 - ❌ session-, machine-, or tool-local detail
 
-If you catch yourself writing `batch-5-...`, ask "what does this change actually do?"
-and name it that instead. Each branch stands alone;
-there is no "batch 5" from a reviewer's perspective.
+If you catch yourself writing `batch-5-...`, ask "what does this change actually do?" and name it that instead. Each branch stands alone; there is no "batch 5" from a reviewer's perspective.
 
 ## After the branch exists
 
-Per repo workflow, this skill **creates the branch and leaves the edits uncommitted** —
-the maintainer commits and pushes, and opens a PR only when explicitly asked. Do not commit, push,
-or open a PR as part of creating the branch.
+Per repo workflow, this skill **creates the branch and leaves the edits uncommitted** — the maintainer commits and pushes, and opens a PR only when explicitly asked. Do not commit, push, or open a PR as part of creating the branch.

--- a/.github/skills/create-plan/SKILL.md
+++ b/.github/skills/create-plan/SKILL.md
@@ -11,17 +11,11 @@ user-invocable: true
 
 # Planning gokit work as applyable step files
 
-A plan is a written contract for a change set: what to do, in what order,
-and how you will know each part is done. In this repo a plan is **not prose to admire** —
-it is a folder of markdown that the `apply-plan` / `apply-step` skills execute iteratively.
+A plan is a written contract for a change set: what to do, in what order, and how you will know each part is done. In this repo a plan is **not prose to admire** — it is a folder of markdown that the `apply-plan` / `apply-step` skills execute iteratively.
 
 ## Where plans live: `tmp/<plan-name>/`
 
-Always create plans under `tmp/` at the repo root. `tmp/` is **gitignored** —
-plans are local working scratch, never committed and never shipped.
-Name the folder by the change itself in kebab-case (`tmp/typed-di-cycle-detection/`, `tmp/storage-gcs-backend/`)
-— the same high-level naming rule as branches: no `batch-N`, plan numbers,
-or internal/session detail in the folder name.
+Always create plans under `tmp/` at the repo root. `tmp/` is **gitignored** — plans are local working scratch, never committed and never shipped. Name the folder by the change itself in kebab-case (`tmp/typed-di-cycle-detection/`, `tmp/storage-gcs-backend/`) — the same high-level naming rule as branches: no `batch-N`, plan numbers, or internal/session detail in the folder name.
 
 ```bash
 mkdir -p tmp/<plan-name>
@@ -71,11 +65,7 @@ and the `- [ ]` boxes are the progress signal `apply-plan` reads to find the fir
 
 ## Bind every plan to the baseline
 
-A plan may **not** invent a lighter standard than gokit's. Its cross-cutting rules restate —
-and link to —
-the engineering baseline in [`../../copilot-instructions.md`](../../copilot-instructions.md)
-and defer detailed judgment to the `review` skill's eight passes. In every plan's README,
-make these load-bearing (not decorative):
+A plan may **not** invent a lighter standard than gokit's. Its cross-cutting rules restate — and link to — the engineering baseline in [`../../copilot-instructions.md`](../../copilot-instructions.md) and defer detailed judgment to the `review` skill's eight passes. In every plan's README, make these load-bearing (not decorative):
 
 - **Test-first (TDD).** Each behavior gets a failing test first, then minimal code,
   then refactor while green — failure paths included. Never batch production code

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -10,18 +10,13 @@ user-invocable: true
 
 # Opening a reviewer-friendly pull request
 
-A PR is a reviewer's entry point, not a changelog of your keystrokes.
-This skill turns a pushed branch into a PR whose description explains the change **at a high level,
-organized and simplified**,
-and whose template sections are filled **honestly** against gokit's baseline.
+A PR is a reviewer's entry point, not a changelog of your keystrokes. This skill turns a pushed branch into a PR whose description explains the change **at a high level, organized and simplified**, and whose template sections are filled **honestly** against gokit's baseline.
 
 Create a PR **only when explicitly asked** — never as a side effect of finishing work.
 
 ## 1. Preconditions
 
-- The branch is committed
-  and **pushed** to `origin` (the maintainer commits and pushes, per repo workflow).
-  Confirm before opening:
+- The branch is committed and **pushed** to `origin` (the maintainer commits and pushes, per repo workflow). Confirm before opening:
 
 ```bash
 git rev-parse --abbrev-ref HEAD
@@ -41,9 +36,7 @@ git diff origin/main...HEAD --stat
 git diff origin/main...HEAD            # skim for the shape of the change, not to transcribe it
 ```
 
-Answer, in your head: what capability/fix/refactor is this, which modules it touches,
-what a reviewer must understand to judge it,
-and whether it changes a public abstraction (error codes, Component lifecycle, Provider/stream shapes) that needs sibling-parity handling.
+Answer, in your head: what capability/fix/refactor is this, which modules it touches, what a reviewer must understand to judge it, and whether it changes a public abstraction (error codes, Component lifecycle, Provider/stream shapes) that needs sibling-parity handling.
 
 ## 3. Write the description — high level, organized, simplified
 
@@ -54,15 +47,10 @@ without reconstructing it from the diff.
 - **Title** — Conventional Commit style, naming the change: `feat(storage): add GCS backend`,
   `refactor(di): typed cycle detection`. No plan/batch/step numbers or internal sequencing —
   the PR stands alone.
-- **Description** — a few sentences of *what changed and why it's shaped this way*,
-  at the level of capabilities and decisions, not code lines.
-- **Motivation** — the problem it solves. Link issues as `Fixes #123`;
-  reference **other repos as full URLs** (e.g. `https://github.com/kbukum/rskit/issues/45`),
-  never a bare `#45`.
+- **Description** — a few sentences of *what changed and why it's shaped this way*, at the level of capabilities and decisions, not code lines.
+- **Motivation** — the problem it solves. Link issues as `Fixes #123`; reference **other repos as full URLs** (e.g. `https://github.com/kbukum/rskit/issues/45`), never a bare `#45`.
 - **Type of Change / Module(s) Affected** — mark accurately.
-- **Changes Made** — a short,
-  grouped bullet list of the *key* changes by concern (e.g. "typed registry factory", "in-memory default kept in core"),
-  not one bullet per file and not a commit log.
+- **Changes Made** — a short, grouped bullet list of the *key* changes by concern (e.g. "typed registry factory", "in-memory default kept in core"), not one bullet per file and not a commit log.
 - **Testing** — check only the gates you actually ran; scope to affected modules.
   These map to `toven` (see the `validate` skill):
   `toven test/lint/format-check/vuln --module go:<name>` or `toven affected ...`.
@@ -91,6 +79,4 @@ gh pr create --base main --title "<conventional-title>" --body-file <path>
 
 ## Baseline
 
-The PR asserts the change meets gokit's engineering baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md));
-if it doesn't yet, run the `review` skill first
-and fix findings rather than opening a PR that fails its own checklist.
+The PR asserts the change meets gokit's engineering baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md)); if it doesn't yet, run the `review` skill first and fix findings rather than opening a PR that fails its own checklist.

--- a/.github/skills/fix-reviews/SKILL.md
+++ b/.github/skills/fix-reviews/SKILL.md
@@ -11,18 +11,13 @@ user-invocable: true
 
 # Fixing PR reviews by pattern
 
-A review comment points at one spot, but it almost always describes a *class* of problem.
-The value of this skill is **generalization**: treat each comment as a probe into a pattern,
-fix every instance of that pattern across the change set, and only then resolve the thread.
-A reviewer who flags one typo, one missing timeout,
-or one ungeneric API is telling you where to look — not the full extent of the fix.
+A review comment points at one spot, but it almost always describes a *class* of problem. The value of this skill is **generalization**: treat each comment as a probe into a pattern, fix every instance of that pattern across the change set, and only then resolve the thread. A reviewer who flags one typo, one missing timeout, or one ungeneric API is telling you where to look — not the full extent of the fix.
 
 Act on reviews **only when explicitly asked** — never as a side effect of finishing work.
 
 ## 1. Gather the reviews
 
-Identify the PR (current branch's PR unless one is named) and pull every review, inline comment,
-and thread with its resolution state and node IDs:
+Identify the PR (current branch's PR unless one is named) and pull every review, inline comment, and thread with its resolution state and node IDs:
 
 ```bash
 gh pr view --json number,title,url,headRefName
@@ -50,19 +45,14 @@ gh api graphql -f query='
 
 For every comment, decide before touching code:
 
-- **Valid?** Judge it against gokit's baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md)),
-  not the reviewer's authority. If a suggestion conflicts with the baseline or is simply wrong,
-  **do not apply it** —
-  note why (you may leave the thread unresolved for the maintainer, but never argue under their name).
+- **Valid?** Judge it against gokit's baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md)), not the reviewer's authority. If a suggestion conflicts with the baseline or is simply wrong, **do not apply it** — note why (you may leave the thread unresolved for the maintainer, but never argue under their name).
 - **What is the real pattern?** Look past the wording to the class of issue:
   - a typo/grammar note → *spelling & wording across all changed prose and comments*
   - a missing timeout/cancellation on one call → *every remote call in the change set*
   - `interface{}`/`any` in one signature → *every public surface touched*
   - a naming/formatting nit → *the same construct everywhere in the diff*
   - a duplicated-concern note → *every place that reinvents the canonical owner*
-- **Scope of the sweep.** Default to the PR's change set (`git diff origin/main...HEAD`).
-  Widen to neighbouring files only when the pattern clearly extends there
-  and the fix stays coherent; note the widening. Do not silently refactor unrelated code.
+- **Scope of the sweep.** Default to the PR's change set (`git diff origin/main...HEAD`). Widen to neighbouring files only when the pattern clearly extends there and the fix stays coherent; note the widening. Do not silently refactor unrelated code.
 
 ## 3. Apply the pattern across the change set
 
@@ -89,11 +79,7 @@ Docs/prose-only sweeps need no Go gates. Never resolve a thread whose fix hasn't
 
 ## 5. Commit, push, and resolve
 
-Commit the pattern fixes using the [`commit`](../commit/SKILL.md) skill — a single compact,
-developer-friendly message that states the change as it stands, **no `Co-authored-by` trailer**
-and no review/plan/batch narration.
-Group commits by pattern when it aids the reader (one commit per class of fix),
-or a single tidy commit when the sweep is small.
+Commit the pattern fixes using the [`commit`](../commit/SKILL.md) skill — a single compact, developer-friendly message that states the change as it stands, **no `Co-authored-by` trailer** and no review/plan/batch narration. Group commits by pattern when it aids the reader (one commit per class of fix), or a single tidy commit when the sweep is small.
 
 ```bash
 git push
@@ -108,11 +94,8 @@ gh api graphql -f query='
   -F id=<threadId>
 ```
 
-Leave unresolved only the threads you deliberately rejected (baseline conflict)
-or that need a maintainer decision; briefly report those back rather than resolving them silently.
+Leave unresolved only the threads you deliberately rejected (baseline conflict) or that need a maintainer decision; briefly report those back rather than resolving them silently.
 
 ## Baseline
 
-Every fix must still satisfy gokit's engineering baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md))
-— a review-driven change is held to the same bar as any other.
-If acting on a comment would push code below the baseline, reject the comment instead.
+Every fix must still satisfy gokit's engineering baseline ([`../../copilot-instructions.md`](../../copilot-instructions.md)) — a review-driven change is held to the same bar as any other. If acting on a comment would push code below the baseline, reject the comment instead.

--- a/.github/skills/new-backend/SKILL.md
+++ b/.github/skills/new-backend/SKILL.md
@@ -11,27 +11,19 @@ user-invocable: true
 
 # Adding a backend adapter to gokit
 
-gokit's data/ai layers use a registry + factory pattern so a core module ships an in-memory
-or local default and heavy provider backends live in opt-in **contrib sub-modules**.
-Follow the existing owners exactly — do not invent a new registration mechanism.
+gokit's data/ai layers use a registry + factory pattern so a core module ships an in-memory or local default and heavy provider backends live in opt-in **contrib sub-modules**. Follow the existing owners exactly — do not invent a new registration mechanism.
 
 ## The binding rules
 
-1. **Nested contrib sub-module.** The adapter lives under its owner as its own `go.mod` (`storage/s3`, `storage/gcs`, `vectorstore/qdrant`, `messaging/kafka`, `cache/redis`, `llm/providers`, `inference/vllm`, …).
-   It carries the heavy SDK dependency so core stays light.
-2. **Explicit typed `Register`.** Each backend exposes a typed `Register(registry, cfg Config)` (or `RegisterX(registry, cfg)`) that captures provider config in the **factory closure**.
-   Factories are typed funcs — `func(cfg, log) (T, error)` / `func(cfg) (T, error)` —
-   **never** a `providerCfg any` / `adapterCfg any` parameter.
+1. **Nested contrib sub-module.** The adapter lives under its owner as its own `go.mod` (`storage/s3`, `storage/gcs`, `vectorstore/qdrant`, `messaging/kafka`, `cache/redis`, `llm/providers`, `inference/vllm`, …). It carries the heavy SDK dependency so core stays light.
+2. **Explicit typed `Register`.** Each backend exposes a typed `Register(registry, cfg Config)` (or `RegisterX(registry, cfg)`) that captures provider config in the **factory closure**. Factories are typed funcs — `func(cfg, log) (T, error)` / `func(cfg) (T, error)` — **never** a `providerCfg any` / `adapterCfg any` parameter.
 3. **No `init()` side effects, no mutable package globals.** Registration is explicit
    and caller-driven; the registry is injected, not a global.
    (See the composition principle in `.github/copilot-instructions.md`.)
 4. **Core keeps the default.** The in-memory / local backend stays in the core module
    and remains the zero-config default; contrib backends are selected via config.
 
-Reference owners to copy from: `storage/factory.go` (`StorageFactory`, typed `Register`),
-`vectorstore/factory.go` (`Factory`, `RegisterMemory`),
-`messaging/registry.go` (typed `ProducerFactory`/`ConsumerFactory`),
-and the existing backends `storage/gcs/gcs.go`, `vectorstore/qdrant/qdrant.go`.
+Reference owners to copy from: `storage/factory.go` (`StorageFactory`, typed `Register`), `vectorstore/factory.go` (`Factory`, `RegisterMemory`), `messaging/registry.go` (typed `ProducerFactory`/`ConsumerFactory`), and the existing backends `storage/gcs/gcs.go`, `vectorstore/qdrant/qdrant.go`.
 
 ## Steps
 
@@ -43,20 +35,14 @@ and the existing backends `storage/gcs/gcs.go`, `vectorstore/qdrant/qdrant.go`.
    # replace github.com/kbukum/gokit => ../../   (nested → two levels up)
    ```
 
-Add `./<owner>/<backend>` to **`contrib.go.work`**
-and the module to the owner's domain in `domains.toml`.
+Add `./<owner>/<backend>` to **`contrib.go.work`** and the module to the owner's domain in `domains.toml`.
 
 2. **Define a typed `Config`** for the backend (endpoint, credentials source, timeouts, bucket/ topic names).
    No `any`. Validate it at construction — this is a trust boundary.
 
-3. **Implement the adapter** against the owner's interface.
-   Timeout every remote call via `context.Context`;
-   bounded jittered retries for idempotent ops only;
-   degrade/circuit-break rather than success-shaped fallbacks. Tokens go in headers,
-   not query strings. Split code by concern into focused files (config, client, adapter, mapping).
+3. **Implement the adapter** against the owner's interface. Timeout every remote call via `context.Context`; bounded jittered retries for idempotent ops only; degrade/circuit-break rather than success-shaped fallbacks. Tokens go in headers, not query strings. Split code by concern into focused files (config, client, adapter, mapping).
 
-4. **Expose `Register`** that closes over the config
-   and installs the typed factory into the passed registry. No global registry, no `init()`.
+4. **Expose `Register`** that closes over the config and installs the typed factory into the passed registry. No global registry, no `init()`.
 
    ```go
    // Register installs the <backend> factory into the registry using cfg.

--- a/.github/skills/new-module/SKILL.md
+++ b/.github/skills/new-module/SKILL.md
@@ -10,16 +10,12 @@ user-invocable: true
 
 # Adding a package or module to gokit
 
-gokit is a multi-module monorepo. Core packages share the root `go.mod` (`github.com/kbukum/gokit`);
-packages with heavy external dependencies get their own `go.mod` as sub-modules. Getting placement
-and wiring right up front avoids layering violations and pseudo -version breakage later.
+gokit is a multi-module monorepo. Core packages share the root `go.mod` (`github.com/kbukum/gokit`); packages with heavy external dependencies get their own `go.mod` as sub-modules. Getting placement and wiring right up front avoids layering violations and pseudo-version breakage later.
 
 ## Step 1 — Decide: root package or sub-module
 
-- **No heavy third-party deps** (stdlib + existing gokit only) → add a package **under the root module**.
-  No new `go.mod`.
-- **Heavy deps** (a cloud SDK, a driver, a broker client, an ML runtime) → create a **sub-module** with its own `go.mod`
-  so consumers who don't need it don't pay for the dependency.
+- **No heavy third-party deps** (stdlib + existing gokit only) → add a package **under the root module**. No new `go.mod`.
+- **Heavy deps** (a cloud SDK, a driver, a broker client, an ML runtime) → create a **sub-module** with its own `go.mod` so consumers who don't need it don't pay for the dependency.
 
 When in doubt, prefer the root module;
 promote to a sub-module only when a real heavy dependency forces it.
@@ -31,10 +27,7 @@ Consult `domains.toml` for the domain→module map and each domain's `depends_on
 
 - core → patterns → crosscutting → composition → transport → auth → {data, ai} → media → infra
 
-Your new package may only import lower or same-layer packages.
-A lower layer importing a higher one is a **blocker**.
-Transport (server/grpc/connect/sse) specifically must not import auth/authz —
-inject local interfaces instead.
+Your new package may only import lower or same-layer packages. A lower layer importing a higher one is a **blocker**. Transport (server/grpc/connect/sse) specifically must not import auth/authz — inject local interfaces instead.
 
 ## Step 3 — Create the package
 
@@ -49,11 +42,7 @@ package foo
 Conventions: package names are lowercase, single-word, no plurals.
 Exported interfaces (1–3 methods) + factory functions; concrete implementations unexported.
 Constructors take `...Option` (functional options).
-No `interface{}`/`any` in public APIs except a documented opaque value. Organize by focused,
-concern-named files (types, options, registry, middleware, adapter) from the start —
-the `doc.go` aggregator stays docs-only, never a monolithic starter file.
-Before adding a shared helper, check [`docs/concern-owners.md`](../../../docs/concern-owners.md)
-so the new module does not re-own an existing concern.
+No `interface{}`/`any` in public APIs except a documented opaque value. Organize by focused, concern-named files (types, options, registry, middleware, adapter) from the start — the `doc.go` aggregator stays docs-only, never a monolithic starter file. Before adding a shared helper, check [`docs/concern-owners.md`](../../../docs/concern-owners.md) so the new module does not re-own an existing concern.
 
 ## Step 4 — Sub-module wiring (only if you created a new go.mod)
 

--- a/.github/skills/parity/SKILL.md
+++ b/.github/skills/parity/SKILL.md
@@ -10,55 +10,31 @@ user-invocable: true
 
 # Keeping gokit at rskit parity
 
-gokit is a sibling kit to rskit (Rust) and pykit (Python): same module structure and naming,
-same engineering baseline, idiomatic per language. **rskit received a full quality pass
-and is the current reference shape/quality** for cross-kit parity;
-the active goal is bringing gokit to rskit-level and release readiness.
-rskit lives in the sibling repo `../rskit`.
+gokit is a sibling kit to rskit (Rust) and pykit (Python): same module structure and naming, same engineering baseline, idiomatic per language. **rskit received a full quality pass and is the current reference shape/quality** for cross-kit parity; the active goal is bringing gokit to rskit-level and release readiness. rskit lives at https://github.com/kbukum/rskit.
 
 ## Mirror by capability, not blindly
 
-Parity is judged **by capability**, weighing where each language is strongest —
-not by copying every rskit symbol. Decide per capability:
+Parity is judged **by capability**, weighing where each language is strongest — not by copying every rskit symbol. Decide per capability:
 
-- **Fully mirror** when Go is equally capable
-  and the concept is shared infrastructure (errors, config, di, provider shapes, resilience, transport, data adapters).
-- **Light version** when Go can cover the common case but the heavy work belongs in Rust.
-  **Media is the canonical example:** gokit `media` is a light standalone module — detection,
-  metadata, cheap image ops, time/spatial types, subtitles (SRT/VTT).
-  Heavy audio/video/matrix transcoding
-  and codec/filter/pipeline vocabulary stay **rskit-only** by design.
-- **Intentionally kit-only** when a concept is framework-specific (e.g. rskit `http` is Axum -specific and folded into gokit `server`; gokit `connect` is ConnectRPC-specific with no rskit peer).
-  Record these as deliberate `➖` rows with a note, not gaps to close.
+- **Fully mirror** when Go is equally capable and the concept is shared infrastructure (errors, config, di, provider shapes, resilience, transport, data adapters).
+- **Light version** when Go can cover the common case but the heavy work belongs in Rust. **Media is the canonical example:** gokit `media` is a light standalone module — detection, metadata, cheap image ops, time/spatial types, subtitles (SRT/VTT). Heavy audio/video/matrix transcoding and codec/filter/pipeline vocabulary stay **rskit-only** by design.
+- **Intentionally kit-only** when a concept is framework-specific (e.g. rskit `http` is Axum-specific and folded into gokit `server`; gokit `connect` is ConnectRPC-specific with no rskit peer). Record these as deliberate `➖` rows with a note, not gaps to close.
 
 When in doubt about a heavy capability, prefer the light-gokit / strong-rskit split.
 
 ## Workflow
 
-1. **Read the rskit owner.** Find the counterpart crate in `../rskit` and study its public API,
-   invariants, and error model — not just its surface.
+1. **Read the rskit owner.** Find the counterpart crate in the [rskit repo](https://github.com/kbukum/rskit) and study its public API, invariants, and error model — not just its surface.
 2. **Decide the mirroring level** (full / light / kit-only) using the rules above.
-3. **Implement idiomatically in Go** — generics-first, typed errors (`AppError`/RFC 9457),
-   options constructors, no `any` in public APIs. Do not transliterate Rust; match behavior
-   and invariants, express them the Go way.
-   Enforce documented value invariants in code (saturate/ clamp, NaN guards, half-open ranges) as gokit `media` does.
-4. **Update `docs/parity-matrix.md`.** Adjust the module-presence row (✅ / ➖ / ⏳)
-   and the gokit-specific capability tables.
-   The module-presence table is a shared cross-kit source (kept identical in `rskit/docs/parity-matrix.md`)
-   — keep both sides consistent and note any intentional divergence.
-5. **Flag rskit improvements upward.** If aligning gokit exposes a gap, weakness,
-   or redesign opportunity in rskit, note it — rskit is foundational
-   and multi-purpose (not gokit-specific), and is still in development,
-   so improving it generically is wanted. Never make rskit gokit-specific.
+3. **Implement idiomatically in Go** — generics-first, typed errors (`AppError`/RFC 9457), options constructors, no `any` in public APIs. Do not transliterate Rust; match behavior and invariants, express them the Go way. Enforce documented value invariants in code (saturate/clamp, NaN guards, half-open ranges) as gokit `media` does.
+4. **Update `docs/parity-matrix.md`.** Adjust the module-presence row (✅ / ➖ / ⏳) and the gokit-specific capability tables. The module-presence table is a shared cross-kit source (kept identical in `rskit/docs/parity-matrix.md`) — keep both sides consistent and note any intentional divergence.
+5. **Flag rskit improvements upward.** If aligning gokit exposes a gap, weakness, or redesign opportunity in rskit, note it — rskit is foundational and multi-purpose (not gokit-specific), and is still in development, so improving it generically is wanted. Never make rskit gokit-specific.
 
 ## Naming and cross-references
 
-- Module/package names align across kits (gokit `logging` matches rskit `logging`, etc.).
-  Preserve the shared naming; call out any deliberate rename in the parity matrix.
-- In PR/issue text, reference items in rskit (or any other repo) with **full URLs**,
-  never bare `#123` — a bare number resolves to the current repo.
-- Do not name branches/commits/PRs after internal plan or batch numbers;
-  name by the actual capability change. Each PR must read standalone.
+- Module/package names align across kits (gokit `logging` matches rskit `logging`, etc.). Preserve the shared naming; call out any deliberate rename in the parity matrix.
+- In PR/issue text, reference items in rskit (or any other repo) with **full URLs**, never bare `#123` — a bare number resolves to the current repo.
+- Do not name branches/commits/PRs after internal plan or batch numbers; name by the actual capability change. Each PR must read standalone.
 
 ## Validate
 

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -10,10 +10,7 @@ user-invocable: true
 
 # Releasing gokit
 
-gokit is a multi-module repo where **each module needs its own semver git tag** —
-without proper tags Go assigns broken pseudo-versions.
-`tag-modules.sh` tags every module consistently. Full details live in `docs/RELEASING.md`,
-`docs/VERSIONING.md`, `policy/SEMVER.md`, and `policy/DEPRECATION.md`.
+gokit is a multi-module repo where **each module needs its own semver git tag** — without proper tags Go assigns broken pseudo-versions. `tag-modules.sh` tags every module consistently. Full details live in `docs/RELEASING.md`, `docs/VERSIONING.md`, `docs/policy/SEMVER.md`, and `docs/policy/DEPRECATION.md`.
 
 ## Prerequisites
 
@@ -46,7 +43,7 @@ git tag --sort=-v:refname | head -1                 # latest tag
 git log --oneline $(git describe --tags --abbrev=0)..HEAD
 ```
 
-Use `policy/SEMVER.md`. While in `0.x`:
+Use `docs/policy/SEMVER.md`. While in `0.x`:
 a breaking change in the `[Unreleased]` CHANGELOG section bumps **MINOR**; otherwise **PATCH**.
 
 ## Step 3 — Update the CHANGELOG
@@ -78,7 +75,5 @@ CI actions must be SHA-pinned; artifacts signed.
 ## Guardrails
 
 - **Never** run destructive git commands (`reset --hard`, `checkout -- .`, `clean`) on uncommitted work without explicit permission.
-- Per repo workflow, the agent prepares the branch/CHANGELOG/edits; **the maintainer commits,
-  pushes, and runs the actual `--push` tagging** unless explicitly asked otherwise.
-  Only create a PR when explicitly requested, following the PR template.
+- Per repo workflow, the agent prepares the branch/CHANGELOG/edits; **the maintainer commits, pushes, and runs the actual `--push` tagging** unless explicitly asked otherwise. Only create a PR when explicitly requested, following the PR template.
 - Reference other-repo items with full URLs, never bare `#123`.

--- a/.github/skills/review/SKILL.md
+++ b/.github/skills/review/SKILL.md
@@ -11,24 +11,14 @@ user-invocable: true
 
 # Reviewing gokit against its engineering baseline
 
-gokit is shared foundation infrastructure:
-a defect in a core package propagates to every sub-module, every adapter,
-and every downstream consumer (rskit/pykit parity repos and services that import gokit).
-The bar is correspondingly high.
-This skill encodes gokit's permanent review baseline as eight focused passes plus three orchestrators.
+gokit is shared foundation infrastructure: a defect in a core package propagates to every sub-module, every adapter, and every downstream consumer (rskit/pykit parity repos and services that import gokit). The bar is correspondingly high. This skill encodes gokit's permanent review baseline as eight focused passes plus three orchestrators.
 
 The authoritative baseline lives in [`.github/copilot-instructions.md`](../../copilot-instructions.md).
-A plan, issue, or roadmap may be passed in **as a scope checklist only** —
-it defines intended scope, never excuses a baseline violation. If the code diverges from the plan,
-report the divergence; the baseline wins.
+A plan, issue, or roadmap may be passed in **as a scope checklist only** — it defines intended scope, never excuses a baseline violation. If the code diverges from the plan, report the divergence; the baseline wins.
 
 ## Run in a separate, clean-context agent
 
-**Always dispatch a review to a fresh reviewer with no shared session context** —
-never inline in the session that wrote the code.
-A reviewer that "remembers" writing the change rationalizes it;
-an independent agent re-derives every judgment from the code and the principles.
-Hand it only the scope (diff or module/domain) and this skill.
+**Always dispatch a review to a fresh reviewer with no shared session context** — never inline in the session that wrote the code. A reviewer that "remembers" writing the change rationalizes it; an independent agent re-derives every judgment from the code and the principles. Hand it only the scope (diff or module/domain) and this skill.
 
 ## Pick a driver
 
@@ -42,29 +32,16 @@ Hand it only the scope (diff or module/domain) and this skill.
 
 ## The eight focused passes (run in order)
 
-Stop and reject as soon as a change fails pass `00` or `01` — misplaced
-or duplicated code makes every later pass moot.
-Each file also carries a "Project mode" note for tree-wide sweeps
-and can be run standalone when you need only one lens.
+Stop and reject as soon as a change fails pass `00` or `01` — misplaced or duplicated code makes every later pass moot. Each file also carries a "Project mode" note for tree-wide sweeps and can be run standalone when you need only one lens.
 
-1. [`references/00-structure-placement.md`](references/00-structure-placement.md) —
-   module placement (root vs sub-module vs nested adapter), acyclic layering (`depguard`), `doc.go`
-   and go.work wiring.
-2. [`references/01-canonical-reuse.md`](references/01-canonical-reuse.md) —
-   did the code reimplement a concern an existing package (or the stdlib) already owns?
-   *(blocker class)*
-3. [`references/02-principles.md`](references/02-principles.md) — typed/minimal APIs,
-   errors & resilience, concurrency, composition, up-to-date idioms, AI/model features.
-4. [`references/03-security-privacy.md`](references/03-security-privacy.md) —
-   trust-boundary validation, injection safety, token handling, crypto, data minimization.
-5. [`references/04-quality.md`](references/04-quality.md) — root-cause over patches, dead code,
-   file/package organization, maintainability, style gates.
-6. [`references/05-tests-tdd.md`](references/05-tests-tdd.md) — TDD,
-   determinism under `-race -shuffle`, injected clocks, env/cwd discipline, fixtures.
-7. [`references/06-docs-supply-chain.md`](references/06-docs-supply-chain.md) — `doc.go`/godoc,
-   Conventional Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM/provenance.
-8. [`references/07-comments-godoc.md`](references/07-comments-godoc.md) —
-   comments/godoc describe the code as it is, not plans/history/process.
+1. [`references/00-structure-placement.md`](references/00-structure-placement.md) — module placement (root vs sub-module vs nested adapter), acyclic layering (`depguard`), `doc.go` and go.work wiring.
+2. [`references/01-canonical-reuse.md`](references/01-canonical-reuse.md) — did the code reimplement a concern an existing package (or the stdlib) already owns? *(blocker class)*
+3. [`references/02-principles.md`](references/02-principles.md) — typed/minimal APIs, errors & resilience, concurrency, composition, up-to-date idioms, AI/model features.
+4. [`references/03-security-privacy.md`](references/03-security-privacy.md) — trust-boundary validation, injection safety, token handling, crypto, data minimization.
+5. [`references/04-quality.md`](references/04-quality.md) — root-cause over patches, dead code, file/package organization, maintainability, style gates.
+6. [`references/05-tests-tdd.md`](references/05-tests-tdd.md) — TDD, determinism under `-race -shuffle`, injected clocks, env/cwd discipline, fixtures.
+7. [`references/06-docs-supply-chain.md`](references/06-docs-supply-chain.md) — `doc.go`/godoc, Conventional Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM/provenance.
+8. [`references/07-comments-godoc.md`](references/07-comments-godoc.md) — comments/godoc describe the code as it is, not plans/history/process.
 
 ## Severity and finding format
 
@@ -72,20 +49,12 @@ and can be run standalone when you need only one lens.
 severity (blocker / should-fix / nit) — file:line — what's wrong — which principle — suggested fix
 ```
 
-- **blocker** —
-  hard-principle violation (upward/cyclic import, concern reimplemented, `panic()`/`log.Fatal` on a runtime path, goroutine with no cancellation / unbounded channel, package-global mutable registry / `init()` side effect, trust boundary not validated, `interface{}`/`any` on a public surface, behavioral change with no test).
-  Fix before merge.
-- **should-fix** — real defect
-  or debt that isn't a baseline violation (compat shim, `time.Sleep` in a test, unguarded env/cwd test, inline config instead of a fixture, reinvented stdlib facility, one large file that should be split by concern).
+- **blocker** — hard-principle violation (upward/cyclic import, concern reimplemented, `panic()`/`log.Fatal` on a runtime path, goroutine with no cancellation / unbounded channel, package-global mutable registry / `init()` side effect, trust boundary not validated, `interface{}`/`any` on a public surface, behavioral change with no test). Fix before merge.
+- **should-fix** — real defect or debt that isn't a baseline violation (compat shim, `time.Sleep` in a test, unguarded env/cwd test, inline config instead of a fixture, reinvented stdlib facility, one large file that should be split by concern).
 - **nit** — minor/style, take-it-or-leave-it.
 
 ## Validation is via toven (see the `validate` skill)
 
-The reference files were written against `make`/`gomod.sh`;
-read those commands as their toven equivalents (`make lint M=x` → `toven lint --module go:x`, `make test-affected` → `toven affected test --base origin/main --merge-base`, etc.).
-Scope every command to the changed module(s); the full-tree gates belong to a project audit
-or CI sign-off.
+The reference files were written against `make`/`gomod.sh`; read those commands as their toven equivalents (`make lint M=x` → `toven lint --module go:x`, `make test-affected` → `toven affected test --base origin/main --merge-base`, etc.). Scope every command to the changed module(s); the full-tree gates belong to a project audit or CI sign-off.
 
-Treat a green run as **necessary but not sufficient**: it does not catch goroutine leaks,
-missing timeouts/cancellation, unbounded channels, global-registry composition smells,
-duplicated owners, or boundary-validation gaps. Those are on the reviewer.
+Treat a green run as **necessary but not sufficient**: it does not catch goroutine leaks, missing timeouts/cancellation, unbounded channels, global-registry composition smells, duplicated owners, or boundary-validation gaps. Those are on the reviewer.

--- a/.github/skills/review/references/00-structure-placement.md
+++ b/.github/skills/review/references/00-structure-placement.md
@@ -1,18 +1,13 @@
 # Pass 00 — Structure and placement
 
-Confirm every touched (or, in project mode, every existing) item lives in the right module, package,
-and layer, and that the dependency direction stays acyclic. This is the first gate:
-misplaced code makes every later pass moot, so reject on failure here before going further.
+Confirm every touched (or, in project mode, every existing) item lives in the right module, package, and layer, and that the dependency direction stays acyclic. This is the first gate: misplaced code makes every later pass moot, so reject on failure here before going further.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* check the packages the diff touches plus the affected area —
-a change to a core package's public surface fans out to every sub-module, nested adapter,
-and downstream consumer. *Project mode:* sweep each module's packages and dependency edges;
-the placement and acyclicity rules below are invariants for the whole toolkit.
+**Scope note.** *Changes mode:* check the packages the diff touches plus the affected area — a change to a core package's public surface fans out to every sub-module, nested adapter, and downstream consumer. *Project mode:* sweep each module's packages and dependency edges; the placement and acyclicity rules below are invariants for the whole toolkit.
 
 ## The layering invariant
 
@@ -78,5 +73,4 @@ grep -rn --include=*.go '^func init()' . | grep -v _test.go
 scripts/check-structure.sh
 ```
 
-Then run `make lint` (depguard enforces the layer direction)
-and `make check-<domain>` for the touched domain.
+Then run `make lint` (depguard enforces the layer direction) and `make check-<domain>` for the touched domain.

--- a/.github/skills/review/references/01-canonical-reuse.md
+++ b/.github/skills/review/references/01-canonical-reuse.md
@@ -1,26 +1,17 @@
 # Pass 01 — Canonical-owner reuse
 
-gokit *is* the canonical toolkit, so the duplication risk is internal:
-**did the change reimplement something an existing package (or the standard library) already owns?** Vibe-coded code reaches for a fresh local helper instead of the owner
-— assume duplication until proven otherwise. Treat findings here as a blocker class.
+gokit *is* the canonical toolkit, so the duplication risk is internal: **did the change reimplement something an existing package (or the standard library) already owns?** Vibe-coded code reaches for a fresh local helper instead of the owner — assume duplication until proven otherwise. Treat findings here as a blocker class.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* for each new type/helper in the diff, name the concern
-and find its owner. *Project mode:* sweep the tree for the patterns below
-and check each against the owning package —
-long-lived internal forks are exactly what this pass exists to surface.
+**Scope note.** *Changes mode:* for each new type/helper in the diff, name the concern and find its owner. *Project mode:* sweep the tree for the patterns below and check each against the owning package — long-lived internal forks are exactly what this pass exists to surface.
 
 ## The rule
 
-Reuse or enhance the canonical owner before writing new code. Never duplicate a shared concern —
-**errors, config, logging, auth, retries/resilience, observability, HTTP, registries, validation,
-process, di**. If the owner is inadequate,
-enhance it *generically* rather than forking a copy in another package. gokit must stay foundational
-and multi-purpose: a fix belongs in the owner so every consumer benefits.
+Reuse or enhance the canonical owner before writing new code. Never duplicate a shared concern — **errors, config, logging, auth, retries/resilience, observability, HTTP, registries, validation, process, di**. If the owner is inadequate, enhance it *generically* rather than forking a copy in another package. gokit must stay foundational and multi-purpose: a fix belongs in the owner so every consumer benefits.
 
 ## How to check — build the owner map, then compare
 
@@ -29,17 +20,14 @@ The canonical owner set is documented in [`docs/concern-owners.md`](../../../../
 and do not rely on a fixed concern list — that is how a fork slips through. Work it as a method,
 in order:
 
-**1. Build the owner map.** Every gokit module is a potential owner.
-Establish what this module *could* reuse before judging what it *does*:
+**1. Build the owner map.** Every gokit module is a potential owner. Establish what this module *could* reuse before judging what it *does*:
 
 ```bash
 ls -d */ | tr -d /                                       # all gokit modules = the candidate owner set
 grep -E '^\s+github.com/kbukum/gokit' <module>/go.mod    # owners it already imports (reuse adds no new edge)
 ```
 
-**2. Scan the module for every low-level operation
-and check each against that map.** The class most often missed is a **drop to the standard library for a capability a gokit module already wraps** (safe file/path handling, subprocess, HTTP, atomic writes)
-— not just a reimplemented named concern. Sweep the in-scope code, not the tree:
+**2. Scan the module for every low-level operation and check each against that map.** The class most often missed is a **drop to the standard library for a capability a gokit module already wraps** (safe file/path handling, subprocess, HTTP, atomic writes) — not just a reimplemented named concern. Sweep the in-scope code, not the tree:
 
 ```bash
 grep -rnE 'os\.|filepath\.|ioutil\.|exec\.Command|net/http|http\.Client|sort\.Slice|"sort"|errors\.New\(|fmt\.Errorf\(|log\.Print|fmt\.Print|time\.After|context\.WithTimeout' <module> --include=*.go | grep -v _test.go
@@ -78,8 +66,7 @@ so if a hit maps to a gokit owner not named here, it still counts.
 - Deliberately stricter/narrower policy that must not be shared → **justified local**: state why,
   and flag it as a candidate to promote into the owner.
 
-An owner that **nothing imports yet** is a strong signal its intended consumers are running local forks
-— check it explicitly:
+An owner that **nothing imports yet** is a strong signal its intended consumers are running local forks — check it explicitly:
 
 ```bash
 grep -rln 'kbukum/gokit/<owner>' --include=*.go . | grep -v _test.go | grep -v '^./<owner>/'
@@ -87,6 +74,4 @@ grep -rln 'kbukum/gokit/<owner>' --include=*.go . | grep -v _test.go | grep -v '
 
 ## Output for this pass
 
-Per finding,
-name the concrete package/symbol that should have been used (e.g. "use `fs.ConfineExistingPath` instead of the local `ensureUnderRoot`", "use `resilience` retry policy instead of a hand-rolled loop", "wrap with `process` rather than `exec.Command`")
-and its outcome (reuse / enhance / add / justified-local).
+Per finding, name the concrete package/symbol that should have been used (e.g. "use `fs.ConfineExistingPath` instead of the local `ensureUnderRoot`", "use `resilience` retry policy instead of a hand-rolled loop", "wrap with `process` rather than `exec.Command`") and its outcome (reuse / enhance / add / justified-local).

--- a/.github/skills/review/references/02-principles.md
+++ b/.github/skills/review/references/02-principles.md
@@ -1,59 +1,41 @@
 # Pass 02 — Principles
 
-Each item here is a hard principle from [`.github/copilot-instructions.md`](../../../copilot-instructions.md),
-not a preference. This is where vibe coding drifts most — especially around resilience, concurrency,
-and composition.
+Each item here is a hard principle from [`.github/copilot-instructions.md`](../../../copilot-instructions.md), not a preference. This is where vibe coding drifts most — especially around resilience, concurrency, and composition.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* grep the touched packages and reason about each runtime path.
-*Project mode:* the panic/concurrency/composition invariants below hold across the whole library surface
-— sweep the tree.
+**Scope note.** *Changes mode:* grep the touched packages and reason about each runtime path. *Project mode:* the panic/concurrency/composition invariants below hold across the whole library surface — sweep the tree.
 
 ## Typed, minimal APIs
 
 Generics-first:
-no `interface{}`/`any` on public surfaces except genuinely opaque values (JSON body, `ctx.Value`, DB column scan, third-party interface contract)
-— and those are documented. Actionable typed errors (`AppError`) that preserve cause via `%w`.
-Minimal public surface — no incidental exported identifiers; unexport what callers don't need.
+no `interface{}`/`any` on public surfaces except genuinely opaque values (JSON body, `ctx.Value`, DB column scan, third-party interface contract) — and those are documented. Actionable typed errors (`AppError`) that preserve cause via `%w`. Minimal public surface — no incidental exported identifiers; unexport what callers don't need.
 
 ## Errors & resilience
 
-- No `panic()` / `log.Fatal` / ignored errors (`_ = f()`) / unchecked type assertions (`x.(T)` without the `, ok` form) on runtime paths (tests excepted).
-  `MustXxx` allowed only for compile-time-safe construction (`regexp.MustCompile`, `template.Must`)
-  and explicit Must* twins of error-returning funcs.
+- No `panic()` / `log.Fatal` / ignored errors (`_ = f()`) / unchecked type assertions (`x.(T)` without the `, ok` form) on runtime paths (tests excepted). `MustXxx` allowed only for compile-time-safe construction (`regexp.MustCompile`, `template.Must`) and explicit Must* twins of error-returning funcs.
 - No success-shaped fallbacks that mask failure (returning a zero value + `nil` error on a real failure).
-- Every remote call has a **timeout** via `context.Context`. Retries are **bounded, jittered,
-  and applied to idempotent ops only**. Failures circuit-break
-  and degrade gracefully rather than hang or cascade. (Reuse `resilience` — see pass `01`.)
+- Every remote call has a **timeout** via `context.Context`. Retries are **bounded, jittered, and applied to idempotent ops only**. Failures circuit-break and degrade gracefully rather than hang or cascade. (Reuse `resilience` — see pass `01`.)
 
 ## Concurrency
 
-- Every goroutine has clear **ownership, cancellation (context), timeout, and shutdown** handling;
-  no goroutine leaks (a `go func()` with no way to stop it is a **blocker**).
-- Channels / buffers / concurrency are **bounded with documented backpressure**;
-  components **drain in-flight work on shutdown**.
-  An unbounded queue on an ingest path is a **blocker**.
+- Every goroutine has clear **ownership, cancellation (context), timeout, and shutdown** handling; no goroutine leaks (a `go func()` with no way to stop it is a **blocker**).
+- Channels / buffers / concurrency are **bounded with documented backpressure**; components **drain in-flight work on shutdown**. An unbounded queue on an ingest path is a **blocker**.
 - No data races: shared state guarded by `sync.Mutex`/`sync.RWMutex` or confined to one goroutine;
   verified under `-race`. Context is the first parameter, never stored in a struct.
 
 ## Composition
 
 - Registries and policies are **explicitly injected**; selection is config-driven.
-- **No `init()` side effects, no mutable package-global registries**,
-  no reaching for a global logger/tracer — inject them.
-  A package-level `var registry = …` mutated at runtime,
-  or an `init()` that dials network / reads env / registers into a global, is a **blocker**.
+- **No `init()` side effects, no mutable package-global registries**, no reaching for a global logger/tracer — inject them. A package-level `var registry = …` mutated at runtime, or an `init()` that dials network / reads env / registers into a global, is a **blocker**.
 - Constructors take `...Option`; dependencies passed in, not resolved from a global.
 
 ## Up-to-date
 
-Current Go idioms, not folklore (also enforced in pass `01`). `log/slog` not `logrus`/`zap`;
-`errors.Is/As/Join`; `slices`/`maps`/`cmp`; `any` over `interface{}`;
-loop-var capture is fixed in 1.22+ (no `v := v` workarounds). Flag outdated patterns.
+Current Go idioms, not folklore (also enforced in pass `01`). `log/slog` not `logrus`/`zap`; `errors.Is/As/Join`; `slices`/`maps`/`cmp`; `any` over `interface{}`; loop-var capture is fixed in 1.22+ (no `v := v` workarounds). Flag outdated patterns.
 
 ## AI / model features (only if the change touches them)
 

--- a/.github/skills/review/references/03-security-privacy.md
+++ b/.github/skills/review/references/03-security-privacy.md
@@ -1,35 +1,22 @@
 # Pass 03 — Security & privacy
 
-A dedicated pass because a vibe-coded path that "just works" usually skips boundary validation,
-and gokit is shared infrastructure — a gap here propagates to every consumer.
-For a deeper sweep on security-sensitive changes, pair this with a dedicated security review;
-this pass is the standing baseline.
+A dedicated pass because a vibe-coded path that "just works" usually skips boundary validation, and gokit is shared infrastructure — a gap here propagates to every consumer. For a deeper sweep on security-sensitive changes, pair this with a dedicated security review; this pass is the standing baseline.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* trace each new input path from its trust boundary to its use.
-*Project mode:* audit the toolkit's external-facing surfaces (HTTP, process, storage/database adapters, auth, crypto) for the invariants below.
+**Scope note.** *Changes mode:* trace each new input path from its trust boundary to its use. *Project mode:* audit the toolkit's external-facing surfaces (HTTP, process, storage/database adapters, auth, crypto) for the invariants below.
 
 ## Checks
 
-- **Validate at every trust boundary.** Untrusted input is validated before use; least- privilege
-  and secure-by-default. An input that flows into a query, a path, a command,
-  or a deserialization without validation is a blocker.
-- **Injection-safe data access.** Parameterized queries only —
-  never string-built SQL (`fmt.Sprintf`/concatenation into a query).
-  Argv-only subprocess execution via `process` —
-  no `sh -c` / shell interpolation of untrusted input.
+- **Validate at every trust boundary.** Untrusted input is validated before use; least-privilege and secure-by-default. An input that flows into a query, a path, a command, or a deserialization without validation is a blocker.
+- **Injection-safe data access.** Parameterized queries only — never string-built SQL (`fmt.Sprintf`/concatenation into a query). Argv-only subprocess execution via `process` — no `sh -c` / shell interpolation of untrusted input.
 - **Safe token handling.** Tokens/credentials go in headers, never query strings; never logged.
   Redact sensitive fields in errors and logs. Auth is header-only; reject query-string tokens.
-- **Current crypto.** No deprecated/weak algorithms (MD5, SHA-1 for security, DES, ECB, static IVs, hard-coded keys);
-  use current primitives (AES-GCM, ChaCha20-Poly1305, Argon2id, Ed25519, RS256/ES256).
-  Reject `alg: none` in JWT; require `exp`/`iss`/`aud`. Crypto belongs in `encryption` / `security`,
-  not hand-rolled.
-- **Data minimization.** Minimize, redact, and retention-bound sensitive data; do not persist
-  or log more than needed.
+- **Current crypto.** No deprecated/weak algorithms (MD5, SHA-1 for security, DES, ECB, static IVs, hard-coded keys); use current primitives (AES-GCM, ChaCha20-Poly1305, Argon2id, Ed25519, RS256/ES256). Reject `alg: none` in JWT; require `exp`/`iss`/`aud`. Crypto belongs in `encryption` / `security`, not hand-rolled.
+- **Data minimization.** Minimize, redact, and retention-bound sensitive data; do not persist or log more than needed.
 
 ## Detection starters
 
@@ -47,8 +34,4 @@ grep -rni --include=*.go 'md5\|sha1\|"DES"\|ecb\|alg.*none' .
 grep -rn --include=*.go '\(password\|secret\|apiKey\|token\)\s*[:=]\s*"' . | grep -v _test.go
 ```
 
-Flag any unbounded read of untrusted input (set explicit size limits — `io.LimitReader`)
-and any path/selector from an untrusted source flowing into filesystem
-or process execution without validation.
-Path-shaped values use `filepath.Join` (never hardcoded separators)
-and a temp-dir helper over hardcoded `/tmp/...`.
+Flag any unbounded read of untrusted input (set explicit size limits — `io.LimitReader`) and any path/selector from an untrusted source flowing into filesystem or process execution without validation. Path-shaped values use `filepath.Join` (never hardcoded separators) and a temp-dir helper over hardcoded `/tmp/...`.

--- a/.github/skills/review/references/04-quality.md
+++ b/.github/skills/review/references/04-quality.md
@@ -1,18 +1,13 @@
 # Pass 04 — Quality, readability & maintainability
 
-This is the pass the user cares about most: **is the code readable, maintainable, and well organized
-—
-or is it piled into one file?** Correctness passes (`02`, `03`) can be green while the code is still a maintenance liability.
-Vibe-coded output tends to grow one giant file with a few 300-line functions;
-this pass rejects that.
+This is the pass the user cares about most: **is the code readable, maintainable, and well organized — or is it piled into one file?** Correctness passes (`02`, `03`) can be green while the code is still a maintenance liability. Vibe-coded output tends to grow one giant file with a few 300-line functions; this pass rejects that.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* judge the readability of the touched files and functions.
-*Project mode:* sweep for oversized files, god-packages, and duplicated logic across the tree.
+**Scope note.** *Changes mode:* judge the readability of the touched files and functions. *Project mode:* sweep for oversized files, god-packages, and duplicated logic across the tree.
 
 ## File & package organization (primary focus)
 
@@ -50,12 +45,7 @@ this pass rejects that.
 
 ## Signatures
 
-- **Reduce parameters, don't wrap them.** Go has no column cap and `gofmt` does not wrap signatures,
-  so a function taking 5+ positional parameters is a design signal: fold optional/defaulted
-  or cohesive parameters into a typed request/options struct or functional options,
-  using the owning package's existing `Config`/`...Option` pattern. `context.Context` stays first
-  and is never folded into a struct. A genuinely distinct positional list may stay,
-  but that is a recorded judgment, not the default.
+- **Reduce parameters, don't wrap them.** Go has no column cap and `gofmt` does not wrap signatures, so a function taking 5+ positional parameters is a design signal: fold optional/defaulted or cohesive parameters into a typed request/options struct or functional options, using the owning package's existing `Config`/`...Option` pattern. `context.Context` stays first and is never folded into a struct. A genuinely distinct positional list may stay, but that is a recorded judgment, not the default.
 - **No manual column-wrapping.** A signature hand-broken to hit a column is a fix-by-refactor,
   not an accepted state; the remedy is fewer parameters, not a wrapped parameter list.
 
@@ -76,10 +66,8 @@ grep -rn --include=*.go '^\s*//\s*[a-z].*(' . | grep -v _test.go   # candidate c
 grep -rn --include=*.go 'TODO\|FIXME\|HACK' . | grep -v _test.go   # each needs a tracked issue link
 ```
 
-Then run `make fmt` (`gofmt -s`) and `make lint` — a clean gofmt/golangci-lint run is necessary
-but not sufficient; the organization judgments above are the point of this pass.
+Then run `make fmt` (`gofmt -s`) and `make lint` — a clean gofmt/golangci-lint run is necessary but not sufficient; the organization judgments above are the point of this pass.
 
 ## Output for this pass
 
-For each finding, name the concrete refactor: which file to split, into which files,
-and along which concern boundary — so it is directly actionable, not just "this file is too big".
+For each finding, name the concrete refactor: which file to split, into which files, and along which concern boundary — so it is directly actionable, not just "this file is too big".

--- a/.github/skills/review/references/05-tests-tdd.md
+++ b/.github/skills/review/references/05-tests-tdd.md
@@ -1,17 +1,13 @@
 # Pass 05 — Tests & TDD
 
-Behavior is only real if a test proves it. Vibe-coded changes routinely ship without tests,
-or with tests that assert implementation detail instead of behavior.
-This pass verifies the change is covered, deterministic, and race-clean.
+Behavior is only real if a test proves it. Vibe-coded changes routinely ship without tests, or with tests that assert implementation detail instead of behavior. This pass verifies the change is covered, deterministic, and race-clean.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* every behavioral change in the diff has a test in the same change;
-every bug fix has a regression test. *Project mode:* assess coverage against the gates
-and hunt for flaky/implementation-coupled tests across the suite.
+**Scope note.** *Changes mode:* every behavioral change in the diff has a test in the same change; every bug fix has a regression test. *Project mode:* assess coverage against the gates and hunt for flaky/implementation-coupled tests across the suite.
 
 ## Checks
 
@@ -20,17 +16,9 @@ and hunt for flaky/implementation-coupled tests across the suite.
   Behavior added with no test is a **blocker**.
 - **Behavioral, not implementation-coupled.** Tests assert observable behavior and public contracts,
   not private field values or call sequences that would break on a harmless refactor.
-- **Deterministic.** Clocks are **injected** (never `time.Sleep` to "wait" for async work),
-  RNG is **seeded**,
-  no real network / filesystem in unit tests (use fakes / `testutil` / `t.TempDir`).
-  A test that sleeps or hits the network is a should-fix.
-- **Race / shuffle / parallel green.** Suite passes under `go test -race -shuffle=on`,
-  and `t.Parallel()` tests are actually independent.
-  Table-driven tests capture the range var correctly (trivially safe on 1.22+, but still check shared mutable state).
-- **Coverage gates.** ≥80% per package, ≥85% overall;
-  ≥85% for the security-load-bearing packages (`errors`, `auth`, `authz`, `security`, `resilience`, `encryption`).
-  A change that drops a gated package below its floor is a blocker.
-  (CI enforces project 80% / patch 85% via `codecov.yml`; the per-package floors are checked each step via `make test-coverage`.)
+- **Deterministic.** Clocks are **injected** (never `time.Sleep` to "wait" for async work), RNG is **seeded**, no real network / filesystem in unit tests (use fakes / `testutil` / `t.TempDir`). A test that sleeps or hits the network is a should-fix.
+- **Race / shuffle / parallel green.** Suite passes under `go test -race -shuffle=on`, and `t.Parallel()` tests are actually independent. Table-driven tests capture the range var correctly (trivially safe on 1.22+, but still check shared mutable state).
+- **Coverage gates.** ≥80% per package, ≥85% overall; ≥85% for the security-load-bearing packages (`errors`, `auth`, `authz`, `security`, `resilience`, `encryption`). A change that drops a gated package below its floor is a blocker. (CI enforces project 80% / patch 85% via `codecov.yml`; the per-package floors are checked each step via `make test-coverage`.)
 - **Fuzz where it matters.** Parsers, validators, auth/JWT, codecs, and schema have `Fuzz` targets.
   A new parser/validator with no fuzz target is a should-fix.
 - **Environment-independent.** Tests use `t.Setenv` (auto-restored) rather than mutating global env;
@@ -58,5 +46,4 @@ make test-affected                 # race-enabled, only affected modules (fast i
 make check-<domain>                # domain gate (fmt + vet + lint + test) for the touched area
 ```
 
-A behavioral change with a green race+shuffle run and coverage above the gate passes;
-anything untested, sleeping, or below the coverage floor does not.
+A behavioral change with a green race+shuffle run and coverage above the gate passes; anything untested, sleeping, or below the coverage floor does not.

--- a/.github/skills/review/references/06-docs-supply-chain.md
+++ b/.github/skills/review/references/06-docs-supply-chain.md
@@ -1,46 +1,28 @@
 # Pass 06 — Docs & supply chain
 
-Docs drift and dependency risk are the quiet failures — the code works,
-so nobody notices the stale godoc or the unvetted new dependency until much later.
-This pass keeps the published surface honest and the dependency set clean.
+Docs drift and dependency risk are the quiet failures — the code works, so nobody notices the stale godoc or the unvetted new dependency until much later. This pass keeps the published surface honest and the dependency set clean.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* check the docs and deps the diff touches or invalidates.
-*Project mode:* audit every module's `doc.go`, READMEs, `go.mod`/`go.sum`,
-and the CI/release wiring for the invariants below.
+**Scope note.** *Changes mode:* check the docs and deps the diff touches or invalidates. *Project mode:* audit every module's `doc.go`, READMEs, `go.mod`/`go.sum`, and the CI/release wiring for the invariants below.
 
 ## Docs
 
-- **Public API documented.** Every exported identifier has a godoc comment starting with its name;
-  every package has a `doc.go` with a package overview. gokit publishes to **pkg.go.dev**,
-  so godoc *is* the public documentation — missing docs on new exports is a should-fix.
-- **Docs match behavior.** A behavioral change updates the affected godoc, package overview,
-  and any README/example. Stale docs that now describe removed or changed behavior are a should-fix.
-  (Godoc *accuracy* vs the code is pass `07`; this check is that docs were updated at all.)
-- **Canonical docs regenerated.** A module rename/add/remove updates `domains.toml`,
-  `docs/MODULE-INDEX.md`, and `docs/parity-matrix.md` in the same change. A stale parity matrix
-  or module index is a should-fix.
+- **Public API documented.** Every exported identifier has a godoc comment starting with its name; every package has a `doc.go` with a package overview. gokit publishes to **pkg.go.dev**, so godoc *is* the public documentation — missing docs on new exports is a should-fix.
+- **Docs match behavior.** A behavioral change updates the affected godoc, package overview, and any README/example. Stale docs that now describe removed or changed behavior are a should-fix. (Godoc *accuracy* vs the code is pass `07`; this check is that docs were updated at all.)
+- **Canonical docs regenerated.** A module rename/add/remove updates `domains.toml`, `docs/MODULE-INDEX.md`, and `docs/parity-matrix.md` in the same change. A stale parity matrix or module index is a should-fix.
 - **Examples compile.** Example code / `Example` test functions build and reflect the current API.
 - **Prose flows naturally.** Markdown paragraphs stay continuous in source instead of being hard-wrapped to a fixed column; renderers own viewport-aware wrapping. `doc.go` and godoc/`//` prose likewise avoid arbitrary column-based breaks. Intentional paragraph, list, blockquote, table, and code-block structure remains intact. AI-generated hard wraps are a should-fix.
 
 ## Supply chain
 
-- **New dep justified.** Each added dependency is necessary (stdlib does not already cover it — pass `01`),
-  maintained (recent releases), license-compatible, and free of known advisories. An unjustified
-  or unmaintained dependency is a should-fix; one with an open CVE is a blocker.
-- **Vulnerability + license clean.** `govulncheck` passes;
-  new findings are triaged in `.github/govulncheck-suppressions.json` with a rationale,
-  not silently ignored. `gosec` (config in `gosec.toml`) passes.
-- **Tidy modules.** `go.mod`/`go.sum` reflect exactly what is used (`go mod tidy` run per affected module);
-  no leftover or phantom requires;
-  `go.work` / `core.go.work` / `contrib.go.work` include any new module.
-- **CI/release safety** (if touched). GitHub Actions pinned by commit SHA (never a moving tag);
-  minimum job permissions; release artifacts signed (cosign) and SBOM (CycloneDX) produced.
-  A workflow pinned to a tag or granting broad permissions is a should-fix.
+- **New dep justified.** Each added dependency is necessary (stdlib does not already cover it — pass `01`), maintained (recent releases), license-compatible, and free of known advisories. An unjustified or unmaintained dependency is a should-fix; one with an open CVE is a blocker.
+- **Vulnerability + license clean.** `govulncheck` passes; new findings are triaged in `.github/govulncheck-suppressions.json` with a rationale, not silently ignored. `gosec` (config in `gosec.toml`) passes.
+- **Tidy modules.** `go.mod`/`go.sum` reflect exactly what is used (`go mod tidy` run per affected module); no leftover or phantom requires; `go.work` / `core.go.work` / `contrib.go.work` include any new module.
+- **CI/release safety** (if touched). GitHub Actions pinned by commit SHA (never a moving tag); minimum job permissions; release artifacts signed (cosign) and SBOM (CycloneDX) produced. A workflow pinned to a tag or granting broad permissions is a should-fix.
 
 ## Detection starters
 

--- a/.github/skills/review/references/07-comments-godoc.md
+++ b/.github/skills/review/references/07-comments-godoc.md
@@ -1,28 +1,18 @@
 # Pass 07 — Comments & godoc semantics
 
-The final pass, and a subtle one: comments and godoc are trusted by future readers
-and by pkg.go.dev, so a **wrong** comment is worse than no comment.
-Vibe-coded comments tend to narrate the obvious, restate the code,
-or describe what the code *used to* do. This pass keeps prose truthful and useful.
+The final pass, and a subtle one: comments and godoc are trusted by future readers and by pkg.go.dev, so a **wrong** comment is worse than no comment. Vibe-coded comments tend to narrate the obvious, restate the code, or describe what the code *used to* do. This pass keeps prose truthful and useful.
 
 > **Run in a separate, clean-context agent** — never inline in the session that wrote the code.
 > An independent reviewer re-derives every judgment from the code
 > and the principles instead of trusting prior reasoning.
 > A plan/spec may be passed in as a scope checklist only; it never excuses a baseline violation.
 
-**Scope note.** *Changes mode:* read every comment
-and godoc line in the diff against the code beside it.
-*Project mode:* sample doc comments across packages,
-prioritizing public API godoc that pkg.go.dev renders.
+**Scope note.** *Changes mode:* read every comment and godoc line in the diff against the code beside it. *Project mode:* sample doc comments across packages, prioritizing public API godoc that pkg.go.dev renders.
 
 ## Checks
 
-- **Godoc is accurate.** Each doc comment matches what the function/type actually does now —
-  parameters, return values, error conditions, side effects, and any concurrency/ownership contract.
-  A comment that describes the old behavior after a change is a should-fix (it will mislead every future reader and ship to pkg.go.dev).
-- **Godoc convention.** Doc comments start with the identifier name (`// New returns …`, `// Cache is …`);
-  package overview lives in `doc.go`.
-  Exported items on the public surface are documented (ties to pass `06`; here the focus is *correctness* of the prose).
+- **Godoc is accurate.** Each doc comment matches what the function/type actually does now — parameters, return values, error conditions, side effects, and any concurrency/ownership contract. A comment that describes the old behavior after a change is a should-fix (it will mislead every future reader and ship to pkg.go.dev).
+- **Godoc convention.** Doc comments start with the identifier name (`// New returns …`, `// Cache is …`); package overview lives in `doc.go`. Exported items on the public surface are documented (ties to pass `06`; here the focus is *correctness* of the prose).
 - **Comments earn their place.** Explain **why** — the non-obvious constraint, invariant,
   or trade-off — not **what** the code plainly says.
   Delete comments that merely restate the line below them.
@@ -49,6 +39,4 @@ grep -rn --include=*.go '^// [a-z]' . | grep -v _test.go
 grep -rn --include=*.go 'TODO\|FIXME\|HACK\|XXX' . | grep -v _test.go
 ```
 
-Then read the doc comment on each changed exported identifier next to its implementation
-and confirm the prose is true. Accurate godoc that explains *why* passes;
-anything describing old behavior, restating the obvious, or narrating the fix does not.
+Then read the doc comment on each changed exported identifier next to its implementation and confirm the prose is true. Accurate godoc that explains *why* passes; anything describing old behavior, restating the obvious, or narrating the fix does not.

--- a/.github/skills/review/references/review-changes.md
+++ b/.github/skills/review/references/review-changes.md
@@ -1,63 +1,35 @@
 # Review changes
 
-Standing, re-runnable review of a **change set** in this repository — a branch, a commit range,
-or `HEAD~1`. Use it after every change set, especially fast/"vibe-coded" work.
-It sequences the eight focused passes in [`references/`](./) over a diff and adds scope handling;
-the actual checks live in the focused files.
+Standing, re-runnable review of a **change set** in this repository — a branch, a commit range, or `HEAD~1`. Use it after every change set, especially fast/"vibe-coded" work. It sequences the eight focused passes in [`references/`](./) over a diff and adds scope handling; the actual checks live in the focused files.
 
 ## Run this in a separate, clean-context agent
 
-**Always dispatch this review to a fresh reviewer agent with no shared session context.** A reviewer that "remembers" writing the code rationalizes it;
-an independent agent re-derives every judgment from the diff and the principles.
-Do not run it inline in the same session that produced the change.
+**Always dispatch this review to a fresh reviewer agent with no shared session context.** A reviewer that "remembers" writing the code rationalizes it; an independent agent re-derives every judgment from the diff and the principles. Do not run it inline in the same session that produced the change.
 
-- Hand the reviewer agent: the diff (or base ref), this file, and the [`references/`](./) folder.
-  Nothing else from the authoring session.
-- The reviewer reads the code as-is;
-  it does not trust prior reasoning about why the code "should" be correct.
-- **Optional plan check.** If a plan/spec exists (e.g. an entry under a `tmp/<plan-name>/` folder, an issue, or a design doc),
-  pass it in *as a scope checklist only* — "here is what this change set claimed to do;
-  verify the diff actually did it, with tests." The plan defines intended scope;
-  it never excuses a principle violation. If the diff diverges from the plan, report the divergence;
-  the baseline in [`.github/copilot-instructions.md`](../../../copilot-instructions.md) wins over any plan.
+- Hand the reviewer agent: the diff (or base ref), this file, and the [`references/`](./) folder. Nothing else from the authoring session.
+- The reviewer reads the code as-is; it does not trust prior reasoning about why the code "should" be correct.
+- **Optional plan check.** If a plan/spec exists (e.g. an entry under a `tmp/<plan-name>/` folder, an issue, or a design doc), pass it in *as a scope checklist only* — "here is what this change set claimed to do; verify the diff actually did it, with tests." The plan defines intended scope; it never excuses a principle violation. If the diff diverges from the plan, report the divergence; the baseline in [`.github/copilot-instructions.md`](../../../copilot-instructions.md) wins over any plan.
 
 ## Pass 0 — Scope and context
 
-- Get the actual diff: `git diff <base>...HEAD --stat`, then per file.
-  Review only what changed plus its affected area;
-  do not audit the whole repo (that is [`review-project.md`](./review-project.md)).
-- gokit is a foundation toolkit:
-  a change to a core package's public surface fans out to every sub-module, nested adapter,
-  and downstream repo (rskit/pykit parity, consuming services).
-  List that affected area before reviewing.
-- Note whether the change belongs in the **root module**, a **sub-module** (own `go.mod`),
-  or a **nested adapter** (e.g. `storage/s3`), and whether it belongs in *this* package at all.
+- Get the actual diff: `git diff <base>...HEAD --stat`, then per file. Review only what changed plus its affected area; do not audit the whole repo (that is [`review-project.md`](./review-project.md)).
+- gokit is a foundation toolkit: a change to a core package's public surface fans out to every sub-module, nested adapter, and downstream repo (rskit/pykit parity, consuming services). List that affected area before reviewing.
+- Note whether the change belongs in the **root module**, a **sub-module** (own `go.mod`), or a **nested adapter** (e.g. `storage/s3`), and whether it belongs in *this* package at all.
 
 ## Passes — run in order, stop early on a structural failure
 
-Work the focused files top to bottom. **Stop and reject as soon as a change fails pass `00`
-or `01`** — misplaced or duplicated code makes every later pass moot.
+Work the focused files top to bottom. **Stop and reject as soon as a change fails pass `00` or `01`** — misplaced or duplicated code makes every later pass moot.
 
-1. [`00-structure-placement.md`](./00-structure-placement.md) — module/package placement,
-   acyclic layering, `doc.go` and go.work wiring.
-2. [`01-canonical-reuse.md`](./01-canonical-reuse.md) —
-   reuse vs. reimplementation of a package/stdlib-owned concern. *(blocker class)*
-3. [`02-principles.md`](./02-principles.md) — typed/minimal APIs, errors & resilience, concurrency,
-   composition, up-to-date idioms, AI features.
-4. [`03-security-privacy.md`](./03-security-privacy.md) — trust-boundary validation,
-   injection safety, token handling, crypto, data minimization.
-5. [`04-quality.md`](./04-quality.md) — root-cause over patches, dead code,
-   file/package organization, style gates.
-6. [`05-tests-tdd.md`](./05-tests-tdd.md) — TDD, `-race -shuffle` determinism,
-   clock/env/cwd discipline, fixtures.
-7. [`06-docs-supply-chain.md`](./06-docs-supply-chain.md) — `doc.go`/godoc, Conventional Commits,
-   `go.sum`, `govulncheck`, SHA-pinned actions, SBOM.
-8. [`07-comments-godoc.md`](./07-comments-godoc.md) — comments and godoc explain the code as it is;
-   rewrite or delete plan/history/process prose.
+1. [`00-structure-placement.md`](./00-structure-placement.md) — module/package placement, acyclic layering, `doc.go` and go.work wiring.
+2. [`01-canonical-reuse.md`](./01-canonical-reuse.md) — reuse vs. reimplementation of a package/stdlib-owned concern. *(blocker class)*
+3. [`02-principles.md`](./02-principles.md) — typed/minimal APIs, errors & resilience, concurrency, composition, up-to-date idioms, AI features.
+4. [`03-security-privacy.md`](./03-security-privacy.md) — trust-boundary validation, injection safety, token handling, crypto, data minimization.
+5. [`04-quality.md`](./04-quality.md) — root-cause over patches, dead code, file/package organization, style gates.
+6. [`05-tests-tdd.md`](./05-tests-tdd.md) — TDD, `-race -shuffle` determinism, clock/env/cwd discipline, fixtures.
+7. [`06-docs-supply-chain.md`](./06-docs-supply-chain.md) — `doc.go`/godoc, Conventional Commits, `go.sum`, `govulncheck`, SHA-pinned actions, SBOM.
+8. [`07-comments-godoc.md`](./07-comments-godoc.md) — comments and godoc explain the code as it is; rewrite or delete plan/history/process prose.
 
-Each focused file carries a "Changes mode" scope note — follow that mode here.
-When you only need one lens (e.g. just security, just TDD),
-run that focused file directly instead of this orchestrator.
+Each focused file carries a "Changes mode" scope note — follow that mode here. When you only need one lens (e.g. just security, just TDD), run that focused file directly instead of this orchestrator.
 
 ## Findings
 
@@ -71,11 +43,7 @@ See [`SKILL.md`](../SKILL.md) for severity definitions.
 
 ## Validation
 
-**Scope every command to the changed module(s) —
-do not run the full-tree gates here.** gokit has many modules;
-`make check` / `make test` / `make build` across the whole tree are slow
-and are reserved for [`review-project.md`](./review-project.md)
-or final pre-merge sign-off (typically in CI). For a change set, run only:
+**Scope every command to the changed module(s) — do not run the full-tree gates here.** gokit has many modules; `make check` / `make test` / `make build` across the whole tree are slow and are reserved for [`review-project.md`](./review-project.md) or final pre-merge sign-off (typically in CI). For a change set, run only:
 
 ```bash
 make fmt                             # gofmt -s clean

--- a/.github/skills/review/references/review-details.md
+++ b/.github/skills/review/references/review-details.md
@@ -1,10 +1,6 @@
 # Go Review — Plan, Clarify, Apply
 
-An alternative orchestrator to [`review-changes.md`](./review-changes.md) / [`review-project.md`](./review-project.md):
-instead of sequencing the 00–07 lenses,
-it fans the review out into **parallel subagent passes by Go concern**, then plans
-and applies fixes.
-Use it when you want one driver to take a change from review through to merged fixes.
+An alternative orchestrator to [`review-changes.md`](./review-changes.md) / [`review-project.md`](./review-project.md): instead of sequencing the 00–07 lenses, it fans the review out into **parallel subagent passes by Go concern**, then plans and applies fixes. Use it when you want one driver to take a change from review through to merged fixes.
 
 Run each pass as a **separate subagent with clean context**.
 The orchestrator (this file) sequences them and collects findings.
@@ -34,9 +30,7 @@ or **project** (whole tree, no diff). State the mode up front.
 3. Determine which passes apply via the triggers below.
    Skip non-applicable passes explicitly in the final report.
 
-The reviewer judges code as written, against the rules below
-and the baseline in [`.github/copilot-instructions.md`](../../../copilot-instructions.md).
-PR descriptions, commit messages, or plan/ADR docs are scope hints only — never justifications.
+The reviewer judges code as written, against the rules below and the baseline in [`.github/copilot-instructions.md`](../../../copilot-instructions.md). PR descriptions, commit messages, or plan/ADR docs are scope hints only — never justifications.
 
 ## Phase 2 — Passes
 
@@ -44,9 +38,7 @@ Run **A first** (cheap, gates the rest). Then **B–F in parallel** where indepe
 Then **G last** (cross-references everything).
 
 Each subagent receives: its scope, the pass spec below, and nothing else.
-Scope `go`/`make` to the touched module(s) with `./gomod.sh cmd "<cmd>" -m <module>`
-or `make check-<domain>`; the unscoped workspace gates are slow across every module
-and belong to sign-off/CI.
+Scope `go`/`make` to the touched module(s) with `./gomod.sh cmd "<cmd>" -m <module>` or `make check-<domain>`; the unscoped workspace gates are slow across every module and belong to sign-off/CI.
 
 ### Pass A — Mechanical (always runs)
 

--- a/.github/skills/review/references/review-project.md
+++ b/.github/skills/review/references/review-project.md
@@ -1,27 +1,17 @@
 # Review project
 
-Standing, re-runnable **whole-toolkit audit**, independent of any diff. Use it periodically,
-before a release, when onboarding to a module,
-or whenever you want assurance the tree as a whole still honors the baseline.
-It sequences the same eight focused passes in [`references/`](./)
-but over the existing code rather than a change set.
+Standing, re-runnable **whole-toolkit audit**, independent of any diff. Use it periodically, before a release, when onboarding to a module, or whenever you want assurance the tree as a whole still honors the baseline. It sequences the same eight focused passes in [`references/`](./) but over the existing code rather than a change set.
 
 ## Run this in a separate, clean-context agent
 
-**Always dispatch this audit to a fresh agent with no shared session context.** The point of a full audit is an independent read of the code as it exists
-— not filtered through whatever a prior session believed about it.
-Do not run it inline in a session that has been editing the same code.
+**Always dispatch this audit to a fresh agent with no shared session context.** The point of a full audit is an independent read of the code as it exists — not filtered through whatever a prior session believed about it. Do not run it inline in a session that has been editing the same code.
 
 - Hand the agent: the module(s)/domain to audit (or "the whole tree"), this file,
   and the [`references/`](./) folder.
 - The agent judges the code as written,
   against the principles in [`.github/copilot-instructions.md`](../../../copilot-instructions.md) —
   not against any session's recollection.
-- **Optional roadmap check.** If there is a roadmap
-  or versioning plan (e.g. under a `tmp/<plan-name>/` folder, `docs/VERSIONING.md`),
-  pass it in *as context for intended state only* — "here is where the toolkit is meant to be;
-  flag where the tree has not caught up." It frames expectations;
-  it never excuses a baseline violation.
+- **Optional roadmap check.** If there is a roadmap or versioning plan (e.g. under a `tmp/<plan-name>/` folder, `docs/VERSIONING.md`), pass it in *as context for intended state only* — "here is where the toolkit is meant to be; flag where the tree has not caught up." It frames expectations; it never excuses a baseline violation.
 
 ## Scope first to keep the audit tractable
 
@@ -95,6 +85,4 @@ make check                # full canonical gate
 govulncheck ./...         # per module via ./gomod.sh cmd "govulncheck ./..."
 ```
 
-A green `make check` is necessary but **not sufficient** — goroutine leaks,
-missing timeouts/ cancellation, unbounded channels, global-registry composition smells,
-duplicated owners, and boundary-validation gaps are on the reviewer, not the gate.
+A green `make check` is necessary but **not sufficient** — goroutine leaks, missing timeouts/cancellation, unbounded channels, global-registry composition smells, duplicated owners, and boundary-validation gaps are on the reviewer, not the gate.

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -10,12 +10,7 @@ user-invocable: true
 
 # Validating gokit changes with toven
 
-gokit is a multi-module Go monorepo.
-**`toven` is the canonical task runner** (config in `toven.toml`, sibling repo `../toven`).
-It discovers every `go.mod`, orders work by the dependency graph, caches results,
-and can scope to just the modules a diff touched.
-Prefer it over calling `go`/`make`/`gomod.sh` by hand — the Makefile targets are thin wrappers
-and toven gives you affected-set detection and per-module caching for free.
+gokit is a multi-module Go monorepo. **`toven` is the canonical task runner** (config in `toven.toml`, sibling repo `../toven`). It discovers every `go.mod`, orders work by the dependency graph, caches results, and can scope to just the modules a diff touched. Prefer it over calling `go`/`make`/`gomod.sh` by hand — the Makefile targets are thin wrappers and toven gives you affected-set detection and per-module caching for free.
 
 ## Golden rule: scope to what changed
 
@@ -95,9 +90,6 @@ toven caches per-unit results. Use `toven cache stats` to inspect, `--no-cache` 
 
 ## Before you hand work off
 
-For a self-contained change, the minimum green bar is: `format-check`/gofumpt, `lint`,
-`check` (vet), and `test -- -race -count=1 -shuffle=on` on the affected modules.
-Escalate to a full-tree run only when the affected set is genuinely tree-wide
-or you are preparing a release.
+For a self-contained change, the minimum green bar is: `format-check`/gofumpt, `lint`, `check` (vet), and `test -- -race -count=1 -shuffle=on` on the affected modules. Escalate to a full-tree run only when the affected set is genuinely tree-wide or you are preparing a release.
 
 Per repo workflow, **create the branch and make edits only** — the maintainer commits and pushes.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build test test-integration test-coverage lint vet fmt tidy update update-go check check-fast test-affected structure \
        check-core check-patterns check-crosscutting check-composition check-transport check-auth check-data check-ai \
-       check-media check-infra clean help tag tag-push tag-force list-tags release-dry ci ci-test ci-lint ensure-act
+       check-media check-infra check-devtools clean help tag tag-push tag-force list-tags release-dry ci ci-test ci-lint ensure-act
 
 GOMOD := ./gomod.sh
 
@@ -204,6 +204,10 @@ check-media:
 check-infra:
 	@./scripts/check-domain.sh infra
 
+## Check only devtools domain modules
+check-devtools:
+	@./scripts/check-domain.sh devtools
+
 ## Clean build artifacts
 clean:
 	@find . -name "coverage.out" -o -name "coverage.html" | xargs rm -f
@@ -258,6 +262,7 @@ help:
 	@echo "  make check-ai                 Check only ai domain modules"
 	@echo "  make check-media              Check only media domain modules"
 	@echo "  make check-infra              Check only infra domain modules"
+	@echo "  make check-devtools           Check only devtools domain modules"
 	@echo "  make clean                    Remove build artifacts"
 	@echo ""
 	@echo "Go version:"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Go 1.26+](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](go.mod)
 
-**A modular Go toolkit for building production services.** Config, logging, resilience,
-observability, dependency injection, and infrastructure adapters —
-so teams can focus on business logic instead of reinventing plumbing.
+**A modular Go toolkit for building production services.** Config, logging, resilience, observability, dependency injection, and infrastructure adapters — so teams can focus on business logic instead of reinventing plumbing.
 
 > **Status — pre-1.0.** Public surface is semver-stable per module;
 > breaking changes are documented in [`CHANGELOG.md`](CHANGELOG.md).
@@ -33,26 +31,18 @@ See [Module Index](docs/MODULE-INDEX.md) for the full breakdown.
 | ai | LLM, inference, agents, tools | `make check-ai` |
 | media | Light detection, metadata, image ops | `make check-media` |
 | infra | Workload, CLI, dataset, benchmarks, testing | `make check-infra` |
+| devtools | Git repository operations | `make check-devtools` |
 
-CI still runs full-workspace validation;
-on pull requests the `changes` job also publishes an `affected` domain list from `./scripts/affected-domains.sh`
-so later workflow steps can consume the same domain mapping developers use locally with `make check-<domain>`.
+CI still runs full-workspace validation; on pull requests the `changes` job also publishes an `affected` domain list from `./scripts/affected-domains.sh` so later workflow steps can consume the same domain mapping developers use locally with `make check-<domain>`.
 
 ## Highlights
 
-- **Multi-module layout** —
-  light core (`github.com/kbukum/gokit`) + sub-modules (`gokit/server`, `gokit/database`, …) you opt into individually.
-  No transitive heavy deps unless you ask.
-- **Lifecycle-managed components** — uniform `Component` interface (start / stop / health)
-  and `bootstrap.App` orchestrator with graceful shutdown.
-- **Production resilience** — circuit breakers, retries with backoff + jitter, bulkheads,
-  rate limiting, OpenTelemetry tracing & metrics.
-- **Provider pattern** — typed `RequestResponse[I,O]`, `Stream`, `Sink`,
-  and `Duplex` traits with composable middleware and sink combinators.
-- **Per-module versioning** — `gokit/server` and `gokit/database` upgrade independently of core.
-  See [`docs/VERSIONING.md`](docs/VERSIONING.md).
-- **Sibling parity** — APIs mirror [rskit](https://github.com/kbukum/rskit) (Rust)
-  and [pykit](https://github.com/kbukum/pykit) (Python).
+- **Multi-module layout** — light core (`github.com/kbukum/gokit`) + sub-modules (`gokit/server`, `gokit/database`, …) you opt into individually. No transitive heavy deps unless you ask.
+- **Lifecycle-managed components** — uniform `Component` interface (start / stop / health) and `bootstrap.App` orchestrator with graceful shutdown.
+- **Production resilience** — circuit breakers, retries with backoff + jitter, bulkheads, rate limiting, OpenTelemetry tracing & metrics.
+- **Provider pattern** — typed `RequestResponse[I,O]`, `Stream`, `Sink`, and `Duplex` traits with composable middleware and sink combinators.
+- **Per-module versioning** — `gokit/server` and `gokit/database` upgrade independently of core. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
+- **Sibling parity** — APIs mirror [rskit](https://github.com/kbukum/rskit) (Rust) and [pykit](https://github.com/kbukum/pykit) (Python).
 
 ## Install
 
@@ -74,28 +64,36 @@ package main
 
 import (
     "context"
+
     "github.com/kbukum/gokit/bootstrap"
-    "github.com/kbukum/gokit/logging"
+    "github.com/kbukum/gokit/config"
 )
 
-func main() {
-    log := logging.New(&logging.Config{Level: "info", Format: "console"}, "my-service")
+type Config struct {
+    config.ServiceConfig `mapstructure:",squash"`
+}
 
-    app := bootstrap.NewApp("my-service", "1.0.0", bootstrap.WithLogger(log))
-    app.OnConfigure(func(ctx context.Context, app *bootstrap.App) error {
+func main() {
+    cfg := &Config{ServiceConfig: config.ServiceConfig{Name: "my-service", Version: "1.0.0"}}
+
+    app, err := bootstrap.NewApp(cfg)
+    if err != nil {
+        panic(err)
+    }
+
+    app.OnConfigure(func(ctx context.Context, app *bootstrap.App[*Config]) error {
         // wire routes, handlers, business logic — components are already started
         return nil
     })
 
     // Init → Start → Configure → Ready → wait for signal → Stop
     if err := app.Run(context.Background()); err != nil {
-        log.Fatal("app failed", map[string]interface{}{"error": err})
+        app.Logger.Fatal("app failed", map[string]any{"error": err})
     }
 }
 ```
 
-More examples → [`docs/EXAMPLES.md`](docs/EXAMPLES.md).
-Full package list → [`docs/PACKAGES.md`](docs/PACKAGES.md).
+More examples → [`docs/EXAMPLES.md`](docs/EXAMPLES.md). Full package list → [`docs/PACKAGES.md`](docs/PACKAGES.md).
 
 ## Documentation
 
@@ -120,11 +118,9 @@ make tidy     # go mod tidy for core + sub-modules
 
 ## Contributing
 
-We welcome contributions. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, coding standards,
-and the PR process. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+We welcome contributions. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, coding standards, and the PR process. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-Other community docs:
-[`SECURITY.md`](SECURITY.md) · [`GOVERNANCE.md`](GOVERNANCE.md) · [`MAINTAINERS.md`](MAINTAINERS.md)
+Other community docs: [`SECURITY.md`](SECURITY.md) · [`GOVERNANCE.md`](GOVERNANCE.md) · [`MAINTAINERS.md`](MAINTAINERS.md)
 
 ## License
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,7 +1,6 @@
 # gokit/agent
 
-`agent` owns the bounded LLM/tool loop. Defaults are bounded: `MaxTurns=10`, `WallClock=60s`,
-`MaxTokens=100000`, `MaxToolCalls=50`, `ToolConcurrency=4`, and `ToolTimeout=30s`.
+`agent` owns the bounded LLM/tool loop. Defaults are bounded: `MaxTurns=10`, `WallClock=60s`, `MaxTokens=100000`, `MaxToolCalls=50`, `ToolConcurrency=4`, and `ToolTimeout=30s`.
 
 ## Install
 
@@ -87,5 +86,4 @@ func main() {
 
 ## When to use
 
-Use `agent` when you want the bounded turn loop, budgets, tool dispatch, hooks,
-and memory policy in one place instead of building an orchestration loop yourself.
+Use `agent` when you want the bounded turn loop, budgets, tool dispatch, hooks, and memory policy in one place instead of building an orchestration loop yourself.

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,7 +1,6 @@
 # gokit/ai
 
-`ai` owns shared AI/ML value types only: content blocks, chat messages, models, usage, streams,
-prompts, vectors, and OTel semantic conventions.
+`ai` owns shared AI/ML value types only: content blocks, chat messages, models, usage, streams, prompts, vectors, and OTel semantic conventions.
 
 ## Architecture
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,7 +1,6 @@
 # auth
 
-Authentication building blocks with locked JWT policy, Argon2id-first password hashing,
-OIDC verification, and shared token validation interfaces.
+Authentication building blocks with locked JWT policy, Argon2id-first password hashing, OIDC verification, and shared token validation interfaces.
 
 For authorization (permission checking, RBAC), see [authz](../authz/).
 

--- a/authz/README.md
+++ b/authz/README.md
@@ -1,7 +1,6 @@
 # authz
 
-Authorization building blocks with a canonical **RBAC + ABAC** engine
-and explicit default-deny semantics.
+Authorization building blocks with a canonical **RBAC + ABAC** engine and explicit default-deny semantics.
 
 This module has **zero external dependencies**.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -13,20 +13,16 @@ datasets flow through **pipelines**, and metrics are fully pluggable.
 
 ## Features
 
-- **Generics-first** — `Sample[L]`, `Prediction[L]`,
-  `Evaluator[L]` are parameterised on the label type
-- **Provider integration** —
-  any `provider.RequestResponse` becomes an evaluator with one adapter call
-- **Pipeline integration** — datasets expose a `stream.Pipeline` / `stream.Iterator` for lazy,
-  backpressure-aware loading
+- **Generics-first** — `Sample[L]`, `Prediction[L]`, `Evaluator[L]` are parameterised on the label type
+- **Provider integration** — any `provider.RequestResponse` becomes an evaluator with one adapter call
+- **Pipeline integration** — datasets expose a `stream.Pipeline` / `stream.Iterator` for lazy, backpressure-aware loading
 - **Pluggable metrics** — classification, probability, ranking, regression, matching —
   or bring your own
 - **Multiple output formats** — JSON, Markdown, CSV, HTML, JUnit XML, Vega-Lite, SVG visualisations
 - **Comparison & regression detection** — diff two runs, surface fixed/regressed samples,
   gate CI on thresholds
 - **CLI helpers** — `CLIRunner` wires up run → store → compare → print in a few lines
-- **Concurrent evaluation** — fan out across evaluators with configurable concurrency
-  and per-sample timeouts
+- **Concurrent evaluation** — fan out across evaluators with configurable concurrency and per-sample timeouts
 
 ## Install
 

--- a/bench/storage/README.md
+++ b/bench/storage/README.md
@@ -2,8 +2,7 @@
 
 **Cloud storage adapter for bench results — wraps gokit/storage**
 
-`bench/storage` implements the `bench.RunStorage` interface on top of any `gokit/storage.Storage` provider (S3, GCS, Azure Blob, local filesystem, etc.),
-so benchmark results can be persisted and queried without changing a line of benchmarking code.
+`bench/storage` implements the `bench.RunStorage` interface on top of any `gokit/storage.Storage` provider (S3, GCS, Azure Blob, local filesystem, etc.), so benchmark results can be persisted and queried without changing a line of benchmarking code.
 
 ## Install
 
@@ -28,8 +27,10 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// 1. Create a gokit/storage provider (e.g. S3, GCS, local).
-	store, _ := storage.New("s3://my-bucket")
+	// 1. Build a gokit/storage provider (register a backend into the registry first).
+	reg := storage.NewFactoryRegistry()
+	// Register the desired backend (e.g. via s3.Register, gcs.Register, or local.Register).
+	store, _ := storage.New(reg, storage.Config{Provider: "s3"}, nil)
 
 	// 2. Wrap it as bench RunStorage.
 	rs := benchstore.NewProviderStorage(store,

--- a/bench/storage/README.md
+++ b/bench/storage/README.md
@@ -22,6 +22,7 @@ import (
 	"github.com/kbukum/gokit/bench"
 	benchstore "github.com/kbukum/gokit/bench/storage"
 	"github.com/kbukum/gokit/storage"
+	"github.com/kbukum/gokit/storage/local"
 )
 
 func main() {
@@ -29,8 +30,13 @@ func main() {
 
 	// 1. Build a gokit/storage provider (register a backend into the registry first).
 	reg := storage.NewFactoryRegistry()
-	// Register the desired backend (e.g. via s3.Register, gcs.Register, or local.Register).
-	store, _ := storage.New(reg, storage.Config{Provider: "s3"}, nil)
+	if err := local.Register(reg, local.Config{BasePath: "./benchmarks"}); err != nil {
+		panic(err)
+	}
+	store, err := storage.New(reg, storage.Config{Provider: storage.ProviderLocal}, nil)
+	if err != nil {
+		panic(err)
+	}
 
 	// 2. Wrap it as bench RunStorage.
 	rs := benchstore.NewProviderStorage(store,

--- a/chain/README.md
+++ b/chain/README.md
@@ -1,14 +1,8 @@
 # chain
 
-Typed, sequential chain execution:
-a statically typed sequence of steps where each step consumes the previous step's output
-and produces the next step's input type. Supports per-step progress reporting,
-cancellation at step boundaries,
-and automatic reverse-order cleanup of completed steps when a later step fails
-or the chain is canceled.
+Typed, sequential chain execution: a statically typed sequence of steps where each step consumes the previous step's output and produces the next step's input type. Supports per-step progress reporting, cancellation at step boundaries, and automatic reverse-order cleanup of completed steps when a later step fails or the chain is canceled.
 
-Mirrors `rskit-chain` (Rust) and `pykit-chain` (Python) —
-the same typed `Step` / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
+Mirrors `rskit-chain` (Rust) and `pykit-chain` (Python) — the same typed `Step` / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
 
 ## Install
 
@@ -48,9 +42,7 @@ func main() {
 }
 ```
 
-Because Go methods cannot introduce new type parameters,
-steps are appended with the package-level `Then` function rather than a fluent method,
-so each `Then` can transform the output type.
+Because Go methods cannot introduce new type parameters, steps are appended with the package-level `Then` function rather than a fluent method, so each `Then` can transform the output type.
 
 ## Key Types & Functions
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,14 +1,8 @@
 # cli
 
-A parser-agnostic terminal-UX toolkit for gokit command-line programs. It is not a flag parser;
-it owns the presentation, input, and cancellation concerns a CLI shares, so every gokit CLI renders
-and behaves consistently.
+A parser-agnostic terminal-UX toolkit for gokit command-line programs. It is not a flag parser; it owns the presentation, input, and cancellation concerns a CLI shares, so every gokit CLI renders and behaves consistently.
 
-`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and leans on the standard library,
-with `go.yaml.in/yaml/v3` (for `render`'s YAML output) as its only external dependency.
-It is the **light** Go mirror of rskit's `rskit-cli`: theming, structured output, progress, prompts,
-signals, and a bounded live console.
-Heavy raw-mode rich widgets (arrow-key radio/checkbox lists) stay rskit-only by design.
+`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and leans on the standard library, with `go.yaml.in/yaml/v3` (for `render`'s YAML output) as its only external dependency. It is the **light** Go mirror of rskit's `rskit-cli`: theming, structured output, progress, prompts, signals, and a bounded live console. Heavy raw-mode rich widgets (arrow-key radio/checkbox lists) stay rskit-only by design.
 
 > This is the one gokit module where writing to stdout/stderr is expected.
 > Every renderer takes an injected `io.Writer`; every other module uses the injected logger.
@@ -59,13 +53,9 @@ func main() {
 Everything is testable without a real terminal:
 
 - `prompt.ScriptedTerminal` replays canned input and captures output.
-- `progress.Bar`/`progress.Spinner` advance only when the caller updates them — no clock,
-  no background goroutine.
+- `progress.Bar`/`progress.Spinner` advance only when the caller updates them — no clock, no background goroutine.
 - `live.Console` redraws only on `Render()`, writing to an injected writer.
 
 ## Capability split (light by design)
 
-gokit `cli` mirrors rskit's *surface* idiomatically but stays light:
-it lands theme/render/progress/prompt/signal plus a bounded live console.
-A full raw-mode rich TUI (live arrow-key navigation via a terminal driver dependency) stays rskit-only
-— the line-driven prompt path is always available and dependency-free.
+gokit `cli` mirrors rskit's *surface* idiomatically but stays light: it lands theme/render/progress/prompt/signal plus a bounded live console. A full raw-mode rich TUI (live arrow-key navigation via a terminal driver dependency) stays rskit-only — the line-driven prompt path is always available and dependency-free.

--- a/codec/README.md
+++ b/codec/README.md
@@ -1,8 +1,6 @@
 # codec
 
-Pluggable structured-text codecs (JSON, TOML, …) over a single canonical in-memory model.
-Any package that reads or writes a config file, manifest,
-or document reuses these codecs instead of re-implementing "bounded read → parse → typed error" per format.
+Pluggable structured-text codecs (JSON, TOML, …) over a single canonical in-memory model. Any package that reads or writes a config file, manifest, or document reuses these codecs instead of re-implementing "bounded read → parse → typed error" per format.
 
 ## Install
 

--- a/component/README.md
+++ b/component/README.md
@@ -51,7 +51,7 @@ func main() {
 | Name | Description |
 |------|-------------|
 | `Component` | Interface: `Name()`, `Start()`, `Stop()`, `Health()` |
-| `ComponentHealth` | Health status with name, status, message |
+| `Health` | Health status with name, status, message |
 | `Registry` | Manages component lifecycle with deterministic ordering |
 | `BaseLazyComponent` | Thread-safe lazy initialization wrapper |
 | `NewRegistry()` | Create component registry |

--- a/config/README.md
+++ b/config/README.md
@@ -1,7 +1,6 @@
 # config
 
-Configuration loading from YAML files and environment variables with automatic resolution
-and validation.
+Configuration loading from YAML files and environment variables with automatic resolution and validation.
 
 ## Install
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,7 +1,6 @@
 # connect
 
-Connect-Go integration for gokit — server-side interceptors, error mapping, service mounting,
-and client utilities.
+Connect-Go integration for gokit — server-side interceptors, error mapping, service mounting, and client utilities.
 
 ## Install
 
@@ -288,11 +287,11 @@ func main() {
     )
 
     // Start server
-    srv := server.New(server.Config{Port: 8080}, log)
+    srv := server.New(&server.Config{Port: 8080}, log)
     goconnect.Mount(srv, publicPath, publicHandler)
     goconnect.Mount(srv, protectedPath, protectedHandler)
     
-    if err := srv.Start(); err != nil {
+    if err := srv.Start(context.Background()); err != nil {
         log.Fatal("server failed", map[string]interface{}{"error": err})
     }
 }

--- a/dag/README.md
+++ b/dag/README.md
@@ -103,9 +103,7 @@ graph, _ := dag.ResolvePipeline(pipeline, registry, loader)
 
 ### Optional Nodes & Error Policies
 
-Nodes can be marked `optional` — if the component is not registered,
-a placeholder is inserted that returns `ErrUnavailable`.
-The engine skips dependents per-cycle without removing them from the graph.
+Nodes can be marked `optional` — if the component is not registered, a placeholder is inserted that returns `ErrUnavailable`. The engine skips dependents per-cycle without removing them from the graph.
 
 ```yaml
 nodes:
@@ -129,9 +127,7 @@ nodes:
 
 ### FailurePolicy modes
 
-`EngineConfig.FailurePolicy` controls how batch and streaming execution react to node failures.
-Node-level `on_error` values from YAML map onto the same behavior
-and override the engine default for that node.
+`EngineConfig.FailurePolicy` controls how batch and streaming execution react to node failures. Node-level `on_error` values from YAML map onto the same behavior and override the engine default for that node.
 
 | Mode | Behavior |
 |---|---|
@@ -141,18 +137,11 @@ and override the engine default for that node.
 
 ### Cycle detection guarantee
 
-`BuildLevels` uses Kahn's algorithm before execution. Any cycle returns an error
-and prevents execution from starting; the engine never runs a partial cyclic graph.
-Edges that reference unknown nodes are also rejected during level building.
+`BuildLevels` uses Kahn's algorithm before execution. Any cycle returns an error and prevents execution from starting; the engine never runs a partial cyclic graph. Edges that reference unknown nodes are also rejected during level building.
 
 ### Parallelism semantics
 
-Nodes are grouped into dependency levels.
-Nodes within the same level have no unresolved dependencies between them and may run concurrently.
-`Engine.MaxParallel` / `EngineConfig.MaxParallel` limits concurrency per level;
-`0` means no explicit limit beyond the number of ready nodes.
-Dependent levels start only after the previous level has completed
-or been skipped according to the active `FailurePolicy`.
+Nodes are grouped into dependency levels. Nodes within the same level have no unresolved dependencies between them and may run concurrently. `Engine.MaxParallel` / `EngineConfig.MaxParallel` limits concurrency per level; `0` means no explicit limit beyond the number of ready nodes. Dependent levels start only after the previous level has completed or been skipped according to the active `FailurePolicy`.
 
 ### Schedule Config
 
@@ -191,8 +180,7 @@ node = dag.WithLogging(node, log)
 
 ## Cascade: Staged Execution Pipeline
 
-For multi-stage processing where each stage is a sub-DAG with its own configuration,
-conditional advancement, and early exit.
+For multi-stage processing where each stage is a sub-DAG with its own configuration, conditional advancement, and early exit.
 
 ```go
 cascade := dag.NewCascade[Input, Result]().
@@ -239,15 +227,12 @@ fmt.Println(trace.EarlyExit)     // true — confident at stage 1
 - **Per-stage timeout** — independent timeout for each stage
 - **Node failure policies** — `ContinueWithPartial()` or abort on node failure
 - **Stage failure policies** — `Abort()`, `SkipToFinal()`, or `ContinueOnFailure()`
-- **Ordering strategies** — `OrderByCost()`, `OrderByLatency()`,
-  `WeightedScore(weights)` using `provider.Meta`
-- **Execution trace** — `CascadeTrace` with per-node timing, cost aggregation,
-  stages executed/skipped
+- **Ordering strategies** — `OrderByCost()`, `OrderByLatency()`, `WeightedScore(weights)` using `provider.Meta`
+- **Execution trace** — `CascadeTrace` with per-node timing, cost aggregation, stages executed/skipped
 
 ### Ordering Strategies
 
-OrderBy affects scheduling when multiple nodes are ready simultaneously
-and resources are constrained (`MaxConcurrency`). Strategies read `provider.Meta`:
+OrderBy affects scheduling when multiple nodes are ready simultaneously and resources are constrained (`MaxConcurrency`). Strategies read `provider.Meta`:
 
 ```go
 // Cheapest nodes first (reads "cost" from provider.Meta)

--- a/database/sqlite/README.md
+++ b/database/sqlite/README.md
@@ -3,8 +3,7 @@
 SQLite driver adapter for `github.com/kbukum/gokit/database`.
 
 The core `database` module owns the database component, repository helpers, and `DriverRegistry`.
-This adapter owns the SQLite driver dependency
-and registers itself only when the application explicitly calls `Register`.
+This adapter owns the SQLite driver dependency and registers itself only when the application explicitly calls `Register`.
 
 ## Usage
 
@@ -25,5 +24,4 @@ func configure() (*database.DriverRegistry, error) {
 }
 ```
 
-Importing this package has no side effects. Applications own the registry
-and choose the driver through configuration.
+Importing this package has no side effects. Applications own the registry and choose the driver through configuration.

--- a/database/testutil/README.md
+++ b/database/testutil/README.md
@@ -101,13 +101,13 @@ func TestWithFixtures(t *testing.T) {
     db.DB().Exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")
     
     // Load fixture data
-    dbtestutil.LoadFixture(db.DB(), "users", []map[string]interface{}{
+    dbtestutil.LoadFixture(db.DB(), "users", []map[string]any{
         {"name": "Alice", "email": "alice@example.com"},
         {"name": "Bob", "email": "bob@example.com"},
     })
     
     // Or use MustLoadFixture to fail test on error
-    dbtestutil.MustLoadFixture(t, db.DB(), "users", []map[string]interface{}{
+    dbtestutil.MustLoadFixture(t, db.DB(), "users", []map[string]any{
         {"name": "Charlie", "email": "charlie@example.com"},
     })
 }
@@ -295,7 +295,7 @@ Prefer fixture helpers over raw SQL when loading test data:
 
 ```go
 // Good ✓
-dbtestutil.MustLoadFixture(t, db.DB(), "users", []map[string]interface{}{
+dbtestutil.MustLoadFixture(t, db.DB(), "users", []map[string]any{
     {"name": "Alice", "email": "alice@example.com"},
     {"name": "Bob", "email": "bob@example.com"},
 })
@@ -330,7 +330,7 @@ if count != 5 {
 func NewComponent() *Component
 
 // WithModels registers models for auto-migration
-func (c *Component) WithModels(models ...interface{}) *Component
+func (c *Component) WithModels(models ...any) *Component
 
 // DB returns the underlying *gorm.DB
 func (c *Component) DB() *gorm.DB
@@ -343,18 +343,18 @@ Health(ctx context.Context) component.Health
 
 // TestComponent interface methods
 Reset(ctx context.Context) error
-Snapshot(ctx context.Context) (interface{}, error)
-Restore(ctx context.Context, snapshot interface{}) error
+Snapshot(ctx context.Context) (any, error)
+Restore(ctx context.Context, snapshot any) error
 ```
 
 ### Fixture Functions
 
 ```go
 // LoadFixture loads test data into a table
-func LoadFixture(db *gorm.DB, table string, data []map[string]interface{}) error
+func LoadFixture(db *gorm.DB, table string, data []map[string]any) error
 
 // MustLoadFixture loads test data and fails the test on error
-func MustLoadFixture(t *testing.T, db *gorm.DB, table string, data []map[string]interface{})
+func MustLoadFixture(t *testing.T, db *gorm.DB, table string, data []map[string]any)
 
 // TruncateTable removes all rows from a table
 func TruncateTable(db *gorm.DB, table string) error
@@ -391,7 +391,3 @@ func AssertRowCount(t *testing.T, db *gorm.DB, table string, expected int64)
 See the test files for comprehensive examples:
 - `component_test.go` - TestComponent lifecycle and state management
 - `fixtures_test.go` - Fixture helper usage patterns
-
-## Coverage
-
-Current test coverage: **84.2%** (32 tests, all passing)

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -1,15 +1,8 @@
 # dataset
 
-A streaming dataset-collection framework: bounded sources feed typed transforms and targets,
-with fail-closed schema validation, a manifest/cache layer,
-and spill-to-file for oversized payloads. It is the cross-kit Go mirror of rskit's `rskit-dataset`,
-kept **light**: heavy image/media transforms stay rskit-only by design.
+A streaming dataset-collection framework: bounded sources feed typed transforms and targets, with fail-closed schema validation, a manifest/cache layer, and spill-to-file for oversized payloads. It is the cross-kit Go mirror of rskit's `rskit-dataset`, kept **light**: heavy image/media transforms stay rskit-only by design.
 
-`dataset` is a sub-module (`github.com/kbukum/gokit/dataset`)
-so it can reuse the `schema` sub-module.
-It builds on gokit's canonical owners rather than a parallel stack —
-record streams are [`stream`](../stream) pipelines, bounded file reads go through [`fs`](../fs),
-and validation reuses [`schema`](../schema).
+`dataset` is a sub-module (`github.com/kbukum/gokit/dataset`) so it can reuse the `schema` sub-module. It builds on gokit's canonical owners rather than a parallel stack — record streams are [`stream`](../stream) pipelines, bounded file reads go through [`fs`](../fs), and validation reuses [`schema`](../schema).
 
 It is split into focused sub-packages by concern:
 
@@ -25,16 +18,9 @@ It is split into focused sub-packages by concern:
 
 ## Bounds & safety
 
-- Every read
-  and payload is bounded by `payload.Limits` (8 MiB in-memory cap, 64-record stream buffer by default);
-  oversized payloads spill to a file rather than being held in memory.
-- Untrusted CSV/JSON records and schema validation **fail closed**; `record`'s readers
-  and `Schema.Validate` have `Fuzz` targets.
-- The collector streams sources through a bounded worker pool: the work
-  and event channels are sized by `Limits.StreamBuffer` for backpressure,
-  each source is bounded by `Config.SourceTimeout` and `context.Context` cancellation,
-  and a resumable source that made partial progress is recorded as `partial`
-  so a later run continues it from its offset.
+- Every read and payload is bounded by `payload.Limits` (8 MiB in-memory cap, 64-record stream buffer by default); oversized payloads spill to a file rather than being held in memory.
+- Untrusted CSV/JSON records and schema validation **fail closed**; `record`'s readers and `Schema.Validate` have `Fuzz` targets.
+- The collector streams sources through a bounded worker pool: the work and event channels are sized by `Limits.StreamBuffer` for backpressure, each source is bounded by `Config.SourceTimeout` and `context.Context` cancellation, and a resumable source that made partial progress is recorded as `partial` so a later run continues it from its offset.
 
 ## Quick start
 

--- a/di/README.md
+++ b/di/README.md
@@ -1,9 +1,6 @@
 # di
 
-Small,
-type-keyed dependency injection container with eager / singleton / transient registration modes,
-closeable lifecycle, and context-based cycle detection. The public API is generic
-and typed end-to-end — there is no untyped registration or lookup.
+Small, type-keyed dependency injection container with eager / singleton / transient registration modes, closeable lifecycle, and context-based cycle detection. The public API is generic and typed end-to-end — there is no untyped registration or lookup.
 
 ## Install
 
@@ -57,17 +54,9 @@ func main() {
 }
 ```
 
-Constructor injection is the only wiring pattern:
-a factory receives the resolution `context.Context`
-and calls `Resolve` with it for each dependency it needs.
-The active resolution chain travels in that context, so circular dependencies are detected
-and returned as an error, and a canceled context aborts resolution.
+Constructor injection is the only wiring pattern: a factory receives the resolution `context.Context` and calls `Resolve` with it for each dependency it needs. The active resolution chain travels in that context, so circular dependencies are detected and returned as an error, and a canceled context aborts resolution.
 
-Resource cleanup is opt-in: only values registered with `RegisterCloseable`
-or `RegisterSingletonCloseable` are released by `Container.Close`,
-which runs their disposers in reverse order of construction and joins any errors.
-Plain `Register` values and unresolved singletons are never closed by the container —
-the caller owns them.
+Resource cleanup is opt-in: only values registered with `RegisterCloseable` or `RegisterSingletonCloseable` are released by `Container.Close`, which runs their disposers in reverse order of construction and joins any errors. Plain `Register` values and unresolved singletons are never closed by the container — the caller owns them.
 
 ## Key Types & Functions
 

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -57,7 +57,7 @@ instances, _ := comp.Discovery().Discover(ctx, "user-service")
 | `Config` | Provider, Consul address/token, service name/port, health check, tags, metadata |
 | `ServiceInfo` | ID, Name, Address, Port, Tags, Metadata |
 | `ServiceInstance` | Extends ServiceInfo with Health status and LastSeen |
-| `NewComponent(reg, cfg, log)` | Create a managed discovery component |
+| `NewComponent(reg, cfg, log, ...opts) (*Component, error)` | Create a managed discovery component |
 
 ### Providers
 

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -57,7 +57,7 @@ instances, _ := comp.Discovery().Discover(ctx, "user-service")
 | `Config` | Provider, Consul address/token, service name/port, health check, tags, metadata |
 | `ServiceInfo` | ID, Name, Address, Port, Tags, Metadata |
 | `ServiceInstance` | Extends ServiceInfo with Health status and LastSeen |
-| `NewComponent(cfg, log)` | Create a managed discovery component |
+| `NewComponent(reg, cfg, log)` | Create a managed discovery component |
 
 ### Providers
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -1,8 +1,6 @@
 # gokit Package Map
 
-gokit is a multi-module Go workspace.
-The **core module** (`github.com/kbukum/gokit`) is light-weight and dependency-thin;
-**sub-modules** (`github.com/kbukum/gokit/{name}`) bring in heavier dependencies à la carte.
+gokit is a multi-module Go workspace. The **core module** (`github.com/kbukum/gokit`) is light-weight and dependency-thin; **sub-modules** (`github.com/kbukum/gokit/{name}`) bring in heavier dependencies à la carte.
 
 Every package has its own `README.md` with API examples — start there for details.
 This file is the bird's-eye index.
@@ -34,12 +32,13 @@ This file is the bird's-eye index.
 | `stream` | `gokit/stream` | Pull-based stream (Throttle, Batch, Debounce, Window) |
 | `dag` | `gokit/dag` | DAG execution engine — batch / streaming / cascade |
 | `chain` | `gokit/chain` | Sequential chain execution — step piping, progress, cancellation |
-| `media` | `gokit/media` | Light standalone kit: type/format detection, metadata, cheap image ops |
 | `security` | `gokit/security` | TLS configuration and certificate utilities |
 | `process` | `gokit/process` | Subprocess execution with cancellation |
 | `worker` | `gokit/worker` | Push-based worker pools with supervision |
 | `component` | `gokit/component` | Lifecycle interface (start/stop/health) |
 | `bootstrap` | `gokit/bootstrap` | Application startup orchestration & graceful shutdown |
+| `hook` | `gokit/hook` | Generic event hook system |
+| `cli` | `gokit/cli` | Parser-agnostic terminal-UX toolkit — theme, render, progress, prompt, signal, live |
 
 ## Sub-Modules
 
@@ -59,6 +58,8 @@ This file is the bird's-eye index.
 | `workload` | `gokit/workload` | Docker / Kubernetes workload execution |
 | `testutil` | `gokit/testutil` | Component lifecycle & state-management testing |
 | `stateful` | `gokit/stateful` | Push-based stateful accumulation |
+| `media` | `gokit/media` | Light standalone kit: type/format detection, metadata, cheap image ops |
+| `dataset` | `gokit/dataset` | Streaming dataset-collection toolkit — fetch, transform, validate, publish |
 | `llm` | `gokit/llm` | LLM chat completion abstraction |
 | `inference` | `gokit/inference` | Model-serving runtime adapters — Triton, KServe v2, vLLM, TGI |
 | `ai` | `gokit/ai` | Universal AI/ML primitives — value types, sentinel errors, semantic keys |
@@ -68,7 +69,6 @@ This file is the bird's-eye index.
 | `agent` | `gokit/agent` | Agentic loop — LLM, tools, context management |
 | `tool` | `gokit/tool` | Type-safe tool definitions with auto-generated schemas |
 | `schema` | `gokit/schema` | JSON Schema generation from Go types |
-| `hook` | `gokit/hook` | Generic event hook system |
 | `mcp` | `gokit/mcp` | Model Context Protocol server / client |
 | `skill` | `gokit/skill` | SDK-free skill manifests, loading, registry, activation |
 | `git` | `gokit/git` | Git repository operations — capability interfaces, embedded/CLI backends |
@@ -81,26 +81,25 @@ This file is the bird's-eye index.
 |---|---|---|
 | **Foundation** | errors, config, logging, version, codec, fs | Configuration, logging, errors, encoding, filesystem |
 | **Utilities** | util, encryption, validation | Helpers and data validation |
-| **Architecture** | di, provider, component, bootstrap | DI, lifecycle, provider pattern |
+| **Architecture** | di, provider, component, bootstrap, hook | DI, lifecycle, provider pattern, event hooks |
 | **Auth & Authz** | auth, authz | Authentication and authorization |
 | **Resilience** | resilience, observability | Fault tolerance, tracing, metrics |
-| **Data & Flow** | stream, dag, chain, sse, media, stateful | Streams, DAGs, chains, SSE, media, accumulation |
+| **Data & Flow** | stream, dag, chain, sse, media, stateful, dataset | Streams, DAGs, chains, SSE, media, accumulation, dataset collection |
 | **Infrastructure** | database, cache, messaging, storage | Data stores and messaging |
 | **Networking** | httpclient | HTTP client with resilience |
 | **Transport** | server, grpc, connect, discovery | HTTP, gRPC, service discovery |
 | **Execution** | process, workload, worker | Subprocess and container workloads |
 | **Testing** | testutil | Component lifecycle testing infrastructure |
-| **AI** | ai, llm, inference, agent, tool, hook, mcp, skill, schema | LLM orchestration & tooling |
+| **AI** | ai, llm, inference, agent, tool, mcp, skill, schema | LLM orchestration & tooling |
 | **Evaluation** | bench, bench/viz, bench/storage | Provider benchmarking |
 | **Vectors** | embedding, vectorstore | Embedding & similarity search |
-| **Devtools** | git | Git repository operations |
+| **Devtools** | git, cli | Git repository operations, terminal UX tooling |
 
 See [`docs/adr/0001-three-tier-layering.md`](adr/0001-three-tier-layering.md) for the layering rationale.
 
 ## Multi-Module Versioning
 
-Core and sub-modules version **independently**. Each sub-module has its own `go.mod`
-and release tags:
+Core and sub-modules version **independently**. Each sub-module has its own `go.mod` and release tags:
 
 ```
 v0.5.0              ← core module

--- a/docs/concern-owners.md
+++ b/docs/concern-owners.md
@@ -1,14 +1,8 @@
 # Concern owners
 
-The canonical **concern → owning module** map for gokit. Before adding any shared helper, type,
-or capability, find the concern below and **reuse or extend the named owner** —
-do not fork a local copy. If the owner is inadequate,
-enhance it *generically* (so every consumer benefits), never caller-specifically.
-Reimplementing a concern that already has an owner is a review blocker.
+The canonical **concern → owning module** map for gokit. Before adding any shared helper, type, or capability, find the concern below and **reuse or extend the named owner** — do not fork a local copy. If the owner is inadequate, enhance it *generically* (so every consumer benefits), never caller-specifically. Reimplementing a concern that already has an owner is a review blocker.
 
-This map names *who* owns each concern;
-the *how to judge* procedure (reuse / enhance / add / justify) lives in the review pass [`.github/skills/review/references/01-canonical-reuse.md`](../.github/skills/review/references/01-canonical-reuse.md).
-Start here, then check each low-level operation against that pass.
+This map names *who* owns each concern; the *how to judge* procedure (reuse / enhance / add / justify) lives in the review pass [`.github/skills/review/references/01-canonical-reuse.md`](../.github/skills/review/references/01-canonical-reuse.md). Start here, then check each low-level operation against that pass.
 
 | Concern | Owner | Reuse this, not | Notes |
 |---|---|---|---|
@@ -31,12 +25,8 @@ Start here, then check each low-level operation against that pass.
 ## How to use this map
 
 1. Name the concern before writing the code.
-2. Find its owner above; **consume
-   or implement its contract** (see the [reuse review pass](../.github/skills/review/references/01-canonical-reuse.md)).
+2. Find its owner above; **consume or implement its contract** (see the [reuse review pass](../.github/skills/review/references/01-canonical-reuse.md)).
 3. If the owner is close but inadequate, enhance it generically, then consume — never fork.
-4. If a concern has genuinely no owner and is foundational,
-   add it to the correct owning module (or a new correctly-layered one), with tests and docs —
-   not locally.
+4. If a concern has genuinely no owner and is foundational, add it to the correct owning module (or a new correctly-layered one), with tests and docs — not locally.
 
-The list is illustrative, not exhaustive: **any** gokit module is a potential owner,
-so a capability that maps to an owner not named here still counts.
+The list is illustrative, not exhaustive: **any** gokit module is a potential owner, so a capability that maps to an owner not named here still counts.

--- a/embedding/README.md
+++ b/embedding/README.md
@@ -42,5 +42,4 @@ func main() {
 
 ## When to use
 
-Use `embedding` for canonical vector generation contracts. Provider implementations live here
-or in the provider-specific module that naturally owns the backend.
+Use `embedding` for canonical vector generation contracts. Provider implementations live here or in the provider-specific module that naturally owns the backend.

--- a/errors/README.md
+++ b/errors/README.md
@@ -4,15 +4,9 @@ Unified application error handling with HTTP status codes, error codes, and retr
 
 ## Overview
 
-The `errors` module provides a structured approach to error handling across Go microservices.
-It moves away from simple string-based errors towards a machine-readable `AppError` type that includes semantic error codes,
-HTTP status mappings, and metadata.
+The `errors` module provides a structured approach to error handling across Go microservices. It moves away from simple string-based errors towards a machine-readable `AppError` type that includes semantic error codes, HTTP status mappings, and metadata.
 
-This design follows best practices such as RFC 9457 (Problem Details for HTTP APIs)
-and Google AIP-193. It allows services to communicate clearly about what went wrong,
-whether the client should retry,
-and provides structured details that can be easily parsed by frontend applications
-or observability tools.
+This design follows best practices such as RFC 9457 (Problem Details for HTTP APIs) and Google AIP-193. It allows services to communicate clearly about what went wrong, whether the client should retry, and provides structured details that can be easily parsed by frontend applications or observability tools.
 
 ## Installation
 
@@ -51,8 +45,7 @@ func main() {
 
 ## Configuration
 
-This module does not require external configuration. It uses a predefined set of error codes
-and mapping logic.
+This module does not require external configuration. It uses a predefined set of error codes and mapping logic.
 
 ## API Reference
 
@@ -115,28 +108,25 @@ rfc := appErr.ToProblemDetail()
 // ProblemDetail{Type, Title, Status, Detail, Instance, Code, Retryable, Details}
 ```
 
-The `ProblemDetail` struct includes `Type`, `Title`, `Status`, `Detail`, `Instance`, `Code`,
-`Retryable`, and `Details` fields suitable for direct JSON serialization in HTTP APIs.
+The `ProblemDetail` struct includes `Type`, `Title`, `Status`, `Detail`, `Instance`, `Code`, `Retryable`, and `Details` fields suitable for direct JSON serialization in HTTP APIs.
 
 ## Advanced Usage
 
 ### Error Wrapping
 
-`AppError` supports Go 1.13+ error wrapping. You can use `errors.Is`
-and `errors.As` from the standard library.
+`AppError` supports Go 1.13+ error wrapping. You can use `errors.Is` and `errors.As` from the standard library.
 
 ```go
 cause := fmt.Errorf("connection refused")
 appErr := errors.DatabaseError(cause)
 
 // Unwrap works as expected
-fmt.Println(errors.Unwrap(appErr) == cause) // true
+fmt.Println(appErr.Unwrap() == cause) // true
 ```
 
 ### Retry Logic
 
-The `Retryable` flag is automatically set based on the `ErrorCode`. This can be used by middleware
-or clients to implement backoff and retry strategies.
+The `Retryable` flag is automatically set based on the `ErrorCode`. This can be used by middleware or clients to implement backoff and retry strategies.
 
 ```go
 if appErr, ok := errors.AsAppError(err); ok && appErr.Retryable {

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,11 +1,6 @@
 # fs
 
-Local filesystem primitives for safe paths, temporary files and directories, atomic writes,
-permissions, and metadata. It stays deliberately below storage abstractions —
-higher-level packages (`storage`, `cache`, `httpclient`) reuse these primitives instead of each re-implementing path safety,
-temp files, and atomic replacement.
-Where the standard library already suffices (`os`, `io/fs`, `path/filepath`),
-this package builds on it.
+Local filesystem primitives for safe paths, temporary files and directories, atomic writes, permissions, and metadata. It stays deliberately below storage abstractions — higher-level packages (`storage`, `cache`, `httpclient`) reuse these primitives instead of each re-implementing path safety, temp files, and atomic replacement. Where the standard library already suffices (`os`, `io/fs`, `path/filepath`), this package builds on it.
 
 ## Install
 

--- a/git/README.md
+++ b/git/README.md
@@ -1,9 +1,6 @@
 # git
 
-Domain-grouped interfaces and backend orchestration for Git repository operations.
-The root package exposes capability-oriented interfaces (refs, remotes, config, diff, log, blame, index, commits, …)
-and shared types; concrete implementations live in backend sub-packages (`embedded` and `cli`).
-A `*Repo` composes those backends behind a single ergonomic surface.
+Domain-grouped interfaces and backend orchestration for Git repository operations. The root package exposes capability-oriented interfaces (refs, remotes, config, diff, log, blame, index, commits, …) and shared types; concrete implementations live in backend sub-packages (`embedded` and `cli`). A `*Repo` composes those backends behind a single ergonomic surface.
 
 ## Install
 

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -1,7 +1,6 @@
 # grpc
 
-gRPC client library with lazy initialization, generic client wrapper, interceptors,
-and error mapping.
+gRPC client library with lazy initialization, generic client wrapper, interceptors, and error mapping.
 
 ## Install
 
@@ -73,8 +72,7 @@ For gokit's gRPC client builder, the built-in unary chain is:
 2. resilience
 3. user-supplied interceptors
 
-This keeps logging around the whole RPC while letting resilience set deadlines
-and retries before custom per-call behavior.
+This keeps logging around the whole RPC while letting resilience set deadlines and retries before custom per-call behavior.
 
 ## TLS policy
 

--- a/hook/README.md
+++ b/hook/README.md
@@ -1,10 +1,6 @@
 # hook
 
-A lightweight, generic, observe-only event system. Register handlers for arbitrary event types;
-handlers run sequentially in registration order. Non-fatal errors are aggregated
-and surfaced through the canonical `on_error` event —
-only errors wrapping `ErrFatalHook` abort dispatch. The package is domain-agnostic:
-applications define their own event types by implementing the `Event` interface.
+A lightweight, generic, observe-only event system. Register handlers for arbitrary event types; handlers run sequentially in registration order. Non-fatal errors are aggregated and surfaced through the canonical `on_error` event — only errors wrapping `ErrFatalHook` abort dispatch. The package is domain-agnostic: applications define their own event types by implementing the `Event` interface.
 
 ## Install
 

--- a/httpclient/README.md
+++ b/httpclient/README.md
@@ -1,8 +1,6 @@
 # httpclient
 
-Configurable HTTP client with built-in authentication, TLS,
-resilience (retry, circuit breaker, rate limiting), and streaming support.
-Includes a typed REST client for JSON APIs.
+Configurable HTTP client with built-in authentication, TLS, resilience (retry, circuit breaker, rate limiting), and streaming support. Includes a typed REST client for JSON APIs.
 
 ## Install
 
@@ -101,12 +99,9 @@ httpclient.BearerAuth("token")
 // Basic auth
 httpclient.BasicAuth("user", "pass")
 
-// API key in header
+// API key in header (default: "X-API-Key")
 httpclient.APIKeyAuth("secret")
 httpclient.APIKeyAuthHeader("secret", "X-Custom-Key")
-
-// API key in query parameter
-httpclient.APIKeyAuthQuery("secret", "api_key")
 
 // Custom auth
 httpclient.CustomAuth(func(req *http.Request) {

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,7 +1,6 @@
 # gokit/inference
 
-`inference` is the model-serving runtime layer.
-It adapts serving backends into one `Predict` surface with typed values.
+`inference` is the model-serving runtime layer. It adapts serving backends into one `Predict` surface with typed values.
 
 ## Install
 
@@ -56,5 +55,4 @@ func main() {
 
 ## When to use
 
-Use `inference` for model-serving backends and typed runtime I/O. If you want chat semantics,
-tool use, or canonical message streaming, stay in `llm`.
+Use `inference` for model-serving backends and typed runtime I/O. If you want chat semantics, tool use, or canonical message streaming, stay in `llm`.

--- a/llm/README.md
+++ b/llm/README.md
@@ -1,8 +1,6 @@
 # gokit/llm
 
-`llm` owns gokit's canonical chat-completion surface: request/response types,
-canonical stream events, the provider-facing `Dialect` seam,
-and the adapter that turns provider wire formats into one SDK-free API.
+`llm` owns gokit's canonical chat-completion surface: request/response types, canonical stream events, the provider-facing `Dialect` seam, and the adapter that turns provider wire formats into one SDK-free API.
 
 ## Install
 
@@ -57,5 +55,4 @@ func main() {
 
 ## When to use
 
-Use `llm` for chat-style completions, tool calling, and canonical streaming.
-Use `inference` when you are integrating lower-level serving runtimes such as Triton, vLLM, or TGI.
+Use `llm` for chat-style completions, tool calling, and canonical streaming. Use `inference` when you are integrating lower-level serving runtimes such as Triton, vLLM, or TGI.

--- a/llm/providers/README.md
+++ b/llm/providers/README.md
@@ -89,5 +89,4 @@ func main() {
 
 ## When to use
 
-Import only the providers you actually ship. Registration is explicit
-so composition stays predictable and there are no package-init side effects.
+Import only the providers you actually ship. Registration is explicit so composition stays predictable and there are no package-init side effects.

--- a/logging/README.md
+++ b/logging/README.md
@@ -91,9 +91,7 @@ logging:
 ## Masking
 
 Masking is **enabled by default**.
-Every log field is checked against sensitive field names (case-insensitive)
-and value patterns (regex). If a match is found,
-the value is replaced before it reaches any output sink.
+Every log field is checked against sensitive field names (case-insensitive) and value patterns (regex). If a match is found, the value is replaced before it reaches any output sink.
 
 ### Default Masked Fields
 
@@ -154,8 +152,7 @@ This turns `"password": "hunter2"` into `"password": "***REDACTED***ter2"`.
 
 ## Sampling
 
-Sampling reduces log volume in high-throughput services. When enabled,
-each log level gets an independent counter per one-second window:
+Sampling reduces log volume in high-throughput services. When enabled, each log level gets an independent counter per one-second window:
 
 1. **Burst** — the first `initial_rate` messages per second per level pass through unconditionally.
 2. **Thereafter** — after the burst, only every `thereafter_rate`-th message is kept.
@@ -183,8 +180,7 @@ Sampling uses zerolog's `BurstSampler` under the hood:
 
 ## Module Levels
 
-Override the global log level for specific components. Useful for silencing noisy dependencies
-or enabling debug output for a single subsystem.
+Override the global log level for specific components. Useful for silencing noisy dependencies or enabling debug output for a single subsystem.
 
 ```yaml
 logging:
@@ -204,14 +200,11 @@ dbLog := log.WithComponent("database")   // → debug level
 kafkaLog := log.WithComponent("kafka")   // → warn level
 ```
 
-Module levels are configured via the `module_levels` map (config or `logging.Config`)
-and applied automatically by `WithComponent`. The underlying `ModuleLevelManager` is thread-safe;
-its `SetLevel()` is used internally when levels are established from configuration.
+Module levels are configured via the `module_levels` map (config or `logging.Config`) and applied automatically by `WithComponent`. The underlying `ModuleLevelManager` is thread-safe; its `SetLevel()` is used internally when levels are established from configuration.
 
 ## OTLP Export
 
-The OpenTelemetry Logs bridge sends log records to an OTLP collector alongside your local output.
-Logs are emitted via the OTel SDK `LoggerProvider` with batch processing.
+The OpenTelemetry Logs bridge sends log records to an OTLP collector alongside your local output. Logs are emitted via the OTel SDK `LoggerProvider` with batch processing.
 
 ### Setup
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,15 +1,10 @@
 # gokit/mcp
 
-`mcp` is a hardened,
-protocol-shaped [Model Context Protocol](https://modelcontextprotocol.io/) server
-and client backed by gokit's `tool.Registry`.
-The official [`modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk) owns the protocol wire (tools, prompts, resources + templates, subscribe, roots, sampling, elicitation, logging, progress, cancellation) over the **stdio**
-and **Streamable HTTP** transports; this package is the typed, fail-closed facade on top of it.
+`mcp` is a hardened, protocol-shaped [Model Context Protocol](https://modelcontextprotocol.io/) server and client backed by gokit's `tool.Registry`. The official [`modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk) owns the protocol wire (tools, prompts, resources + templates, subscribe, roots, sampling, elicitation, logging, progress, cancellation) over the **stdio** and **Streamable HTTP** transports; this package is the typed, fail-closed facade on top of it.
 
 ## Server hardening chain
 
-Every `tools/call` runs a fail-closed chain —
-any step short-circuits to an audited MCP error result:
+Every `tools/call` runs a fail-closed chain — any step short-circuits to an audited MCP error result:
 
 ```
 allow-list → input-size limit → schema validation → authorization
@@ -17,20 +12,14 @@ allow-list → input-size limit → schema validation → authorization
   → output schema validation → audit
 ```
 
-Prompts and resources share the capability allow-list and audit;
-server→client helpers (`Sample`, `Elicit`, `ListRoots`, `Log`, `NotifyProgress`) treat model output
-and elicited content as untrusted (size-limited and audited) and guard against nil sessions.
+Prompts and resources share the capability allow-list and audit; server→client helpers (`Sample`, `Elicit`, `ListRoots`, `Log`, `NotifyProgress`) treat model output and elicited content as untrusted (size-limited and audited) and guard against nil sessions.
 
-Untrusted client/model payloads are carried as `json.RawMessage`;
-documented JSON-Schema is `schema.JSON`.
-No `interface{}`/`any` on exported surfaces beyond those documented opaque types.
+Untrusted client/model payloads are carried as `json.RawMessage`; documented JSON-Schema is `schema.JSON`. No `interface{}`/`any` on exported surfaces beyond those documented opaque types.
 
 ## Transports
 
 - **stdio** — `Server.ServeStdio(ctx)` for local, single-client integrations (IDEs, agents).
-- **Streamable HTTP** —
-  `Server.StreamableHTTPHandler(cfg, token)` wraps the SDK handler with Origin cross-origin protection
-  and optional constant-time bearer-token auth. Localhost (loopback) protection is on by default.
+- **Streamable HTTP** — `Server.StreamableHTTPHandler(cfg, token)` wraps the SDK handler with Origin cross-origin protection and optional constant-time bearer-token auth. Localhost (loopback) protection is on by default.
 
 ## Architecture
 
@@ -64,5 +53,4 @@ flowchart TD
     S2C --> SDK
 ```
 
-See [`CONFORMANCE.md`](CONFORMANCE.md) for the full 2025-06-18 capability matrix.
-Remote MCP servers are tool sources, not skills; skill manifests live in `gokit/skill`.
+See [`CONFORMANCE.md`](CONFORMANCE.md) for the full 2025-06-18 capability matrix. Remote MCP servers are tool sources, not skills; skill manifests live in `gokit/skill`.

--- a/media/README.md
+++ b/media/README.md
@@ -1,15 +1,8 @@
 # media
 
-Light, dependency-free media handling for Go: byte-signature type/format detection,
-container metadata reads, cheap pure-Go image ops, pure-Go time/spatial vocabulary,
-and subtitle (SRT/WebVTT) parsing. Zero external dependencies.
+Light, dependency-free media handling for Go: byte-signature type/format detection, container metadata reads, cheap pure-Go image ops, pure-Go time/spatial vocabulary, and subtitle (SRT/WebVTT) parsing. Zero external dependencies.
 
-`media` is a standalone module (`github.com/kbukum/gokit/media`).
-It is the **light** mirror of rskit's media capability: Go handles metadata, format
-and container inspection, cheap image ops, time/spatial math, and subtitle parsing;
-**heavy audio/video/matrix/DSP processing stays rskit-only by design**.
-This is a capability decision, not a parity gap —
-see [Capability split](#capability-split-light-by-design).
+`media` is a standalone module (`github.com/kbukum/gokit/media`). It is the **light** mirror of rskit's media capability: Go handles metadata, format and container inspection, cheap image ops, time/spatial math, and subtitle parsing; **heavy audio/video/matrix/DSP processing stays rskit-only by design**. This is a capability decision, not a parity gap — see [Capability split](#capability-split-light-by-design).
 
 ## Install
 
@@ -54,8 +47,7 @@ info, err := media.DetectFile("/path/to/file.png")
 
 ## Registry & probing
 
-A `Registry` ties the format catalog together with injected `Prober` backends.
-It is constructed explicitly with functional options — no package globals, no `init()` side effects.
+A `Registry` ties the format catalog together with injected `Prober` backends. It is constructed explicitly with functional options — no package globals, no `init()` side effects.
 
 ```go
 reg := media.NewRegistry(media.WithImageProber())
@@ -89,9 +81,7 @@ thumb := media.Thumbnail(img, 256, 256)       // nearest-neighbor, never upscale
 view := media.Crop(img, image.Rect(0, 0, 100, 100))
 ```
 
-Formats outside the stdlib decoders (WebP, TIFF, HEIF, AVIF) are **detected** but not decoded here;
-decoding/processing those is rskit's or an external service's job. `Decode` reads the header first
-and rejects inputs above `MaxDecodePixels` to bound memory on untrusted content (decompression bombs).
+Formats outside the stdlib decoders (WebP, TIFF, HEIF, AVIF) are **detected** but not decoded here; decoding/processing those is rskit's or an external service's job. `Decode` reads the header first and rejects inputs above `MaxDecodePixels` to bound memory on untrusted content (decompression bombs).
 
 ## Time & spatial types (pure Go)
 
@@ -111,8 +101,7 @@ fps := media.NTSC30().Float() // 29.97
 
 ## Subtitles (SRT / WebVTT)
 
-Pure-Go parsing, serialization, time-shifting, and range filtering. HTML tags are stripped
-and (for VTT) entities decoded; malformed timestamps fail closed with `ErrInvalidSubtitle`.
+Pure-Go parsing, serialization, time-shifting, and range filtering. HTML tags are stripped and (for VTT) entities decoded; malformed timestamps fail closed with `ErrInvalidSubtitle`.
 
 ```go
 track, err := media.ParseSRT(srtText)
@@ -135,10 +124,7 @@ vtt := clip.VTT()                         // convert SRT → WebVTT
 | Matrix/DSP, scene detection, waveforms | ➖ (by design) | ✅ |
 | Codec/color/pipeline/output executor vocabulary | ➖ (backend-only) | ✅ |
 
-The heavy path is **rskit or an external service**, never a Go reimplementation.
-gokit deliberately has **no cgo, no ffmpeg, and no Go DSP/matrix code**.
-Backend-only vocabulary (codec, color, filter graphs, pipeline/output configs) is intentionally omitted:
-without a transcoding executor it would be dead surface.
+The heavy path is **rskit or an external service**, never a Go reimplementation. gokit deliberately has **no cgo, no ffmpeg, and no Go DSP/matrix code**. Backend-only vocabulary (codec, color, filter graphs, pipeline/output configs) is intentionally omitted: without a transcoding executor it would be dead surface.
 
 ## Supported formats (detection)
 

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -5,14 +5,9 @@ in-memory broker for testing, and composable middleware.
 
 ## Overview
 
-The `messaging` module provides a unified interface for publishing
-and consuming messages across different transports. It defines core types (`Message`, `Event`),
-producer/consumer interfaces, and higher-level patterns like routing, batching,
-and managed consumers — all independent of any specific broker.
+The `messaging` module provides a unified interface for publishing and consuming messages across different transports. It defines core types (`Message`, `Event`), producer/consumer interfaces, and higher-level patterns like routing, batching, and managed consumers — all independent of any specific broker.
 
-Concrete implementations (Kafka, NATS, RabbitMQ, in-memory) plug into these interfaces,
-so application code stays transport-agnostic.
-A middleware system allows cross-cutting concerns (retry, dead-letter, tracing, deduplication, metrics) to be composed around any handler.
+Concrete implementations (Kafka, NATS, RabbitMQ, in-memory) plug into these interfaces, so application code stays transport-agnostic. A middleware system allows cross-cutting concerns (retry, dead-letter, tracing, deduplication, metrics) to be composed around any handler.
 
 ## Installation
 
@@ -87,30 +82,13 @@ func main() {
 
 ## Sub-Packages
 
-Broker SDKs live in opt-in nested modules (`messaging/kafka`, `messaging/nats`, and `messaging/rabbitmq`)
-so importing core `messaging` only pulls abstractions, registry, middleware,
-and the in-memory default into the module graph.
-Adapter packages register factories only through explicit config-free `Register(registry)` calls;
-runtime config is passed when creating producer/consumer instances.
-They do not use `init` registration side effects.
+Broker SDKs live in opt-in nested modules (`messaging/kafka`, `messaging/nats`, and `messaging/rabbitmq`) so importing core `messaging` only pulls abstractions, registry, middleware, and the in-memory default into the module graph. Adapter packages register factories only through explicit config-free `Register(registry)` calls; runtime config is passed when creating producer/consumer instances. They do not use `init` registration side effects.
 
-Core `messaging.Config` owns only broker-neutral policy: instance `Name`, `Enabled`, `Adapter`,
-delivery guarantee, commit strategy, DLQ policy, max in-flight, consumer group,
-allowed topics/subscriptions, request timeout, and retry attempts/ backoff.
-Adapter configs contain only provider-specific connection/protocol knobs:
-Kafka keeps brokers/resolve, TLS/SASL, compression, required acks, batch settings,
-session/heartbeat/rebalance tuning, and dial/idle/metadata TTLs; NATS keeps URL, auth, TLS,
-reconnect, drain, queue-group, and subject-prefix settings; RabbitMQ keeps URL, username/password,
-TLS, exchange/queue/routing, heartbeat, prefetch, and AMQP timeouts. Factories explicitly map
-or reject common semantics before dialing; no adapter uses `init` registration side effects
-or package-level mutable registries. Kafka, NATS,
-and RabbitMQ SDKs stay isolated to their subpackages; importing core `messaging`
-or `messaging/memory` does not pull optional broker SDKs.
+Core `messaging.Config` owns only broker-neutral policy: instance `Name`, `Enabled`, `Adapter`, delivery guarantee, commit strategy, DLQ policy, max in-flight, consumer group, allowed topics/subscriptions, request timeout, and retry attempts/ backoff. Adapter configs contain only provider-specific connection/protocol knobs: Kafka keeps brokers/resolve, TLS/SASL, compression, required acks, batch settings, session/heartbeat/rebalance tuning, and dial/idle/metadata TTLs; NATS keeps URL, auth, TLS, reconnect, drain, queue-group, and subject-prefix settings; RabbitMQ keeps URL, username/password, TLS, exchange/queue/routing, heartbeat, prefetch, and AMQP timeouts. Factories explicitly map or reject common semantics before dialing; no adapter uses `init` registration side effects or package-level mutable registries. Kafka, NATS, and RabbitMQ SDKs stay isolated to their subpackages; importing core `messaging` or `messaging/memory` does not pull optional broker SDKs.
 
 ### `kafka/` — Kafka Implementation
 
-Production-ready Kafka producer and consumer using `segmentio/kafka-go`. Supports TLS,
-SASL authentication, consumer groups, compression, and configurable batching.
+Production-ready Kafka producer and consumer using `segmentio/kafka-go`. Supports TLS, SASL authentication, consumer groups, compression, and configurable batching.
 
 ```go
 import (
@@ -142,8 +120,7 @@ _ = producer.Publish(ctx, "events", event)
 
 ### `nats/` — NATS Implementation
 
-Opt-in NATS adapter using `github.com/nats-io/nats.go`, with typed connection, auth, timeout,
-reconnect, and subject settings.
+Opt-in NATS adapter using `github.com/nats-io/nats.go`, with typed connection, auth, timeout, reconnect, and subject settings.
 
 ```go
 import natsadapter "github.com/kbukum/gokit/messaging/nats"
@@ -165,8 +142,7 @@ producer, _ := reg.NewProducer(ctx,
 
 ### `rabbitmq/` — RabbitMQ Implementation
 
-Opt-in RabbitMQ adapter using `github.com/rabbitmq/amqp091-go`, with typed connection, exchange,
-queue, acknowledgement, prefetch, timeout, and TLS settings.
+Opt-in RabbitMQ adapter using `github.com/rabbitmq/amqp091-go`, with typed connection, exchange, queue, acknowledgement, prefetch, timeout, and TLS settings.
 
 ```go
 import (
@@ -244,26 +220,14 @@ Broker-agnostic mocks for unit testing:
 
 ## Security and DLQ defaults
 
-Broker adapters are secure by default. Kafka requires TLS unless `AllowInsecureDev` is set;
-NATS requires `tls://` or `wss://`; RabbitMQ requires `amqps://`.
-Credentials are provided through typed config fields, not broker URLs or hardcoded examples. Topic,
-subject, queue, and consumer-group names are validated before construction or use.
+Broker adapters are secure by default. Kafka requires TLS unless `AllowInsecureDev` is set; NATS requires `tls://` or `wss://`; RabbitMQ requires `amqps://`. Credentials are provided through typed config fields, not broker URLs or hardcoded examples. Topic, subject, queue, and consumer-group names are validated before construction or use.
 
-DLQ routing is disabled until explicitly configured. The shared config carries DLQ intent,
-but adapters that cannot provide broker-managed DLQ reject enabled adapter DLQ settings
-and expect callers to wire the broker-agnostic `DeadLetterProducer` middleware instead.
-
-## Validation
-
-Focused docs checks verify that NATS/RabbitMQ are documented as real opt-in adapters,
-examples avoid hardcoded credentials, and core docs do not imply optional SDK imports.
-Final workspace validation counts should come from CI or the dedicated validation pass.
+DLQ routing is disabled until explicitly configured. The shared config carries DLQ intent, but adapters that cannot provide broker-managed DLQ reject enabled adapter DLQ settings and expect callers to wire the broker-agnostic `DeadLetterProducer` middleware instead.
 
 ## Testing
 
 ```bash
-cd messaging
-go test -race ./...
+make test M=messaging
 ```
 
 ## Contributing

--- a/observability/README.md
+++ b/observability/README.md
@@ -22,11 +22,13 @@ func main() {
     ctx := context.Background()
 
     // Initialize tracer
-    tp, _ := observability.InitTracer(ctx, observability.DefaultTracerConfig("my-service"))
+    tracerCfg := observability.DefaultTracerConfig("my-service")
+    tp, _ := observability.InitTracer(ctx, &tracerCfg)
     defer tp.Shutdown(ctx)
 
     // Initialize metrics
-    mp, _ := observability.InitMeter(ctx, observability.DefaultMeterConfig("my-service"))
+    meterCfg := observability.DefaultMeterConfig("my-service")
+    mp, _ := observability.InitMeter(ctx, &meterCfg)
     defer mp.Shutdown(ctx)
 
     // Start a span
@@ -36,7 +38,7 @@ func main() {
 
     // Health checks
     health := observability.NewServiceHealth("my-service", "1.0.0")
-    health.AddComponent(observability.ComponentHealth{
+    health.AddComponent(observability.Health{
         Name:   "database",
         Status: "healthy",
     })

--- a/process/README.md
+++ b/process/README.md
@@ -4,13 +4,9 @@ Subprocess execution with context cancellation, signal handling, and provider in
 
 ## Overview
 
-The `process` package provides a structured way to run external commands from Go services.
-It wraps `os/exec` with context-aware cancellation, process group management,
-graceful shutdown (SIGTERM → SIGKILL), and automatic output capture. Results include stdout, stderr,
-exit code, and duration.
+The `process` package provides a structured way to run external commands from Go services. It wraps `os/exec` with context-aware cancellation, process group management, graceful shutdown (SIGTERM → SIGKILL), and automatic output capture. Results include stdout, stderr, exit code, and duration.
 
-For long-running or unreliable subprocesses, the package integrates with gokit's provider
-and resilience frameworks — adding retry, circuit breaker, and generic I/O adapters.
+For long-running or unreliable subprocesses, the package integrates with gokit's provider and resilience frameworks — adding retry, circuit breaker, and generic I/O adapters.
 
 ## Installation
 
@@ -74,8 +70,7 @@ Executes the command, captures output, and returns a `*Result` (always populated
 
 ### Context Cancellation
 
-When the context is cancelled, `Run` sends SIGTERM to the entire process group.
-If the process doesn't exit within `GracePeriod` (default 5s), it escalates to SIGKILL.
+When the context is cancelled, `Run` sends SIGTERM to the entire process group. If the process doesn't exit within `GracePeriod` (default 5s), it escalates to SIGKILL.
 
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -103,13 +98,12 @@ Extra environment variables are merged with the parent process environment.
 
 ### Resilient Execution
 
-Use `Runner` for subprocesses that may fail transiently.
-Circuit breaker state persists across calls.
+Use `Runner` for subprocesses that may fail transiently. Circuit breaker state persists across calls.
 
 ```go
 runner := process.NewRunner(provider.ResilienceConfig{
 	CircuitBreaker: &resilience.CircuitBreakerConfig{
-		Threshold: 3, ResetTimeout: 30 * time.Second,
+		MaxFailures: 3, Timeout: 30 * time.Second,
 	},
 })
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -81,9 +81,7 @@ cost, _ := meta.Float("cost")
 latency, _ := meta.Duration("latency_ms")
 ```
 
-Meta is consumed by `dag.OrderByCost()`, `dag.OrderByLatency()`,
-and `dag.WeightedScore()` for intelligent node scheduling. Also available for Sink
-and Stream providers via `WithSinkMeta` and `WithStreamMeta`.
+Meta is consumed by `dag.OrderByCost()`, `dag.OrderByLatency()`, and `dag.WeightedScore()` for intelligent node scheduling. Also available for Sink and Stream providers via `WithSinkMeta` and `WithStreamMeta`.
 
 ## Stream Composition
 

--- a/resilience/README.md
+++ b/resilience/README.md
@@ -1,7 +1,6 @@
 # resilience
 
-Resilience patterns: circuit breaker, retry with backoff, rate limiter,
-and bulkhead for concurrency control.
+Resilience patterns: circuit breaker, retry with backoff, rate limiter, and bulkhead for concurrency control.
 
 ## Install
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,9 +1,6 @@
 # schema
 
-JSON Schema generation from Go types.
-Wraps [`invopop/jsonschema`](https://github.com/invopop/jsonschema) to produce standard JSON Schema 2020-12 documents from struct tags,
-exposed as a plain `map[string]any` suitable for tool definitions, MCP, and LLM APIs.
-Values are validated against schemas with bounded depth, node-count, and string-byte limits.
+JSON Schema generation from Go types. Wraps [`invopop/jsonschema`](https://github.com/invopop/jsonschema) to produce standard JSON Schema 2020-12 documents from struct tags, exposed as a plain `map[string]any` suitable for tool definitions, MCP, and LLM APIs. Values are validated against schemas with bounded depth, node-count, and string-byte limits.
 
 ## Install
 

--- a/security/README.md
+++ b/security/README.md
@@ -1,7 +1,6 @@
 # gokit/security
 
-TLS configuration, secure header policies,
-and test helpers for secure transport across gokit modules.
+TLS configuration, secure header policies, and test helpers for secure transport across gokit modules.
 
 ## Overview
 
@@ -18,11 +17,9 @@ The locked transport policy is explicit:
 - minimum supported floor: TLS 1.2
 - default negotiation outcome: TLS 1.3 whenever both peers support it
 - explicit floors below TLS 1.2 are rejected during validation
-- secure headers default-on: HSTS, CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy,
-  Permissions-Policy
+- secure headers default-on: HSTS, CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy
 
-The companion `tlstest` sub-package generates self-signed certificates for integration tests —
-no external tools or fixtures required.
+The companion `tlstest` sub-package generates self-signed certificates for integration tests — no external tools or fixtures required.
 
 ## Installation
 
@@ -163,8 +160,7 @@ func TestMTLS(t *testing.T) {
 }
 ```
 
-`GenerateTLSCerts` creates an ECDSA P-256 CA and server certificate valid for `localhost`,
-`127.0.0.1`, and `::1`. Files are written to `t.TempDir()` and cleaned up automatically.
+`GenerateTLSCerts` creates an ECDSA P-256 CA and server certificate valid for `localhost`, `127.0.0.1`, and `::1`. Files are written to `t.TempDir()` and cleaned up automatically.
 
 Use `WriteInvalidPEM(t, "bad.pem")` to generate invalid certificate files for error-path testing.
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,7 +1,6 @@
 # server
 
-Gin-based HTTP server with h2c support, built-in middleware, health/info endpoints,
-and component lifecycle.
+Gin-based HTTP server with h2c support, built-in middleware, health/info endpoints, and component lifecycle.
 
 ## Install
 
@@ -37,7 +36,7 @@ defer comp.Stop(ctx)
 | `Server` | Wraps Gin engine + `http.ServeMux` with h2c |
 | `Config` | Host, Port, timeouts, max body size, CORS, Docs |
 | `DocsConfig` | Controls API documentation serving (`docs.enabled`) |
-| `ServerComponent` | Managed lifecycle — `Start`, `Stop`, `Health` |
+| `Component` | Managed lifecycle — `Start`, `Stop`, `Health` |
 | `New(cfg, log)` | Create a server instance |
 | `(*Server) GinEngine()` | Access the underlying `*gin.Engine` |
 | `RespondOK(c, data)` | JSON 200 response |
@@ -122,9 +121,7 @@ Apply recovery outside that chain so panics from any layer are captured consiste
 
 ### TLS policy
 
-`server` itself is transport-focused and commonly runs behind TLS termination
-or alongside a gRPC listener. For TLS settings shared across gokit transports,
-use `security.TLSConfig` with the locked policy:
+`server` itself is transport-focused and commonly runs behind TLS termination or alongside a gRPC listener. For TLS settings shared across gokit transports, use `security.TLSConfig` with the locked policy:
 
 - minimum supported floor: TLS 1.2
 - default negotiation outcome: TLS 1.3 whenever peers support it

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -5,5 +5,4 @@
 
 # Skill title
 
-Describe when to use this skill, its workflow, and references.
-This file is progressive-disclosure content loaded only when the skill is activated.
+Describe when to use this skill, its workflow, and references. This file is progressive-disclosure content loaded only when the skill is activated.

--- a/storage/README.md
+++ b/storage/README.md
@@ -2,9 +2,7 @@
 
 Object storage abstraction for gokit.
 
-Core contains provider-neutral contracts, explicit `FactoryRegistry`, component integration,
-content-addressable wrappers, and lean local storage.
-Backend SDK dependencies are isolated in opt-in adapter modules such as `storage/s3`.
+Core contains provider-neutral contracts, explicit `FactoryRegistry`, component integration, content-addressable wrappers, and lean local storage. Backend SDK dependencies are isolated in opt-in adapter modules such as `storage/s3`.
 
 ## Local default
 
@@ -12,14 +10,14 @@ Backend SDK dependencies are isolated in opt-in adapter modules such as `storage
 import local "github.com/kbukum/gokit/storage/local"
 
 reg := storage.NewFactoryRegistry()
-if err := local.Register(reg); err != nil {
+if err := local.Register(reg, local.Config{BasePath: "./data"}); err != nil {
     return err
 }
 
 store, err := storage.New(reg, storage.Config{
     Provider: storage.ProviderLocal,
     Enabled:  true,
-}, &local.Config{BasePath: "./data"}, log)
+}, log)
 ```
 
 ## S3 adapter
@@ -41,9 +39,7 @@ if err := storages3.Register(reg); err != nil {
 
 ## Supabase adapter
 
-The Supabase adapter lives in the `storage/supabase` package. It is HTTP-only,
-so it stays within the storage module (no separate `go.mod`),
-but it is still opt-in with no import-time side effects — register it explicitly:
+The Supabase adapter lives in the `storage/supabase` package. It is HTTP-only, so it stays within the storage module (no separate `go.mod`), but it is still opt-in with no import-time side effects — register it explicitly:
 
 ```go
 import (
@@ -57,5 +53,4 @@ if err := supabase.Register(reg); err != nil {
 }
 ```
 
-If a future SDK-backed adapter is introduced,
-it must move to a nested adapter module before adding that dependency.
+If a future SDK-backed adapter is introduced, it must move to a nested adapter module before adding that dependency.

--- a/stream/README.md
+++ b/stream/README.md
@@ -2,15 +2,9 @@
 
 **Pull-based data pipeline with composable operators, plus a bounded push fan-out source**
 
-`stream` provides lazy, backpressure-aware data processing for Go. Pipelines pull values on demand —
-no work happens until you call `Collect`, `Drain`, or `ForEach`.
-This design naturally handles flow control without buffering or blocking.
-For the genuinely push-shaped "one source, many observers" case,
-`Broadcaster` fans events out to independent subscribers with bounded, drop-on-overflow buffers.
+`stream` provides lazy, backpressure-aware data processing for Go. Pipelines pull values on demand — no work happens until you call `Collect`, `Drain`, or `ForEach`. This design naturally handles flow control without buffering or blocking. For the genuinely push-shaped "one source, many observers" case, `Broadcaster` fans events out to independent subscribers with bounded, drop-on-overflow buffers.
 
-gokit converges on the [`rskit-stream`](https://github.com/kbukum/rskit/tree/main/core/rskit-stream) operator vocabulary (`map`/`filter`/`fan_out`/`window`/`batch`/`parallel`/`merge`/`partition`/…)
-and its `Broadcaster`, expressed idiomatically in Go: a pull iterator for transformation pipelines
-and a bounded channel bus for fan-out. No operator buffers without bound.
+gokit converges on the [`rskit-stream`](https://github.com/kbukum/rskit/tree/main/core/rskit-stream) operator vocabulary (`map`/`filter`/`fan_out`/`window`/`batch`/`parallel`/`merge`/`partition`/…) and its `Broadcaster`, expressed idiomatically in Go: a pull iterator for transformation pipelines and a bounded channel bus for fan-out. No operator buffers without bound.
 
 ## Features
 
@@ -112,10 +106,7 @@ func main() {
 
 ### Push Fan-Out (Broadcaster)
 
-For the "watch one source → fan a typed change stream out to many independent observers" shape (config reloads, service discovery, cache invalidation, secret rotation),
-use `Broadcaster[T]`. Each subscriber owns a private bounded channel:
-a subscriber lagging beyond its buffer drops the overflow (backpressure by drop)
-but never blocks the broadcaster or its peers.
+For the "watch one source → fan a typed change stream out to many independent observers" shape (config reloads, service discovery, cache invalidation, secret rotation), use `Broadcaster[T]`. Each subscriber owns a private bounded channel: a subscriber lagging beyond its buffer drops the overflow (backpressure by drop) but never blocks the broadcaster or its peers.
 
 | Operator | Description |
 |----------|-------------|
@@ -373,10 +364,8 @@ func TestPipeline(t *testing.T) {
 
 - **Lazy evaluation** means no work until terminal operator runs
 - **Synchronous operators** (Map, Filter) add negligible overhead
-- **Concurrent operators** (Parallel, Buffer, Merge) spawn goroutines — use when I/O
-  or CPU-heavy work benefits from parallelism
-- **Throttle/Batch/Debounce** use timers — appropriate for real-time/streaming scenarios,
-  not batch processing
+- **Concurrent operators** (Parallel, Buffer, Merge) spawn goroutines — use when I/O or CPU-heavy work benefits from parallelism
+- **Throttle/Batch/Debounce** use timers — appropriate for real-time/streaming scenarios, not batch processing
 - **Context cancellation** stops the pipeline immediately at the next operator
 
 ## Related Packages

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -280,6 +280,8 @@ package mymodule
 
 import (
     "context"
+    "fmt"
+
     "github.com/kbukum/gokit/component"
     "github.com/kbukum/gokit/testutil"
 )
@@ -328,7 +330,10 @@ func (c *TestMyComponent) Snapshot(ctx context.Context) (any, error) {
 
 func (c *TestMyComponent) Restore(ctx context.Context, snapshot any) error {
     // Restore from snapshot
-    state := snapshot.(map[string]any)
+    state, ok := snapshot.(map[string]any)
+    if !ok {
+        return fmt.Errorf("unexpected snapshot type %T", snapshot)
+    }
     c.data = state["data"]
     return nil
 }

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -1,8 +1,6 @@
 # TestUtil - Testing Infrastructure for gokit
 
-The `testutil` package provides a comprehensive testing infrastructure for gokit components,
-following the same lifecycle patterns as production components. It enables easy setup, teardown,
-and management of test components with support for state snapshots and resets.
+The `testutil` package provides a comprehensive testing infrastructure for gokit components, following the same lifecycle patterns as production components. It enables easy setup, teardown, and management of test components with support for state snapshots and resets.
 
 ## Features
 
@@ -113,8 +111,8 @@ type TestComponent interface {
     
     // Testing-specific methods
     Reset(ctx context.Context) error
-    Snapshot(ctx context.Context) (interface{}, error)
-    Restore(ctx context.Context, snapshot interface{}) error
+    Snapshot(ctx context.Context) (any, error)
+    Restore(ctx context.Context, snapshot any) error
 }
 ```
 
@@ -321,16 +319,16 @@ func (c *TestMyComponent) Reset(ctx context.Context) error {
     return nil
 }
 
-func (c *TestMyComponent) Snapshot(ctx context.Context) (interface{}, error) {
+func (c *TestMyComponent) Snapshot(ctx context.Context) (any, error) {
     // Capture current state
-    return map[string]interface{}{
+    return map[string]any{
         "data": c.data,
     }, nil
 }
 
-func (c *TestMyComponent) Restore(ctx context.Context, snapshot interface{}) error {
+func (c *TestMyComponent) Restore(ctx context.Context, snapshot any) error {
     // Restore from snapshot
-    state := snapshot.(map[string]interface{})
+    state := snapshot.(map[string]any)
     c.data = state["data"]
     return nil
 }
@@ -368,14 +366,11 @@ See the test files for comprehensive examples:
 
 ## Thread Safety
 
-All TestManager operations are thread-safe and can be called concurrently.
-Individual TestComponent implementations should also ensure thread-safety if they will be used in concurrent tests.
+All TestManager operations are thread-safe and can be called concurrently. Individual TestComponent implementations should also ensure thread-safety if they will be used in concurrent tests.
 
 ## Next Steps
 
 - See module-specific testutil packages for database, Redis, Kafka, etc.
-- Review the [Testing Guide](../docs/testing-guide.md) for best practices (when available)
-- Check the [TestUtil Cookbook](../docs/testutil-cookbook.md) for common patterns (when available)
 
 ## Contributing
 

--- a/tool/README.md
+++ b/tool/README.md
@@ -1,7 +1,6 @@
 # gokit/tool
 
-`tool` owns typed callable definitions, JSON Schema input/output, structured results, registries,
-batch dispatch, and the executable permission envelope.
+`tool` owns typed callable definitions, JSON Schema input/output, structured results, registries, batch dispatch, and the executable permission envelope.
 
 ## Architecture
 

--- a/vectorstore/README.md
+++ b/vectorstore/README.md
@@ -39,7 +39,7 @@ func main() {
 	ctx := context.Background()
 	
 	// Ensure collection exists
-	err := store.EnsureCollection(ctx, "documents", 384)
+	err = store.EnsureCollection(ctx, "documents", 384)
 	if err != nil {
 		panic(err)
 	}
@@ -161,8 +161,7 @@ All conditions are AND-ed together. Only exact matches are supported.
 
 ## Thread Safety
 
-`InMemoryStore` is thread-safe via `sync.RWMutex`.
-Multiple goroutines can safely call methods concurrently.
+`InMemoryStore` is thread-safe via `sync.RWMutex`. Multiple goroutines can safely call methods concurrently.
 
 ## Performance Notes
 
@@ -181,16 +180,14 @@ For production use cases, consider:
 
 ## Testing
 
-Run tests with:
-
 ```bash
-go test ./... -race -count=1
+make test M=vectorstore
 ```
 
 Run linting with:
 
 ```bash
-go vet ./...
+make lint M=vectorstore
 ```
 
 ## Examples

--- a/version/README.md
+++ b/version/README.md
@@ -1,8 +1,6 @@
 # version
 
-Build-time version information with Git metadata,
-derived from embedded build info (debug.ReadBuildInfo),
-optionally overridden at link time via an unexported seam.
+Build-time version information with Git metadata, derived from embedded build info (debug.ReadBuildInfo), optionally overridden at link time via an unexported seam.
 
 ## Install
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,24 +2,17 @@
 
 **Push-based task execution with real-time event streaming, worker pools, and supervision**
 
-`worker` provides a generic `Handler[I, O]` abstraction for executing tasks that emit events during execution
-— progress updates, partial results, logs — with built-in pooling, dispatch strategies, supervision,
-middleware, and composition patterns.
-Designed for use cases where callers need real-time visibility into task execution:
-file downloaders, CLI subprocess orchestration, parallel data processing,
-and long-running background jobs.
+`worker` provides a generic `Handler[I, O]` abstraction for executing tasks that emit events during execution — progress updates, partial results, logs — with built-in pooling, dispatch strategies, supervision, middleware, and composition patterns. Designed for use cases where callers need real-time visibility into task execution: file downloaders, CLI subprocess orchestration, parallel data processing, and long-running background jobs.
 
 ## Features
 
 - **Handler[I, O]** — single generic interface for all task execution
 - **Push-based events** — handlers call `emit()` for progress, partial results,
   and logs during execution
-- **Worker pool** — fixed-size goroutine pool with per-task handles, cancellation,
-  and graceful shutdown
+- **Worker pool** — fixed-size goroutine pool with per-task handles, cancellation, and graceful shutdown
 - **Dispatch strategies** — round-robin and least-loaded worker selection
 - **Supervision** — panic tracking, health monitoring, backoff, and configurable restart policies
-- **Middleware** —
-  composable cross-cutting concerns (timeout, recovery) using the same `Chain` pattern as `provider`
+- **Middleware** — composable cross-cutting concerns (timeout, recovery) using the same `Chain` pattern as `provider`
 - **Composition** — FanOut, MapReduce, and Pipeline for combining handlers
 - **Provider bridges** — `FromProvider` / `AsProvider` for interop with `provider.RequestResponse`
 - **Subprocess handler** — wraps `process.Command` with line-by-line stdout/stderr streaming
@@ -169,10 +162,7 @@ pool := worker.NewPool(handler, worker.PoolConfig{
 })
 ```
 
-When a task panics, the worker goroutine survives (panics are caught per-task).
-The supervisor tracks per-worker panic counts
-and marks workers unhealthy after exceeding `MaxRestarts`.
-Unhealthy workers are skipped by the dispatcher.
+When a task panics, the worker goroutine survives (panics are caught per-task). The supervisor tracks per-worker panic counts and marks workers unhealthy after exceeding `MaxRestarts`. Unhealthy workers are skipped by the dispatcher.
 
 ### Example 4: MapReduce — Parallel Processing with Combine
 
@@ -356,11 +346,9 @@ func TestMyWorker(t *testing.T) {
 
 - **Lock-free hot path** — `stopped` is `atomic.Bool`, worker stats use `atomic.Int32`.
   No mutex on Submit, dispatch, or runWorker
-- **Non-blocking event forwarding** —
-  pool-level events use `select/default` to avoid blocking workers; per-task events are buffered
+- **Non-blocking event forwarding** — pool-level events use `select/default` to avoid blocking workers; per-task events are buffered
 - **Timer management** — backoff uses `time.NewTimer` + `Stop()` (no `time.After` leaks)
-- **Context.AfterFunc** —
-  ties task context to pool context for zero-overhead cancellation propagation (Go 1.21+)
+- **Context.AfterFunc** — ties task context to pool context for zero-overhead cancellation propagation (Go 1.21+)
 - **Atomic stats** — `PoolStats` reads use no locks, only atomic loads
 
 ## Related Packages

--- a/workload/README.md
+++ b/workload/README.md
@@ -46,7 +46,9 @@ result, _ := mgr.Deploy(ctx, workload.DeployRequest{
 ### As a Component
 
 ```go
-comp := workload.NewComponent(workload.Config{Provider: "docker"}, dockerCfg, log)
+reg := workload.NewFactoryRegistry()
+_ = docker.Register(reg)
+comp := workload.NewComponent(reg, workload.Config{Provider: "docker"}, dockerCfg, log)
 comp.Start(ctx)
 defer comp.Stop(ctx)
 
@@ -64,7 +66,7 @@ mgr := comp.Manager()
 | `StatsProvider` | Optional — `Stats(ctx, id)` for CPU/memory/network metrics |
 | `LogStreamer` | Optional — `StreamLogs(ctx, id, opts)` for real-time log streaming |
 | `EventWatcher` | Optional — `WatchEvents(ctx, filter)` for lifecycle events |
-| `NewComponent(cfg, providerCfg, log)` | Create lifecycle-managed component |
+| `NewComponent(registry, cfg, providerCfg, log)` | Create lifecycle-managed component |
 | `DeployRequest` | Name, Image, Command, Environment, Resources, Ports, Volumes |
 | `WorkloadStatus` | ID, Status, Running, Healthy, ExitCode, Restarts |
 | `ParseMemory(s)` | Parse memory strings ("512m", "1g") to bytes |

--- a/workload/README.md
+++ b/workload/README.md
@@ -46,11 +46,17 @@ result, _ := mgr.Deploy(ctx, workload.DeployRequest{
 ### As a Component
 
 ```go
+import "github.com/kbukum/gokit/workload/docker"
+
 reg := workload.NewFactoryRegistry()
-_ = docker.Register(reg)
+if err := docker.Register(reg); err != nil {
+    return err
+}
 comp := workload.NewComponent(reg, workload.Config{Provider: "docker"}, dockerCfg, log)
-comp.Start(ctx)
-defer comp.Stop(ctx)
+if err := comp.Start(ctx); err != nil {
+    return err
+}
+defer func() { _ = comp.Stop(ctx) }()
 
 mgr := comp.Manager()
 ```


### PR DESCRIPTION
## Description

Refreshes the repository's Markdown documentation across the root README, per-module READMEs, `docs/`, and the `.github/skills/` guides. The main change is repairing AI-style hard-wrapped prose into natural one-line paragraphs, so renderers own viewport wrapping and the source reads as continuous prose. Alongside the reflow, a few stale details are brought in line with the toolkit as it is today.

## Motivation

Much of the documentation carried hard semantic line breaks that fight Markdown's own wrapping and drift out of the repo's documentation convention (paragraphs flow as natural source lines; only intentional structure — headings, lists, tables, code fences — is preserved). A handful of docs had also fallen behind the code (quickstart example, domain list). This restores consistency and accuracy without touching runtime code.

## Type of Change

- [x] Documentation update

## Module(s) Affected

- Documentation only — root `README.md`, `docs/`, `.github/skills/**`, and per-module `README.md`/`doc` files across the workspace
- `Makefile` (adds the `check-devtools` domain target referenced by the docs)

## Changes Made

- Reflowed hard-wrapped prose to natural paragraphs across READMEs, `docs/`, and skill guides, preserving intentional structure (lists, tables, code blocks, blockquotes)
- Synced the root README quickstart to the current generic `bootstrap.App[*Config]` / `config.ServiceConfig` shape
- Added the `devtools` domain to the README domain table and a matching `check-devtools` target in the `Makefile`
- Corrected stale links, module structure notes, and examples to match the code as it stands

## Testing

Documentation-only change; no build/test gates apply. Rendered Markdown was reviewed for preserved structure.

- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
- [ ] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [x] Manual testing performed (reviewed rendered Markdown; structure preserved)

## Breaking Changes

None. Documentation and a new Makefile helper target only.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Checklist

- [x] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] Documentation reads naturally with no hard column wrapping; intentional structure preserved

## Additional Notes

No runtime code changed; the only non-Markdown edit is the `Makefile` `check-devtools` target that the refreshed README documents.
