### PR TITLE
test(git): stabilize fake-git exec against ETXTBSY race

### DIFF
--- a/git/cli/cli_test.go
+++ b/git/cli/cli_test.go
@@ -3,10 +3,14 @@ package cli
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/kbukum/gokit/git/internal/model"
 	"github.com/kbukum/gokit/process"
@@ -45,10 +49,7 @@ func TestExecRedactsCredentialsFromFailure(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	script := filepath.Join(dir, "fake-git")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'fatal: https://user:secret@example.com/repo.git failed' >&2\nexit 1\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile(fake-git): %v", err)
-	}
+	script := writeFakeGit(t, dir, "#!/bin/sh\necho 'fatal: https://user:secret@example.com/repo.git failed' >&2\nexit 1\n")
 	backend := New(dir, &model.OpenOptions{CLIPath: script, ExtraArgs: []string{"https://arg:secret@example.com/repo.git"}})
 
 	_, err := backend.Exec("fetch", "https://other:secret@example.com/repo.git")
@@ -69,10 +70,7 @@ func TestExecRedactsSensitiveExtraArgs(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	script := filepath.Join(dir, "fake-git")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'fatal: request failed' >&2\nexit 1\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile(fake-git): %v", err)
-	}
+	script := writeFakeGit(t, dir, "#!/bin/sh\necho 'fatal: request failed' >&2\nexit 1\n")
 	const token = "Basic c2VjcmV0LXRva2Vu"
 	backend := New(dir, &model.OpenOptions{
 		CLIPath:   script,
@@ -216,10 +214,7 @@ func TestInspectorInvalidOutput(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
-			script := filepath.Join(dir, "fake-git")
-			if err := os.WriteFile(script, []byte(tc.body), 0o755); err != nil {
-				t.Fatalf("WriteFile(fake-git): %v", err)
-			}
+			script := writeFakeGit(t, dir, tc.body)
 			err := tc.call(New(dir, &model.OpenOptions{CLIPath: script}))
 			if err == nil {
 				t.Fatal("call expected error")
@@ -507,6 +502,34 @@ func TestCleanDryRunDirectoriesAndIgnored(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "build", "out.txt")); err != nil {
 		t.Fatalf("dry-run removed untracked directory file: %v", err)
+	}
+}
+
+// writeFakeGit writes an executable fake-git script into dir and returns its path.
+//
+// A freshly written executable can transiently fail to exec with ETXTBSY ("text
+// file busy") when a concurrent test goroutine forks for its own subprocess and
+// inherits the still-open write descriptor to this file. The helper blocks until
+// the kernel will exec the script so the code under test never observes that race.
+func writeFakeGit(t *testing.T, dir, body string) string {
+	t.Helper()
+
+	script := filepath.Join(dir, "fake-git")
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake-git): %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		// The script exits by design; only ETXTBSY signals the write/exec race,
+		// so any other outcome means the file is runnable.
+		if err := exec.Command(script).Run(); !errors.Is(err, syscall.ETXTBSY) {
+			return script
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("fake-git remained text-file-busy")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix a spurious CI failure that intermittently breaks unrelated PRs (e.g. Dependabot #267, #274) in the `Check (Go 1.26.0)` job.
- The `git/cli` redaction and inspector tests write a `fake-git` executable and immediately exec it under `t.Parallel()`. A concurrent test goroutine that forks for its own subprocess can inherit the still-open write descriptor to that freshly created file, so the kernel rejects the exec with `ETXTBSY` ("text file busy") and the assertion fails before any real behavior runs.
- Route the three write sites through one shared `writeFakeGit` helper that writes the script and then blocks until the kernel will exec it, retrying **only** on `ETXTBSY` (any other outcome means the file is runnable, so nothing is masked).

## Review context

- Root-cause fix in the test setup, not a retry bolted onto production `process` exec — production does not write-then-exec binaries, so the race lives entirely in the test.
- The helper distinguishes the race (`ETXTBSY`) from genuine failures via `errors.Is(err, syscall.ETXTBSY)`; a real exec/format error returns immediately and the test surfaces it as before.
- Bounded 10s deadline with a 5ms backoff; the window is normally sub-millisecond.
- Observed failures this fixes: `TestExecRedactsCredentialsFromFailure`, `TestExecRedactsSensitiveExtraArgs`, and `TestInspectorInvalidOutput` — all `fork/exec .../fake-git: text file busy`.

## Type of change

- [x] Tests or fixtures

## Validation

- [x] Relevant targeted tests

```
$ go test ./git/cli/ -run 'TestExec|TestInspectorInvalidOutput' -race -shuffle=on -count=20
ok  github.com/kbukum/gokit/git/cli  16.069s

$ go test ./git/cli/ -race -shuffle=on -count=1
ok  github.com/kbukum/gokit/git/cli  2.123s
```

## Risk and rollout

Test-only change; no production surface touched. Once merged to `main`, rebase/re-run the affected Dependabot PRs to clear their `Check (Go 1.26.0)` failures.
