### PR TITLE
ci(release): harden alpha release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,8 +88,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: "Which version of gokit? (e.g., v0.1.2, server/v0.1.1)"
-      placeholder: "v0.1.2"
+      description: "Which version of gokit? (e.g., v0.2.0-alpha.1, server/v0.2.0-alpha.1)"
+      placeholder: "v0.2.0-alpha.1"
     validations:
       required: true
 

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -60,8 +60,9 @@ or if the `[vX.Y.Z]` section for the version you're cutting is missing.
 ## Step 4 — Tag every module
 
 ```bash
-./tag-modules.sh vX.Y.Z            # local-only dry run — inspect the tags it would create
-./tag-modules.sh vX.Y.Z --push     # create and push tags to origin
+./tag-modules.sh vX.Y.Z --dry-run # inspect tags without creating them
+./tag-modules.sh vX.Y.Z           # create signed local tags
+./tag-modules.sh vX.Y.Z --push    # create and push tags to origin
 ```
 
 Equivalent Makefile wrappers: `make tag VERSION=vX.Y.Z`, `make tag-push VERSION=vX.Y.Z`,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,17 @@ name: Release
 # Closes F-037 (no release/SBOM/cosign workflow), F-055 (no goreleaser),
 # F-056 (gh release list empty despite tags).
 #
-# Trigger: push of any vX.Y.Z tag (root module). Per-submodule tags
-# (e.g. kafka/v0.2.0) are handled separately by tag-modules.sh and do
+# Trigger: push of any root v* tag. Per-submodule tags
+# (e.g. messaging/kafka/v0.2.0-alpha.1) are handled separately by tag-modules.sh and do
 # not trigger a release here.
 
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    - "v*"
 
 permissions:
   contents: write   # publish release assets
-  packages: write   # in case we publish OCI artifacts later
   id-token: write   # cosign keyless signing via OIDC
   attestations: write   # SLSA build provenance attestation
 
@@ -48,7 +47,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: "v2.11.2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,7 @@
-# goreleaser configuration — library mode (no binaries; SBOM + checksums + signed source archive).
-# Closes F-055 (no .goreleaser.yml).
-#
-# Usage:
-#   goreleaser release --clean       (CI; expects GITHUB_TOKEN, COSIGN_KEY)
-#   goreleaser release --snapshot    (local dry run)
+# Source-only library release: archive, complete source SBOM, checksum, and signature bundle.
 version: 2
 
 project_name: gokit
-
-before:
-  hooks:
-    - go mod tidy
 
 builds:
   - skip: true   # gokit ships libraries, not binaries.
@@ -24,53 +15,23 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
-# SBOM generation (CycloneDX) — closes F-037 SBOM gap when paired with CI.
-# goreleaser runs the sbom cmd from the dist/ directory, so the module root is
-# one level up; cyclonedx-gomod catalogs the root module and its dependencies.
 sboms:
   - artifacts: source
     documents:
       - "{{ .ProjectName }}-{{ .Version }}.cdx.json"
-    cmd: cyclonedx-gomod
-    args: ["mod", "-licenses", "-json", "-output", "$document", ".."]
+    cmd: syft
+    args: ["$artifact", "--output", "cyclonedx-json=$document", "--enrich", "all"]
 
-# Cosign keyless signing of source + checksums + SBOM. Requires the
-# release workflow to run with id-token:write so OIDC is available. The
-# certificate is emitted alongside the signature so the release job can
-# `cosign verify-blob` the artifacts without a static key.
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
-      - "--yes"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
-    artifacts: all
+      - "--yes"
+    artifacts: checksum
     output: true
-
-changelog:
-  use: github
-  sort: asc
-  groups:
-    - title: Features
-      regexp: '^.*?feat(\(.+\))??:.+$'
-      order: 0
-    - title: Bug fixes
-      regexp: '^.*?fix(\(.+\))??:.+$'
-      order: 1
-    - title: Performance
-      regexp: '^.*?perf(\(.+\))??:.+$'
-      order: 2
-    - title: Other
-      order: 999
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      - '^chore:'
-      - '^ci:'
 
 release:
   github:
@@ -78,8 +39,4 @@ release:
     name: gokit
   prerelease: auto
   draft: false
