### PR TITLE
ci: group dependabot PRs and auto-tidy modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    open-pull-requests-limit: 20
     groups:
       actions:
         patterns:
@@ -22,6 +23,17 @@ updates:
   # Dependabot does NOT read go.work; directories must be listed explicitly.
   # The wildcard globs below auto-discover modules at 1-level and 2-level depth
   # so new modules are picked up without editing this file.
+  #
+  # Grouping strategy — collapse the weekly PR fan-out:
+  #   * Semantic groups (golang-x, otel, grpc, google-cloud, aws, k8s) bundle a
+  #     vendor family into ONE PR that spans every directory it appears in.
+  #   * The `go-dependencies` catch-all bundles *everything else* (testify,
+  #     nats.go, …) into a single non-major PR across all modules, instead of
+  #     one PR per module. A dependency lands in the FIRST group it matches, so
+  #     the catch-all only sweeps up what the semantic groups leave behind.
+  #   * Major bumps fall through to individual PRs so a breaking change is
+  #     reviewed on its own.
+  #   * Security fixes ship immediately in their own fast-lane PR.
   - package-ecosystem: "gomod"
     directories:
       - "/"           # root module
@@ -38,32 +50,53 @@ updates:
     labels:
       - "dependencies"
       - "go"
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
     groups:
+      # Security updates always ship in their own PR (fast lane).
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       golang-x:
+        applies-to: version-updates
         patterns:
           - "golang.org/x/*"
       otel:
+        applies-to: version-updates
         patterns:
           - "go.opentelemetry.io/*"
       grpc:
+        applies-to: version-updates
         patterns:
           - "google.golang.org/grpc"
           - "google.golang.org/grpc/*"
           - "google.golang.org/genproto/*"
           - "google.golang.org/protobuf"
+      google-cloud:
+        applies-to: version-updates
+        patterns:
+          - "cloud.google.com/go"
+          - "cloud.google.com/go/*"
+          - "google.golang.org/api"
       aws:
+        applies-to: version-updates
         patterns:
           - "github.com/aws/*"
       k8s:
+        applies-to: version-updates
         patterns:
           - "k8s.io/*"
-      # Security updates always ship in their own PR (fast lane).
-      security-updates:
-        applies-to: security-updates
+      # Catch-all: every remaining Go dependency (testify, nats.go, …) collapses
+      # into ONE grouped PR spanning all directories. Non-major only — majors get
+      # individual PRs for isolated review.
+      go-dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,0 +1,59 @@
+name: Dependabot Auto-Tidy
+
+# Dependabot bumps a dependency in a single module, but this is a go.work
+# monorepo wired with cross-module `replace` directives: a shared or transitive
+# dependency change leaves sibling modules' go.sum stale, which trips the
+# Preflight "modules are tidy" gate. Dependabot never runs a workspace-wide
+# `go mod tidy`, so this workflow does it and pushes the fix back onto the PR.
+#
+# For the follow-up commit to re-trigger the required CI checks, the push must
+# use a token other than the default GITHUB_TOKEN (GitHub suppresses workflow
+# runs for GITHUB_TOKEN pushes to avoid loops). Provide a fine-grained PAT or a
+# GitHub App token as the `DEPENDABOT_TIDY_TOKEN` secret with `contents: write`
+# on this repo. Without it the tidy commit still lands, but Preflight must be
+# re-run manually (or via `@dependabot recreate`).
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-tidy-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    name: Tidy modules
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.DEPENDABOT_TIDY_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Tidy all modules
+        run: ./gomod.sh tidy
+
+      - name: Commit and push if go.mod/go.sum changed
+        run: |
+          if [ -z "$(git status --porcelain -- '*.mod' '*.sum')" ]; then
+            echo "Modules already tidy — nothing to do."
+            exit 0
+          fi
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add -- '*.mod' '*.sum'
+          git commit -m "build: go mod tidy across modules"
+          git push origin HEAD:"${{ github.head_ref }}"


### PR DESCRIPTION
## Description

Reworks the Dependabot setup so the weekly update queue stays small and its PRs pass CI unattended. The `gomod` ecosystem gains a catch-all group and a `google-cloud` group so dependencies without a dedicated group no longer fan out into one PR per module, and a new `dependabot-tidy` workflow runs a workspace-wide `go mod tidy` on Dependabot PRs so cross-module `go.sum` drift doesn't trip the Preflight tidy gate.

## Motivation

Weekly Dependabot runs produced a large, noisy queue: dependencies not covered by a semantic group (e.g. `testify`, `nats.go`, `cloud.google.com/go/auth`, `google.golang.org/api`) opened a separate PR in every module that pins them, and some of those PRs failed CI. The failures were all on Preflight's "modules are tidy" step: this is a `go.work` monorepo with cross-module `replace` directives, so a bump in one module leaves sibling modules' `go.sum` stale, and Dependabot never runs a workspace-wide tidy.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Module(s) Affected

- Repository CI / dependency automation (`.github/`) — no Go modules changed

## Changes Made

- Add a `go-dependencies` catch-all group (minor/patch) that collapses every otherwise-ungrouped dependency into a single grouped PR spanning all directories; majors still open individually.
- Add a `google-cloud` group (`cloud.google.com/go*`, `google.golang.org/api`) to bundle those frequent co-bumps.
- Pin the semantic groups to `applies-to: version-updates` so the `security-updates` fast lane stays isolated, and order the catch-all last so specific groups win.
- Add `.github/workflows/dependabot-tidy.yml`: on Dependabot PRs it runs `./gomod.sh tidy` and pushes the result back, keeping the Preflight tidy gate green.

## Testing

- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
- [ ] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [x] Manual testing performed (describe below if applicable)

### Test Evidence

CI-configuration-only change (no Go sources). Both YAML files validated with `yaml.safe_load`; group precedence and `applies-to` semantics reviewed against the Dependabot options reference.

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Checklist

- [x] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [ ] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [ ] Bug fixes include a regression test that fails without the fix
- [ ] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI Codecov gate
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [ ] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] `make tidy` run so go.mod/go.sum are clean for affected modules
- [ ] CHANGELOG entry added under `[Unreleased]`
- [x] New dependencies (if any) are justified, minimal, and pass `govulncheck`

## Additional Notes

For the auto-tidy commit to re-trigger the required Preflight check, add a fine-grained PAT or GitHub App token as the `DEPENDABOT_TIDY_TOKEN` secret with `contents: write` (a push by the default `GITHUB_TOKEN` does not spawn new workflow runs). Without it the tidy commit still lands, but Preflight must be re-run manually (or via `@dependabot recreate`). Existing open PRs will re-group under the new rules after `@dependabot recreate`.
