### PR TITLE
refactor(encryption): use stdlib PBKDF2

### DIFF
--- a/chain/README.md
+++ b/chain/README.md
@@ -32,7 +32,10 @@ func main() {
         return n * 2, nil
     })
 
-    c := chain.Then(chain.Then(chain.New[string](), parse), double).Build()
+    start := chain.New[string]()
+    parsed := chain.Then(start, parse)
+    doubled := chain.Then(parsed, double)
+    c := doubled.Build()
 
     out, err := c.Execute(context.Background(), "21", nil)
     if err != nil {
@@ -42,7 +45,7 @@ func main() {
 }
 ```
 
-Because Go methods cannot introduce new type parameters, steps are appended with the package-level `Then` function rather than a fluent method, so each `Then` can transform the output type.
+Because Go methods cannot introduce new type parameters, steps are appended with the package-level `Then` function rather than a fluent method, so each `Then` can transform the output type. For chains longer than a couple of steps, prefer naming the intermediate builders as above; the composition reads in execution order and matches the package-level operator style used by `stream`.
 
 ## Key Types & Functions
 

--- a/chain/doc.go
+++ b/chain/doc.go
@@ -6,20 +6,19 @@
 // and runs the cleanup actions registered by already-completed steps (in reverse order) when a later step fails
 // or the chain is canceled.
 //
-// Because Go methods cannot introduce new type parameters,
-// steps are appended with the package-level Then function rather than a fluent method:
+// Because Go methods cannot introduce new type parameters, steps are appended with the package-level Then function rather than a fluent method. For chains longer than a couple of steps, bind each intermediate builder so the code reads in execution order and mirrors the package-level composition style used by stream:
 //
-//	c := chain.Then(
-//		chain.Then(
-//			chain.New[string](),
-//			chain.StepFunc("parse", func(_ chain.StepContext, in string) (int, error) {
-//				return strconv.Atoi(in)
-//			}),
-//		),
-//		chain.StepFunc("double", func(_ chain.StepContext, n int) (int, error) {
-//			return n * 2, nil
-//		}),
-//	).Build()
+//	parse := chain.StepFunc("parse", func(_ chain.StepContext, in string) (int, error) {
+//		return strconv.Atoi(in)
+//	})
+//	double := chain.StepFunc("double", func(_ chain.StepContext, n int) (int, error) {
+//		return n * 2, nil
+//	})
+//
+//	start := chain.New[string]()
+//	parsed := chain.Then(start, parse)
+//	doubled := chain.Then(parsed, double)
+//	c := doubled.Build()
 //
 //	out, err := c.Execute(ctx, "21", nil) // out == 42
 //

--- a/encryption/service.go
+++ b/encryption/service.go
@@ -3,13 +3,12 @@ package encryption
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -33,8 +32,8 @@ func NewService(key string) (*Service, error) {
 	return &Service{passphrase: []byte(key)}, nil
 }
 
-func deriveKey(passphrase, salt []byte) []byte {
-	return pbkdf2.Key(passphrase, salt, pbkdf2Iterations, keySize, sha256.New)
+func deriveKey(passphrase, salt []byte) ([]byte, error) {
+	return pbkdf2.Key(sha256.New, string(passphrase), salt, pbkdf2Iterations, keySize)
 }
 
 func newAESGCM(key []byte) (cipher.AEAD, error) {
@@ -57,7 +56,12 @@ func encryptWithAEAD(passphrase []byte, factory aeadFactory, plaintext string) (
 		return "", fmt.Errorf("generate salt: %w", err)
 	}
 
-	aead, err := factory(deriveKey(passphrase, salt))
+	key, err := deriveKey(passphrase, salt)
+	if err != nil {
+		return "", fmt.Errorf("derive key: %w", err)
+	}
+
+	aead, err := factory(key)
 	if err != nil {
 		return "", err
 	}
@@ -87,7 +91,12 @@ func decryptWithAEAD(passphrase []byte, factory aeadFactory, ciphertext string) 
 	}
 
 	salt := data[:saltSize]
-	aead, err := factory(deriveKey(passphrase, salt))
+	key, err := deriveKey(passphrase, salt)
+	if err != nil {
+		return "", fmt.Errorf("derive key: %w", err)
+	}
+
+	aead, err := factory(key)
 	if err != nil {
 		return "", err
 	}

--- a/encryption/service_test.go
+++ b/encryption/service_test.go
@@ -4,12 +4,32 @@ import (
 	"bytes"
 	"crypto/cipher"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
 )
+
+func TestDeriveKeyMatchesPBKDF2SHA256Vector(t *testing.T) {
+	old := pbkdf2Iterations
+	pbkdf2Iterations = 1000
+	t.Cleanup(func() { pbkdf2Iterations = old })
+
+	got, err := deriveKey([]byte("password"), []byte("salt"))
+	if err != nil {
+		t.Fatalf("deriveKey: %v", err)
+	}
+
+	want, err := hex.DecodeString("632c2812e46d4604102ba7618e9d6d7d2f8128f6266b4a03264d2a0460b7dcb3")
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("deriveKey() = %x, want %x", got, want)
+	}
+}
 
 func TestRoundTrip_BinaryData(t *testing.T) {
 	// All 256 byte values including null bytes


### PR DESCRIPTION
## Description

This replaces the encryption package's PBKDF2 key derivation with Go's standard-library `crypto/pbkdf2` while preserving derived-key compatibility for identical passphrase, salt, and iteration inputs. It also clarifies the recommended `chain` composition style so longer typed chains read in execution order without changing the chain API.

## Motivation

Gokit targets a Go version with stdlib PBKDF2 support, so encryption no longer needs the `golang.org/x/crypto/pbkdf2` helper. The remaining `x/crypto` usage stays for primitives without stdlib equivalents, and the chain docs now make the intended Go-native package-level composition style clearer.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement
- [ ] Performance improvement

## Module(s) Affected

- encryption
- chain

## Changes Made

- Move AES-GCM key derivation from `golang.org/x/crypto/pbkdf2` to stdlib `crypto/pbkdf2` and propagate derivation errors explicitly.
- Add a PBKDF2-SHA256 known-vector test to prove the derived key remains byte-compatible.
- Update chain package docs to show named intermediate builders for readable left-to-right composition.

## Testing

- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [x] `make lint` is clean (includes `vet` + `depguard` layering)
- [x] `make fmt` reports no diffs (`gofmt -s`)
- [x] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [ ] Manual testing performed (describe below if applicable)

### Test Evidence

```
$ go test -race -shuffle=on -count=1 ./chain ./encryption
ok  	github.com/kbukum/gokit/chain	1.243s
ok  	github.com/kbukum/gokit/encryption	2.264s

$ make lint M=.
0 issues.

$ govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (internal change)
- [ ] Sibling-parity tracked: rskit <url>, pykit <url>
- [ ] Reveals an upstream rskit gap (tagged **IMPROVE-RSKIT** in the description)

## Checklist

- [x] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [ ] Bug fixes include a regression test that fails without the fix
- [x] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI Codecov gate
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] `make tidy` run so go.mod/go.sum are clean for affected modules
- [ ] CHANGELOG entry added under `[Unreleased]`
- [x] New dependencies (if any) are justified, minimal, and pass `govulncheck`

## Additional Notes

`golang.org/x/crypto` remains in the module graph for other crypto primitives that do not have stdlib equivalents. The PBKDF2 and OpenPGP packages are not imported.