-  mode: append
-  header: |
-    ## gokit {{ .Tag }}
-
-    See [`CHANGELOG.md`](https://github.com/kbukum/gokit/blob/{{ .Tag }}/CHANGELOG.md) for the curated list of changes.
+  name_template: "{{ .Tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.2.0-alpha.1] - 2026-07-19
+
 ### Added — Generic dataset collection kit
 - **dataset** (NEW module, light mirror of rskit-dataset): a streaming,
   generics-first dataset-collection toolkit built on one item-generic `collect.Collector[T]` engine.
@@ -197,14 +201,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-25
 
-> Tag `v0.2.0` shipped on 2026-04-04 but never received a CHANGELOG entry.
-> This entry back-fills the previous `[Unreleased]` section verbatim. From this release on,
-> every tag MUST be accompanied by a corresponding CHANGELOG entry —
-> enforced by `tag-modules.sh` (see `docs/RELEASING.md`).
->
-> The `kafka/v0.2.0`
-> and `kafka/testutil/v0.2.0` tags are orphans from when the kafka provider lived at `/kafka`;
-> the package now lives at `/messaging/kafka` and is versioned in lock-step with `messaging`.
+> Historical development baseline retained for changelog context. The old `v0.2.0`
+> tags were removed before the prerelease line was started.
 
 ### Changed (Breaking API Changes)
 - **workload**: `RegisterFactory()` global and `New(cfg, providerCfg, log)` removed.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 > **Status — pre-1.0.** Public surface is semver-stable per module;
 > breaking changes are documented in [`CHANGELOG.md`](CHANGELOG.md).
 > See [`docs/policy/SEMVER.md`](docs/policy/SEMVER.md).
+>
+> **Current development line — `v0.2.0-alpha.1`.** This is a prerelease for
+> evaluation and integration testing; APIs may change before `v0.2.0`.
 
 > **Sibling projects.** gokit (Go, this repo) · [**rskit**](https://github.com/kbukum/rskit) (Rust) · [**pykit**](https://github.com/kbukum/pykit) (Python).
 > Public abstractions (`AppError`, `Component`, `Provider`, `Pipeline`, lifecycle hooks) are evaluated for parity across all three.
@@ -41,7 +44,7 @@ CI still runs full-workspace validation; on pull requests the `changes` job also
 - **Lifecycle-managed components** — uniform `Component` interface (start / stop / health) and `bootstrap.App` orchestrator with graceful shutdown.
 - **Production resilience** — circuit breakers, retries with backoff + jitter, bulkheads, rate limiting, OpenTelemetry tracing & metrics.
 - **Provider pattern** — typed `RequestResponse[I,O]`, `Stream`, `Sink`, and `Duplex` traits with composable middleware and sink combinators.
-- **Per-module versioning** — `gokit/server` and `gokit/database` upgrade independently of core. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
+- **Per-module versioning** — every module has its own matching tag, while normal releases are cut in lock-step for convenience. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
 - **Sibling parity** — APIs mirror [rskit](https://github.com/kbukum/rskit) (Rust) and [pykit](https://github.com/kbukum/pykit) (Python).
 
 ## Install

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -9,7 +9,7 @@ This file is the bird's-eye index.
 
 | Go version | gokit version |
 |------------|---------------|
-| 1.26+      | v0.1.2+       |
+| 1.26+      | v0.2.0-alpha.1+ |
 
 ## Core Packages
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -28,43 +28,37 @@ otherwise PATCH.
 ## 2. Update the CHANGELOG
 
 1. Open `CHANGELOG.md`.
-2. Replace `## [Unreleased]` with `## [vX.Y.Z] - YYYY-MM-DD`.
-3. Add a fresh empty `## [Unreleased]` section above it.
-4. If `[Unreleased]` is empty, refuse to release — there is nothing to ship.
-5. Update the link reference at the bottom of the file (if present).
+2. For a prerelease, replace the populated `## [Unreleased]` section with `## [X.Y.Z-alpha.N] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` section above it.
+3. For a stable release, use `## [X.Y.Z] - YYYY-MM-DD` and the same empty-section rotation.
+4. Refuse to release when the populated `[Unreleased]` section is empty.
 
-The `tag-modules.sh` script will refuse to tag if `[Unreleased]` is the only populated section,
-or if `[vX.Y.Z]` for the version you're cutting doesn't exist in the file.
+For stable releases, `tag-modules.sh` requires a matching changelog section.
+Prereleases use the dated alpha or beta section for release notes.
 
 ## 3. Tag every module
 
 ```sh
-./tag-modules.sh vX.Y.Z          # local-only dry run
-./tag-modules.sh vX.Y.Z --push   # push tags to origin
+./tag-modules.sh vX.Y.Z --dry-run # inspect tags without creating them
+./tag-modules.sh vX.Y.Z           # create signed local tags
+./tag-modules.sh vX.Y.Z --push    # create and push signed tags
 ```
 
 The script will:
 - Refuse to run with a dirty working tree (`git status --porcelain` non-empty).
 - Refuse to overwrite existing tags unless `--force` is passed.
-- Refuse if `CHANGELOG.md` lacks a `## [vX.Y.Z]` section.
+- Refuse if a stable release lacks a matching `CHANGELOG.md` section.
 - Create signed annotated tags (`git tag -s -a vX.Y.Z -m "..."`) using your configured GPG key.
 - Tag the root and every sub-module in lock-step.
 
-## 4. Cut the GitHub Release
+## 4. Publish the GitHub Release
 
-Once the tag is on `origin`, generate release notes from the CHANGELOG
-and create the GitHub Release via `gh`:
+Pushing the root tag starts `.github/workflows/release.yml`. GoReleaser creates
+the GitHub prerelease or stable release and publishes the source archive,
+checksums, SBOM, signatures, and provenance. Do not create a second release
+manually with `gh`.
 
-```sh
-./scripts/release-notes.sh vX.Y.Z > /tmp/notes.md
-gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/notes.md
-```
-
-The release-notes script extracts the matching CHANGELOG section verbatim
-and prepends a generated summary line and a link to the full diff.
-
-GitHub Releases are mandatory;
-downstream tooling (`go install`, `dependabot`, `pkg.go.dev`) only surface signal when both the tag *and* the Release exist.
+GitHub Releases are mandatory; downstream tooling (`go install`, Dependabot,
+and pkg.go.dev) only surface release signal when both the tag and release exist.
 
 ## 5. Verify on `pkg.go.dev`
 
@@ -91,26 +85,26 @@ Hotfixes follow the same flow
 but skip the `[Unreleased]` rotation if the fix is targeted at an older line:
 
 ```sh
-git checkout v0.2.0
-git checkout -b hotfix/v0.2.1
+git checkout <existing-release-tag>
+git checkout -b hotfix/vX.Y.Z
 # … apply fix …
 # add a `## [0.2.1] - YYYY-MM-DD` section to CHANGELOG.md
-./tag-modules.sh v0.2.1 --push
+./tag-modules.sh vX.Y.Z --push
 ```
 
 ## Pre-releases
 
 ```sh
-./tag-modules.sh v0.3.0-rc.1 --push
-gh release create v0.3.0-rc.1 --prerelease --title "v0.3.0-rc.1" \
-  --notes-file /tmp/notes.md
+./tag-modules.sh v0.2.0-alpha.1 --dry-run
+./tag-modules.sh v0.2.0-alpha.1 --push
 ```
 
-Pre-releases bypass the CHANGELOG check (the `-rc.N` / `-beta.N` suffix is detected by `tag-modules.sh`).
+The prerelease suffix is detected by GoReleaser and the resulting GitHub
+Release is marked as a prerelease.
 
 ## Supply-chain artifacts (automated)
 
-Pushing a root `vX.Y.Z` tag (including pre-releases like `v0.1.0-alpha.1`) triggers `.github/workflows/release.yml`,
+Pushing a root `vX.Y.Z` tag (including pre-releases like `v0.2.0-alpha.1`) triggers `.github/workflows/release.yml`,
 which runs GoReleaser in library mode and produces, for every release:
 
 - a reproducible source archive (`gokit-<version>-source.tar.gz`) and a `checksums.txt`;

--- a/docs/VERSIONING-QUICK-FIX.md
+++ b/docs/VERSIONING-QUICK-FIX.md
@@ -1,137 +1,36 @@
-# Quick Fix: Versioning Issue
+# Versioning Quick Fix
 
-## Problem
+Use this procedure when a consumer resolves a gokit module to a zero-date pseudo-version.
 
-You're seeing pseudo-versions in your dependencies:
-```
-github.com/kbukum/gokit/connect v0.0.0-00010101000000-000000000000
-github.com/kbukum/gokit/database v0.0.0-00010101000000-000000000000
-...
-```
+## Cause
 
-## Root Cause
+The module's version tag is missing from the remote repository, or the consumer has not requested a published version.
 
-The modules don't have Git tags, so Go cannot determine their version
-and falls back to a pseudo-version.
+## Fix
 
-## Quick Fix (3 Steps)
-
-### Step 1: Commit Your Changes
+From a clean `main` checkout, preview the tags first:
 
 ```bash
-cd /path/to/gokit
-
-# Add all changes
-git add .
-
-# Commit
-git commit -m "chore: prepare release"
+./tag-modules.sh v0.2.0-alpha.1 --dry-run
 ```
 
-### Step 2: Tag All Modules
+Configure signing and create the complete module tag family:
 
 ```bash
-# Tag all modules with v0.1.0
-make tag VERSION=v0.1.0
+git config tag.gpgsign true
+git config user.signingkey <KEY-ID>
+./tag-modules.sh v0.2.0-alpha.1 --push
 ```
 
-This will create tags for all modules automatically (discovered from `go.mod` files):
-- `v0.1.0` (main module)
-- `auth/v0.1.0`
-- `authz/v0.1.0`
-- `bench/v0.1.0`
-- `connect/v0.1.0`
-- `database/v0.1.0`
-- `discovery/v0.1.0`
-- `grpc/v0.1.0`
-- `httpclient/v0.1.0`
-- `llm/v0.1.0`
-- `messaging/v0.1.0`
-- `cache/v0.1.0`
-- `server/v0.1.0`
-- `stateful/v0.1.0`
-- `storage/v0.1.0`
-- `testutil/v0.1.0`
-- `workload/v0.1.0`
-- ... plus all `*/testutil` modules
+The script discovers all `go.mod` files automatically. It creates the root tag (`v0.2.0-alpha.1`) and path-scoped tags such as `auth/v0.2.0-alpha.1` and `database/sqlite/v0.2.0-alpha.1`.
 
-### Step 3: Push Tags to Remote (Optional but Recommended)
+Consumers can then request the published version:
 
 ```bash
-# Push commits and tags
-git push
-git push origin --tags
-
-# Or use the combined command
-make tag-push VERSION=v0.1.0
-```
-
-## Verify the Fix
-
-### In gokit repository:
-
-```bash
-# List all tags
-make list-tags
-
-# Should show:
-# auth/v0.1.0
-# connect/v0.1.0
-# v0.1.0
-# ...
-```
-
-### In consuming projects (like platform):
-
-```bash
-cd /path/to/consuming-project
-
-# Update dependencies to use tagged versions
-go get github.com/kbukum/gokit@v0.1.0
-go get github.com/kbukum/gokit/auth@v0.1.0
-go get github.com/kbukum/gokit/connect@v0.1.0
-
-# Or update all at once
-go get -u github.com/kbukum/gokit/...@v0.1.0
-
-# Then tidy
+go get github.com/kbukum/gokit@v0.2.0-alpha.1
+go get github.com/kbukum/gokit/auth@v0.2.0-alpha.1
+go get github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
 go mod tidy
 ```
 
-## For Local Development
-
-If you want to continue using local development (without tags),
-keep the `replace` directives in your `go.mod`:
-
-```go
-replace (
-    github.com/kbukum/gokit => ../gokit
-    github.com/kbukum/gokit/auth => ../gokit/auth
-    github.com/kbukum/gokit/connect => ../gokit/connect
-    // ... other modules
-)
-```
-
-The pseudo-versions won't affect functionality when using `replace` directives.
-They only appear in the dependency list but are overridden by the local paths.
-
-## Future Releases
-
-When you make changes and want to release:
-
-```bash
-# 1. Update CHANGELOG.md with changes
-# 2. Commit changes
-git add .
-git commit -m "chore: prepare v0.2.0 release"
-
-# 3. Tag new version
-make tag VERSION=v0.2.0
-
-# 4. Push
-git push origin --tags
-```
-
-## More Information
-
-See [docs/VERSIONING.md](docs/VERSIONING.md) for complete versioning guide.
+For local development, use `replace` directives instead of publishing temporary tags. See [`VERSIONING.md`](VERSIONING.md) for the complete policy.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,294 +1,75 @@
-# Multi-Module Versioning Guide
+# Multi-Module Versioning
 
-This document explains how versioning works in the gokit multi-module repository.
+gokit is a Go workspace with one root module and nested sub-modules. Every module receives its own tag because Go resolves module versions from the module's path-scoped tag.
 
-## Problem: Pseudo-Versions
+## Version format
 
-Without proper Git tags,
-Go assigns pseudo-versions like `v0.0.0-00010101000000-000000000000` to modules.
-This happens because Go cannot determine the version from the repository history.
-
-## Solution: Semantic Versioning with Git Tags
-
-gokit uses **semantic versioning** (semver) with Git tags to provide proper module versions.
-
-### Version Format
+Tags use Semantic Versioning:
 
 ```
-vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]
+vMAJOR.MINOR.PATCH[-PRERELEASE]
 ```
 
-Examples:
-- `v0.1.0` - First minor release
-- `v1.0.0` - First major release
-- `v1.2.3` - Standard release
-- `v1.0.0-alpha.1` - Pre-release
-- `v1.0.0+20240522` - With build metadata
+The current development line is `v0.2.0-alpha.1`. Prereleases are ordered as `alpha.1`, `alpha.2`, and so on; the stable `v0.2.0` follows the final prerelease.
 
-### Multi-Module Tag Convention
+## Module tags
 
-In a multi-module repository, each module needs its own tag:
+The root module uses the plain tag and every sub-module uses its directory prefix:
 
 ```
-# Main module
-v0.1.0
-
-# Submodules (auto-discovered from go.mod files)
-auth/v0.1.0
-authz/v0.1.0
-bench/v0.1.0
-connect/v0.1.0
-database/v0.1.0
-discovery/v0.1.0
-grpc/v0.1.0
-httpclient/v0.1.0
-llm/v0.1.0
-messaging/v0.1.0
-cache/v0.1.0
-server/v0.1.0
-stateful/v0.1.0
-storage/v0.1.0
-testutil/v0.1.0
-workload/v0.1.0
+v0.2.0-alpha.1
+auth/v0.2.0-alpha.1
+database/sqlite/v0.2.0-alpha.1
+messaging/kafka/v0.2.0-alpha.1
 ```
 
-> **Note:** The `tag-modules.sh` script automatically discovers all modules by finding `go.mod` files.
-> You never need to maintain a hardcoded list.
+`tag-modules.sh` discovers every `go.mod` file, so the module list is never maintained in documentation. Normal releases tag all modules in lock-step for operational simplicity, while each module remains independently consumable and versioned.
 
-## Tagging Modules
+## Prerelease workflow
 
-### Quick Start
+1. Add the completed changes to a dated `## [0.2.0-alpha.N]` section in `CHANGELOG.md` and leave an empty `## [Unreleased]` section above it.
+2. Run the complete release gates on a clean `main` checkout.
+3. Preview the exact tag set without creating tags:
+
+   ```bash
+   ./tag-modules.sh v0.2.0-alpha.1 --dry-run
+   ```
+
+4. Configure a GPG signing key, create the signed tags, and push them:
+
+   ```bash
+   git config tag.gpgsign true
+   git config user.signingkey <KEY-ID>
+   ./tag-modules.sh v0.2.0-alpha.1 --push
+   ```
+
+5. The root tag starts the release workflow. GoReleaser publishes the GitHub prerelease together with the source archive, checksums, SBOM, signatures, and provenance.
+
+Subsequent prereleases repeat the same flow with `alpha.2`, `alpha.3`, or `beta.N`. Once the API and behavior are ready for consumers, cut `v0.2.0` from the same release line.
+
+## Stable and patch releases
+
+While gokit is below `1.0.0`, breaking changes require a minor version bump and non-breaking additions or fixes use a patch bump. A stable release rotates the populated `[Unreleased]` section into `## [X.Y.Z] - YYYY-MM-DD`, then adds a new empty `[Unreleased]` section.
+
+Hotfixes for an older line use a dedicated hotfix branch and the same module-tagging script. Never move an existing published tag.
+
+## Consumer usage
 
 ```bash
-# Tag all modules with v0.1.0
-make tag VERSION=v0.1.0
-
-# Tag and push to remote
-make tag-push VERSION=v0.1.0
-
-# Force overwrite existing tags
-make tag-force VERSION=v0.1.0
-
-# List all tags
-make list-tags
+go get github.com/kbukum/gokit@v0.2.0-alpha.1
+go get github.com/kbukum/gokit/auth@v0.2.0-alpha.1
+go get github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
 ```
 
-### Manual Tagging
+Use local `replace` directives only for development against an unreleased checkout. Published consumers should use a tag so Go does not select a pseudo-version.
 
-If you prefer manual control:
+## Verification
+
+After publication, verify the root and representative nested modules through the Go proxy:
 
 ```bash
-# Tag main module
-git tag v0.1.0
-
-# Tag submodules
-git tag auth/v0.1.0
-git tag connect/v0.1.0
-git tag database/v0.1.0
-# ... etc
-
-# Push all tags
-git push origin --tags
+GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit@v0.2.0-alpha.1
+GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
 ```
 
-### Using the Script Directly
-
-```bash
-# Basic usage
-./tag-modules.sh v0.1.0
-
-# With options
-./tag-modules.sh v0.1.0 --push        # Tag and push
-./tag-modules.sh v0.1.0 --force       # Force overwrite
-./tag-modules.sh v0.1.0 --push --force # Both
-```
-
-## Version Compatibility
-
-### Breaking Changes (Major Version Bump)
-
-When making breaking changes:
-
-```bash
-# v0.x.x to v1.0.0 (first stable)
-make tag VERSION=v1.0.0
-
-# v1.x.x to v2.0.0 (breaking change)
-make tag VERSION=v2.0.0
-```
-
-For major versions ≥2, Go requires a version suffix in the module path:
-
-```go
-// go.mod for v2+
-module github.com/kbukum/gokit/v2
-
-// imports
-import "github.com/kbukum/gokit/v2/logging"
-```
-
-### Non-Breaking Changes
-
-```bash
-# New features (minor bump)
-make tag VERSION=v0.2.0
-
-# Bug fixes (patch bump)
-make tag VERSION=v0.1.1
-```
-
-## Using Versioned Modules
-
-### In Consumer Projects
-
-```bash
-# Use specific version
-go get github.com/kbukum/gokit@v0.1.0
-go get github.com/kbukum/gokit/auth@v0.1.0
-go get github.com/kbukum/gokit/connect@v0.1.0
-
-# Use latest
-go get -u github.com/kbukum/gokit
-go get -u github.com/kbukum/gokit/auth
-go get -u github.com/kbukum/gokit/connect
-```
-
-### Local Development
-
-For local development, use `replace` directives in `go.mod`:
-
-```go
-replace (
-    github.com/kbukum/gokit => ../gokit
-    github.com/kbukum/gokit/auth => ../gokit/auth
-    github.com/kbukum/gokit/connect => ../gokit/connect
-)
-```
-
-## Release Workflow
-
-### 1. Prepare Release
-
-```bash
-# Update CHANGELOG.md
-vim CHANGELOG.md
-
-# Run all checks
-make check
-
-# Tidy dependencies
-make tidy
-
-# Commit changes
-git add .
-git commit -m "chore: prepare v0.1.0 release"
-```
-
-### 2. Tag Release
-
-```bash
-# Tag all modules
-make tag VERSION=v0.1.0
-
-# Review tags
-make list-tags
-
-# Push tags
-git push origin --tags
-```
-
-### 3. Verify
-
-```bash
-# Check that modules can be fetched
-go get github.com/kbukum/gokit@v0.1.0
-go get github.com/kbukum/gokit/connect@v0.1.0
-```
-
-## Troubleshooting
-
-### Problem: Pseudo-Version Still Appears
-
-**Cause:** Tags not pushed to remote or `go.sum` cache issue
-
-**Solution:**
-```bash
-# Ensure tags are pushed
-git push origin --tags
-
-# Clear Go module cache
-go clean -modcache
-
-# Re-fetch
-go get -u github.com/kbukum/gokit@v0.1.0
-```
-
-### Problem: "Unknown Revision" Error
-
-**Cause:** Tag doesn't exist on remote
-
-**Solution:**
-```bash
-# Push tags to remote
-git push origin --tags
-
-# Or use make target
-make tag-push VERSION=v0.1.0
-```
-
-### Problem: Wrong Version Resolved
-
-**Cause:** Newer tag exists or local cache
-
-**Solution:**
-```bash
-# List all tags
-git tag -l
-
-# Delete wrong tag locally
-git tag -d v0.1.0
-git tag -d auth/v0.1.0
-
-# Delete on remote
-git push origin :refs/tags/v0.1.0
-git push origin :refs/tags/auth/v0.1.0
-
-# Re-tag correctly
-make tag VERSION=v0.1.0 --force
-```
-
-## Best Practices
-
-1. **Always tag all modules together** - Use `make tag` to ensure consistency
-2. **Follow semver strictly** - Breaking changes = major bump
-3. **Update CHANGELOG.md** - Document changes before tagging
-4. **Test before tagging** - Run `make check` first
-5. **Never force-push tags** - Unless absolutely necessary
-6. **Use pre-release tags for testing** - e.g., `v0.2.0-beta.1`
-
-## Version Strategy
-
-### v0.x.x - Pre-1.0 Development
-
-- Breaking changes allowed in minor versions
-- Use for active development
-- API may change
-
-### v1.0.0 - First Stable Release
-
-- Signals API stability
-- Breaking changes require v2.0.0
-- Commit to backward compatibility
-
-### v1.x.x - Stable Maintenance
-
-- Only non-breaking changes
-- Bug fixes in patch versions
-- New features in minor versions
-
-## References
-
-- [Go Modules Reference](https://go.dev/ref/mod)
-- [Semantic Versioning](https://semver.org/)
-- [Go Module Versioning](https://go.dev/doc/modules/version-numbers)
-- [Multi-Module Repositories](https://github.com/go-modules-by-example/index/blob/master/009_submodules/README.md)
+The complete mechanical procedure is in [`RELEASING.md`](RELEASING.md), and the SemVer compatibility rules are in [`policy/SEMVER.md`](policy/SEMVER.md).

--- a/docs/policy/SEMVER.md
+++ b/docs/policy/SEMVER.md
@@ -49,12 +49,12 @@ The following are explicitly **not** part of the public API and may change in an
 
 ## Module-level version skew
 
-Sub-modules may temporarily be at different versions when a focused fix ships (e.g. `storage/v0.2.1` while the rest of the workspace stays at `v0.2.0`).
+Sub-modules may temporarily be at different versions when a focused fix ships (e.g. `storage/v0.2.0-alpha.2` while the rest of the workspace stays at `v0.2.0-alpha.1`).
 The next root-level release brings everything back into lock-step.
 
 ## Pre-release identifiers
 
-Pre-releases use SemVer suffixes: `v0.3.0-rc.1`, `v0.3.0-beta.2`.
+Pre-releases use SemVer suffixes: `v0.2.0-alpha.1`, `v0.2.0-beta.1`.
 Pre-release tags do not require CHANGELOG entries
 but **must** be reproducible builds (no moving Go-toolchain reference, no floating action SHAs).
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# scripts/release-notes.sh — extract a CHANGELOG section for `gh release create`.
-#
-# Usage:
-#   scripts/release-notes.sh v0.2.0 > /tmp/notes.md
-#   gh release create v0.2.0 --notes-file /tmp/notes.md
+
 set -euo pipefail
 
 VERSION="${1:-}"
@@ -12,24 +8,42 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+if [[ ! "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+  echo "error: invalid semantic version: $VERSION" >&2
+  exit 1
+fi
+prerelease=${BASH_REMATCH[5]:-}
+if [[ -n "$prerelease" ]]; then
+  IFS='.' read -r -a identifiers <<<"$prerelease"
+  for identifier in "${identifiers[@]}"; do
+    if [[ "$identifier" =~ ^[0-9]+$ && ${#identifier} -gt 1 && "$identifier" == 0* ]]; then
+      echo "error: invalid semantic version: $VERSION" >&2
+      exit 1
+    fi
+  done
+fi
+
 NOVER="${VERSION#v}"
 CHANGELOG="$(dirname "$0")/../CHANGELOG.md"
+HEADING_PREFIX="## [${NOVER}] - "
 
-if ! grep -qE "^## \[${NOVER}\]" "$CHANGELOG"; then
+if ! awk -v prefix="$HEADING_PREFIX" '
+  index($0, prefix) == 1 { found = 1 }
+  END { exit found ? 0 : 1 }
+' "$CHANGELOG"; then
   echo "error: CHANGELOG.md has no '## [${NOVER}]' section" >&2
   exit 1
 fi
 
-# Find previous tag for the diff link.
-PREV=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${VERSION}$" | head -1 || true)
+PREV=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][a-zA-Z0-9.]+)?$' | grep -v "^${VERSION}$" | head -1 || true)
 
 cat <<EOF
 ## ${VERSION}
 
 EOF
 
-awk -v ver="$NOVER" '
-  $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+awk -v prefix="$HEADING_PREFIX" '
+  index($0, prefix) == 1 {flag=1; next}
   flag && /^## \[/ {flag=0}
   flag {print}
 ' "$CHANGELOG"

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "release-notes.sh"
+
+
+class ReleaseNotesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.repo = Path(self.tempdir.name)
+        (self.repo / "scripts").mkdir()
+        self.script = self.repo / "scripts" / "release-notes.sh"
+        self.script.symlink_to(SCRIPT)
+        (self.repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "### Fixed\n\n"
+            "- Future fix.\n\n"
+            "## [0.3.0-alpha.1] - 2026-07-19\n\n"
+            "### Added\n\n"
+            "- First alpha.\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "init", "-b", "main"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def run_script(self, version: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.script), version],
+            cwd=self.repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_extracts_exact_prerelease_section(self) -> None:
+        result = self.run_script("v0.3.0-alpha.1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("## v0.3.0-alpha.1", result.stdout)
+        self.assertIn("- First alpha.", result.stdout)
+        self.assertNotIn("- Future fix.", result.stdout)
+
+    def test_rejects_missing_prerelease_section(self) -> None:
+        result = self.run_script("v0.3.0-alpha.2")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "CHANGELOG.md has no '## [0.3.0-alpha.2]' section",
+            result.stderr,
+        )
+
+    def test_rejects_invalid_version(self) -> None:
+        result = self.run_script("not-a-version")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid semantic version", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_tag_modules.py
+++ b/scripts/test_tag_modules.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "tag-modules.sh"
+
+
+class TagModulesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        root = Path(self.tempdir.name)
+        self.repo = root / "repo"
+        self.origin = root / "origin.git"
+
+        self.run_git("init", "--bare", str(self.origin), cwd=root)
+        self.run_git("init", "-b", "main", str(self.repo), cwd=root)
+        self.run_git("config", "user.name", "Release Test", cwd=self.repo)
+        self.run_git("config", "user.email", "release-test@example.com", cwd=self.repo)
+
+        (self.repo / "sub").mkdir()
+        (self.repo / "go.mod").write_text(
+            "module github.com/kbukum/gokit\n\ngo 1.26.0\n",
+            encoding="utf-8",
+        )
+        (self.repo / "sub" / "go.mod").write_text(
+            "module github.com/kbukum/gokit/sub\n\ngo 1.26.0\n",
+            encoding="utf-8",
+        )
+        self.write_changelog()
+
+        self.run_git("add", ".", cwd=self.repo)
+        self.run_git("commit", "-m", "initial", cwd=self.repo)
+        self.run_git("remote", "add", "origin", str(self.origin), cwd=self.repo)
+        self.run_git("push", "-u", "origin", "main", cwd=self.repo)
+
+    def write_changelog(self, version: str = "0.3.0-alpha.1") -> None:
+        (self.repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "_No unreleased changes._\n\n"
+            f"## [{version}] - 2026-07-19\n\n"
+            "### Changed\n\n"
+            "- Prepared the release.\n",
+            encoding="utf-8",
+        )
+
+    def run_script(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT), *args],
+            cwd=self.repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    @staticmethod
+    def run_git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_dry_run_is_safe_from_feature_branch_with_dirty_tree(self) -> None:
+        self.run_git("switch", "-c", "feature", cwd=self.repo)
+        (self.repo / "scratch").write_text("dirty\n", encoding="utf-8")
+
+        result = self.run_script("v0.3.0-alpha.1", "--dry-run")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines()[-2:],
+            ["v0.3.0-alpha.1", "sub/v0.3.0-alpha.1"],
+        )
+
+    def test_rejects_invalid_semver(self) -> None:
+        for version in (
+            "0.3.0",
+            "v0.3",
+            "v0.3.0-alpha..1",
+            "v0.3.0-alpha.01",
+            "v0.3.0+build",
+        ):
+            with self.subTest(version=version):
+                result = self.run_script(version, "--dry-run")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("invalid semantic version", result.stderr)
+
+    def test_requires_exact_populated_changelog_section(self) -> None:
+        result = self.run_script("v0.3.0-alpha.2", "--dry-run")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CHANGELOG.md is missing [0.3.0-alpha.2]", result.stderr)
+
+    def test_rejects_unreleased_content(self) -> None:
+        changelog = (self.repo / "CHANGELOG.md").read_text(encoding="utf-8")
+        (self.repo / "CHANGELOG.md").write_text(
+            changelog.replace(
+                "_No unreleased changes._",
+                "### Fixed\n\n- Not yet included in the release.",
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_script("v0.3.0-alpha.1", "--dry-run")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("[Unreleased] must be empty", result.stderr)
+
+    def test_rejects_module_path_that_does_not_match_directory(self) -> None:
+        (self.repo / "sub" / "go.mod").write_text(
+            "module github.com/kbukum/gokit/wrong\n\ngo 1.26.0\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_script("v0.3.0-alpha.1", "--dry-run")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("module path mismatch", result.stderr)
+
+    def test_rejects_force_option(self) -> None:
+        result = self.run_script("v0.3.0-alpha.1", "--force")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown argument: --force", result.stderr)
+
+    def test_pushes_complete_signed_tag_family(self) -> None:
+        if shutil.which("ssh-keygen") is None:
+            self.skipTest("ssh-keygen is required for signed-tag integration test")
+
+        key = Path(self.tempdir.name) / "release-signing-key"
+        subprocess.run(
+            ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key)],
+            check=True,
+        )
+        self.run_git("config", "gpg.format", "ssh", cwd=self.repo)
+        self.run_git("config", "user.signingkey", str(key), cwd=self.repo)
+
+        result = self.run_script("v0.3.0-alpha.1", "--push")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        remote_refs = self.run_git(
+            "ls-remote",
+            "--tags",
+            "origin",
+            cwd=self.repo,
+        ).stdout
+        self.assertIn("refs/tags/v0.3.0-alpha.1\n", remote_refs)
+        self.assertIn("refs/tags/sub/v0.3.0-alpha.1\n", remote_refs)
+        self.assertEqual(
+            self.run_git(
+                "cat-file",
+                "-t",
+                "v0.3.0-alpha.1",
+                cwd=self.repo,
+            ).stdout.strip(),
+            "tag",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/go.mod
+++ b/server/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -91,8 +91,8 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=

--- a/server/testutil/go.mod
+++ b/server/testutil/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect

--- a/server/testutil/go.sum
+++ b/server/testutil/go.sum
@@ -87,8 +87,8 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
 github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tag-modules.sh
+++ b/tag-modules.sh
@@ -1,203 +1,226 @@
-#!/bin/bash
-# tag-modules.sh — Create Git tags for all modules in the multi-module repo
-# This resolves the v0.0.0-00010101000000-000000000000 pseudo-version issue
-#
-# Usage:
-#   ./tag-modules.sh v0.1.0              # Tag all modules with v0.1.0
-#   ./tag-modules.sh v0.1.0 --push       # Tag and push to remote
-#   ./tag-modules.sh v0.1.0 --force      # Force overwrite existing tags
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# Colors
+cd "$(git rev-parse --show-toplevel)"
+
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-VERSION="${1:-}"
+VERSION=""
 PUSH_TAGS=false
-FORCE_TAG=false
+DRY_RUN=false
 
-# Parse arguments
-for arg in "$@"; do
-  case $arg in
+usage() {
+  echo "Usage:"
+  echo "  ./tag-modules.sh v0.3.0-alpha.1 --dry-run"
+  echo "  ./tag-modules.sh v0.3.0-alpha.1 --push"
+}
+
+fail() {
+  echo -e "${RED}Error: $*${NC}" >&2
+  exit 1
+}
+
+valid_semver() {
+  local version=$1
+  local prerelease identifier
+
+  if [[ ! "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+    return 1
+  fi
+
+  prerelease=${BASH_REMATCH[5]:-}
+  if [[ -n "$prerelease" ]]; then
+    IFS='.' read -r -a identifiers <<<"$prerelease"
+    for identifier in "${identifiers[@]}"; do
+      if [[ "$identifier" =~ ^[0-9]+$ && ${#identifier} -gt 1 && "$identifier" == 0* ]]; then
+        return 1
+      fi
+    done
+  fi
+}
+
+validate_changelog() {
+  local release_version=${VERSION#v}
+  local heading_prefix="## [${release_version}] - "
+
+  if ! awk -v prefix="$heading_prefix" '
+    index($0, prefix) == 1 {
+      date = substr($0, length(prefix) + 1)
+      if (date ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) {
+        found = 1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' CHANGELOG.md; then
+    fail "CHANGELOG.md is missing [${release_version}] with a release date"
+  fi
+
+  if ! awk -v prefix="$heading_prefix" '
+    index($0, prefix) == 1 { in_release = 1; next }
+    in_release && /^## \[/ { exit has_content ? 0 : 1 }
+    in_release && $0 !~ /^[[:space:]]*$/ { has_content = 1 }
+    END { exit has_content ? 0 : 1 }
+  ' CHANGELOG.md; then
+    fail "CHANGELOG.md [${release_version}] is empty"
+  fi
+
+  if ! awk '
+    /^## \[Unreleased\]$/ { in_unreleased = 1; next }
+    in_unreleased && /^## \[/ { in_unreleased = 0 }
+    in_unreleased && $0 !~ /^[[:space:]]*$/ && $0 != "_No unreleased changes._" { invalid = 1 }
+    END { exit invalid ? 1 : 0 }
+  ' CHANGELOG.md; then
+    fail "CHANGELOG.md [Unreleased] must be empty before tagging"
+  fi
+}
+
+validate_module_path() {
+  local module_file=$1
+  local module_dir=${module_file%/go.mod}
+  local actual expected
+
+  actual=$(awk '$1 == "module" { print $2; exit }' "$module_file")
+  if [[ "$module_dir" == "." ]]; then
+    expected="github.com/kbukum/gokit"
+  else
+    expected="github.com/kbukum/gokit/${module_dir#./}"
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    fail "module path mismatch in ${module_file}: expected ${expected}, found ${actual:-<missing>}"
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
     --push)
       PUSH_TAGS=true
-      shift
       ;;
-    --force)
-      FORCE_TAG=true
-      shift
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      fail "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "$VERSION" ]]; then
+        echo -e "${RED}Error: multiple versions supplied${NC}" >&2
+        usage >&2
+        exit 1
+      fi
+      VERSION="$1"
       ;;
   esac
+  shift
 done
 
-if [ -z "$VERSION" ]; then
-  echo -e "${RED}Error: Version is required${NC}"
-  echo ""
-  echo "Usage:"
-  echo "  ./tag-modules.sh v0.1.0              # Tag all modules"
-  echo "  ./tag-modules.sh v0.1.0 --push       # Tag and push to remote"
-  echo "  ./tag-modules.sh v0.1.0 --force      # Force overwrite existing tags"
+if [[ -z "$VERSION" ]]; then
+  echo -e "${RED}Error: version is required${NC}" >&2
+  usage >&2
   exit 1
 fi
 
-# Validate semantic version format
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then
-  echo -e "${RED}Error: Invalid version format. Must follow semantic versioning (e.g., v0.1.0)${NC}"
+valid_semver "$VERSION" || fail "invalid semantic version: $VERSION"
+
+if [[ "$PUSH_TAGS" == true && "$DRY_RUN" == true ]]; then
+  fail "--dry-run cannot be combined with --push"
+fi
+if [[ "$PUSH_TAGS" == false && "$DRY_RUN" == false ]]; then
+  fail "choose --dry-run to preview or --push to create and atomically publish tags"
+fi
+
+validate_changelog
+
+MODULE_FILES=()
+while IFS= read -r module_file; do
+  validate_module_path "$module_file"
+  MODULE_FILES+=("$module_file")
+done < <(find . -name go.mod -not -path '*/vendor/*' -not -path '*/.git/*' | sort)
+
+TAGS=("$VERSION")
+for module_file in "${MODULE_FILES[@]}"; do
+  module_dir="${module_file%/go.mod}"
+  if [[ "$module_dir" != "." ]]; then
+    TAGS+=("${module_dir#./}/${VERSION}")
+  fi
+done
+
+for tag in "${TAGS[@]}"; do
+  if git show-ref --tags --verify --quiet "refs/tags/$tag"; then
+    fail "tag already exists locally: $tag"
+  fi
+
+  set +e
+  git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1
+  remote_status=$?
+  set -e
+  if [[ "$remote_status" -eq 0 ]]; then
+    fail "tag already exists on origin: $tag"
+  elif [[ "$remote_status" -ne 2 ]]; then
+    fail "could not check origin for existing tag: $tag"
+  fi
+done
+
+echo -e "${BLUE}Version: ${GREEN}${VERSION}${NC}"
+echo -e "${BLUE}Modules: ${#TAGS[@]} tags${NC}"
+if [[ "$DRY_RUN" == true ]]; then
+  printf '%s\n' "${TAGS[@]}"
+  exit 0
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo -e "${RED}Error: working directory has uncommitted changes${NC}" >&2
+  git --no-pager status --short >&2
   exit 1
 fi
 
-ROOT_DIR=$(pwd)
-
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo -e "${BLUE}  Multi-Module Tagging Script${NC}"
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo -e "Version:      ${GREEN}${VERSION}${NC}"
-echo -e "Push tags:    $([ "$PUSH_TAGS" = true ] && echo "${GREEN}Yes${NC}" || echo "${YELLOW}No${NC}")"
-echo -e "Force update: $([ "$FORCE_TAG" = true ] && echo "${GREEN}Yes${NC}" || echo "${YELLOW}No${NC}")"
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo ""
-
-# Check if git working directory is clean (refuse, don't prompt — releases
-# must be reproducible and signed from a known-good tree).
-if [ -n "$(git status --porcelain)" ]; then
-  echo -e "${RED}✗ Working directory has uncommitted changes.${NC}"
-  echo -e "  Releases must be cut from a clean tree so the tag SHA matches"
-  echo -e "  exactly what's on origin/main. Stash or commit first."
-  git --no-pager status --short
-  exit 1
-fi
-
-# Refuse to tag if HEAD is not on origin/main (or the version's release branch
-# for hotfixes — anything matching hotfix/${VERSION}).
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-expected="main"
+current_branch=$(git symbolic-ref --quiet --short HEAD) || fail "release tags cannot be created from detached HEAD"
+expected_branch="main"
 case "$current_branch" in
-  hotfix/${VERSION}|hotfix/${VERSION#v}) expected="$current_branch" ;;
+  hotfix/${VERSION}|hotfix/${VERSION#v})
+    expected_branch="$current_branch"
+    ;;
 esac
-if [ "$current_branch" != "$expected" ]; then
-  echo -e "${RED}✗ Refusing to tag from branch '$current_branch'.${NC}"
-  echo -e "  Releases must be cut from '$expected' (or 'hotfix/${VERSION}')."
-  exit 1
+if [[ "$current_branch" != "$expected_branch" ]]; then
+  fail "releases must be cut from '${expected_branch}', not '${current_branch}'"
 fi
 
-# CHANGELOG check (skipped for pre-releases like v0.3.0-rc.1, v0.3.0-beta.2).
-if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  if ! grep -qE "^## \[${VERSION#v}\]" CHANGELOG.md; then
-    echo -e "${RED}✗ CHANGELOG.md is missing a '## [${VERSION#v}] - YYYY-MM-DD' section.${NC}"
-    echo -e "  Add one (move items out of '## [Unreleased]') before tagging."
-    exit 1
-  fi
-  # Refuse if [Unreleased] is the only populated section.
-  unreleased_body=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
-  if [ -z "$(echo "$unreleased_body" | grep -v '^[[:space:]]*$' | grep -v '^_No unreleased')" ] \
-     && ! grep -qE "^## \[${VERSION#v}\]" CHANGELOG.md; then
-    echo -e "${RED}✗ Nothing to release — CHANGELOG '[Unreleased]' is empty and no [${VERSION#v}] section exists.${NC}"
-    exit 1
-  fi
-else
-  echo -e "${YELLOW}⚠ Pre-release detected (${VERSION}); skipping CHANGELOG check.${NC}"
+git fetch --no-tags origin "refs/heads/${expected_branch}:refs/remotes/origin/${expected_branch}"
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "refs/remotes/origin/${expected_branch}")" ]]; then
+  fail "HEAD must match origin/${expected_branch} before tagging"
 fi
 
-# Verify GPG signing is configured (required for signed tags).
-if ! git config --get user.signingkey >/dev/null && ! git config --get tag.gpgsign | grep -qi true; then
-  echo -e "${YELLOW}⚠ GPG tag signing is not configured.${NC}"
-  echo -e "  Run: git config --global user.signingkey <KEY-ID>"
-  echo -e "       git config --global tag.gpgsign true"
-  echo -e "  Falling back to annotated (unsigned) tags. Production releases SHOULD be signed."
-  TAG_FLAG="-a"
-  TAG_MSG_FLAG="-m"
-else
-  TAG_FLAG="-s -a"
-  TAG_MSG_FLAG="-m"
+if [[ -z "$(git config --get user.signingkey || true)" ]]; then
+  fail "configure user.signingkey before creating release tags"
 fi
 
-# Find all module directories
-MODULES=$(find . -name "go.mod" -not -path "*/vendor/*" -not -path "*/.git/*" | sort)
-
-# Tag main module first
-echo -e "\n${YELLOW}▶ Tagging main module: ${VERSION}${NC}"
-FORCE_FLAG=""
-if [ "$FORCE_TAG" = true ]; then
-  FORCE_FLAG="-f"
-fi
-
-if git tag $FORCE_FLAG $TAG_FLAG "$VERSION" $TAG_MSG_FLAG "Release $VERSION" 2>/dev/null; then
-  echo -e "${GREEN}✓ Created tag: ${VERSION}${NC}"
-else
-  if [ "$FORCE_TAG" = false ]; then
-    echo -e "${RED}✗ Tag already exists. Use --force to overwrite.${NC}"
-  else
-    echo -e "${RED}✗ Failed to create tag${NC}"
+CREATED_TAGS=()
+rollback_tags() {
+  status=$?
+  if ((${#CREATED_TAGS[@]} > 0)); then
+    git tag -d "${CREATED_TAGS[@]}" >/dev/null 2>&1 || true
   fi
-fi
+  exit "$status"
+}
+trap rollback_tags ERR INT TERM
 
-# Tag each submodule
-for modfile in $MODULES; do
-  dir=$(dirname "$modfile")
-  
-  # Skip root module (already tagged)
-  if [ "$dir" = "." ]; then
-    continue
-  fi
-  
-  # Remove leading ./
-  module_name="${dir#./}"
-  
-  # Create tag: <module>/<version>
-  tag_name="${module_name}/${VERSION}"
-  
-  echo -e "\n${YELLOW}▶ Tagging submodule: ${module_name} → ${tag_name}${NC}"
-  
-  if git tag $FORCE_FLAG $TAG_FLAG "$tag_name" $TAG_MSG_FLAG "Release ${module_name} ${VERSION}" 2>/dev/null; then
-    echo -e "${GREEN}✓ Created tag: ${tag_name}${NC}"
-  else
-    if [ "$FORCE_TAG" = false ]; then
-      echo -e "${RED}✗ Tag already exists. Use --force to overwrite.${NC}"
-    else
-      echo -e "${RED}✗ Failed to create tag${NC}"
-    fi
-  fi
+for tag in "${TAGS[@]}"; do
+  git tag -s -a "$tag" -m "Release ${tag}"
+  CREATED_TAGS+=("$tag")
 done
 
-# List all version tags
-echo -e "\n${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo -e "${BLUE}  Created Tags${NC}"
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-git tag -l | grep -E "^(${VERSION}|.*/${VERSION})$" || echo "No tags found"
-echo ""
+PUSH_REFS=()
+for tag in "${TAGS[@]}"; do
+  PUSH_REFS+=("refs/tags/${tag}:refs/tags/${tag}")
+done
+git push --atomic origin "${PUSH_REFS[@]}"
 
-# Push tags if requested
-if [ "$PUSH_TAGS" = true ]; then
-  echo -e "${YELLOW}▶ Pushing tags to remote...${NC}"
-  PUSH_FORCE_FLAG=""
-  if [ "$FORCE_TAG" = true ]; then
-    PUSH_FORCE_FLAG="--force"
-  fi
-  
-  if git push origin --tags $PUSH_FORCE_FLAG; then
-    echo -e "${GREEN}✓ Tags pushed successfully${NC}"
-  else
-    echo -e "${RED}✗ Failed to push tags${NC}"
-    exit 1
-  fi
-fi
-
-# Display next steps
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-echo -e "${BLUE}  Next Steps${NC}"
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
-if [ "$PUSH_TAGS" = false ]; then
-  echo -e "1. Review the tags: ${YELLOW}git tag -l${NC}"
-  echo -e "2. Push to remote:  ${YELLOW}git push origin --tags${NC}"
-  echo -e "   Or re-run with:  ${YELLOW}./tag-modules.sh ${VERSION} --push${NC}"
-fi
-echo -e ""
-echo -e "To update dependencies in consuming projects:"
-echo -e "  ${YELLOW}go get -u github.com/kbukum/gokit@${VERSION}${NC}"
-echo -e "  ${YELLOW}go get -u github.com/kbukum/gokit/auth@${VERSION}${NC}"
-echo -e "  ${YELLOW}go get -u github.com/kbukum/gokit/connect@${VERSION}${NC}"
-echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+trap - ERR INT TERM
+echo -e "${GREEN}Created and atomically pushed ${#TAGS[@]} signed module tags for ${VERSION}${NC}"


### PR DESCRIPTION
## Description

Prepares gokit for the `v0.2.0-alpha.1` release line with a signed, source-only GitHub release pipeline. The release scripts now validate prerelease versions, changelog state, module paths, and tag creation before publishing the complete module tag family.

## Motivation

Published module tags and a reproducible release process are required for consumers to resolve stable prerelease versions instead of pseudo-versions. The release workflow now produces signed checksums and SBOM metadata directly from the release artifacts.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Module(s) Affected

- Root release automation and documentation
- `server` and `server/testutil` dependency metadata

## Changes Made

- Added `v0.2.0-alpha.1` changelog and documentation guidance for prerelease consumers.
- Hardened module tag creation with semantic-version, changelog, path, signed-tag, and dry-run validation.
- Configured GoReleaser to publish source archives with checksums, SBOMs, and Sigstore bundles, and aligned the release workflow with prerelease tags.
- Added isolated integration coverage for release-note extraction and module tag publication.

## Testing

- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
- [ ] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [ ] Manual testing performed (describe below if applicable)

### Test Evidence

Not run locally.

## Breaking Changes

None. This establishes the prerelease release process and its validation rules.

## Sibling Parity

- [x] Sibling-parity not required (internal change)
- [ ] Sibling-parity tracked: rskit <url>, pykit <url>
- [ ] Reveals an upstream rskit gap (tagged **IMPROVE-RSKIT** in the description)

## Checklist

- [ ] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [ ] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [ ] Bug fixes include a regression test that fails without the fix
- [ ] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (>=80% pkg, >=85% security-load-bearing) and the CI Codecov gate
- [ ] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [ ] `make tidy` run so go.mod/go.sum are clean for affected modules
- [x] CHANGELOG entry added under `[Unreleased]`
- [x] New dependencies (if any) are justified, minimal, and pass `govulncheck`

## Additional Notes

