### PR TITLE
chore: bump Toven to v0.1.0-alpha.7 and pin compute_budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ permissions:
 # the same `command`-ecosystem task the Makefile uses (`toven run structure`).
 # Kept in lock-step with .github/workflows/toven-canary.yml; bump both together.
 env:
-  TOVEN_VERSION: v0.1.0-alpha.6
+  TOVEN_VERSION: v0.1.0-alpha.7
 
 # All third-party actions are pinned by 40-char SHA. Dependabot is configured
 # (see .github/dependabot.yml) to bump both the SHA and the trailing version
@@ -266,7 +266,7 @@ jobs:
         id: toven
         # Pinned by immutable commit SHA; `version` independently pins the
         # installed binary (dual pin, both required). Same pin as toven-canary.yml.
-        uses: kbukum/toven/.github/actions/toven@2efe3c7321a76a9e338656438f167ced87866815 # kbukum/toven install-and-run action
+        uses: kbukum/toven/.github/actions/toven@c74531b0745dec78fa4d82795d77ccd5e26a80cb # v0.1.0-alpha.7
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/.github/workflows/toven-canary.yml
+++ b/.github/workflows/toven-canary.yml
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   # Pin the canary to an immutable published Toven release. Bump deliberately.
-  TOVEN_VERSION: v0.1.0-alpha.6
+  TOVEN_VERSION: v0.1.0-alpha.7
 
 jobs:
   canary:
@@ -57,7 +57,7 @@ jobs:
         # contract: on a cache miss it installs cosign and verifies the archive
         # checksum and the Sigstore signature over SHA256SUMS before extraction;
         # a version-exact cache hit reuses the already-verified binary.
-        uses: kbukum/toven/.github/actions/toven@2efe3c7321a76a9e338656438f167ced87866815 # kbukum/toven install-and-run action
+        uses: kbukum/toven/.github/actions/toven@c74531b0745dec78fa4d82795d77ccd5e26a80cb # v0.1.0-alpha.7
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/toven.toml
+++ b/toven.toml
@@ -3,6 +3,17 @@ name = "gokit"
 root = "."
 base_ref = "origin/main"
 
+# Bound per-tool CPU parallelism during APPLY fan-out. gokit's `test`/`build`/
+# `lint` tasks fan out one `go` process per module (50 modules) across the
+# worker pool; left unbounded, every child defaults its own `GOMAXPROCS` to the
+# whole machine and peak thread pressure climbs toward cores², thrashing the
+# host. `auto` sizes a host-CPU budget and splits it across each concurrent
+# wave, injecting each child's share via `GOMAXPROCS` (never argv). This is the
+# default value; it is set explicitly here to document the intent. Use
+# `inherit` (or `0`) to opt out and restore unbounded per-tool parallelism.
+[toven]
+compute_budget = "auto"
+
 # Smart defaults fill in tasks, run strategy, and toolchain probes.
 # Uncomment to override, e.g.:
 #   run_strategy = "leaf-to-top"


### PR DESCRIPTION
## Description

Bump gokit's Toven pins to the published prerelease `v0.1.0-alpha.7` and land the `[toven] compute_budget = "auto"` intent in `toven.toml`.

## Motivation

Keep gokit's Toven-driven CI guardrail and self-hosting canary in lock-step with the newly published Toven release, and document/enable the per-tool CPU budget that bounds the Go fan-out during `toven run` waves (prevents `GOMAXPROCS`-per-child thread pressure climbing toward cores²).

## Type of Change

- [x] Refactoring (no functional changes)

## Module(s) Affected

- CI workflows (`ci.yml`, `toven-canary.yml`), `toven.toml`

## Changes Made

- `TOVEN_VERSION: v0.1.0-alpha.6` → `v0.1.0-alpha.7` in `ci.yml` and `toven-canary.yml`.
- `kbukum/toven/.github/actions/toven@2efe3c73…` → `@c74531b0745dec78fa4d82795d77ccd5e26a80cb` (v0.1.0-alpha.7), trailing comment updated to reference the version.
- `toven.toml`: explicit `[toven] compute_budget = "auto"`.

## Testing

Exercised against a locally-installed `toven 0.1.0-alpha.7` (`cargo install --path ../toven/apps/toven --force`):

- [x] `toven modules`, `toven tasks`, `toven doctor` (3 checked, 0 missing) all green.
- [x] `toven plan test` / `plan build` / `plan lint` — status ok.
- [x] `toven run test` — 50/50 ok (46 ran, 4 cached); `--no-cache` re-run 50/50 ok.
- [x] `make toven-canary` — green (modules, graph, release status/plan preview fail-closed as expected before first Go release).
- [x] Compute budget verified: on a 12-CPU host, fan-out bounded to 12 concurrent `go` processes each with `GOMAXPROCS=2` injected via env (not argv); peak ~51–56 child threads — well under cores² (144).

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (CI/config bump; rskit gets the same alpha.7 SHA in a parallel PR).

## Additional Notes

Toven-usage audit: gokit's everyday `make` dev gates route the whole workspace through Toven; CI's Go-version-matrix build/test/lint/govulncheck/licenses legs stay **native by design**, as documented in `docs/TOVEN-MIGRATION.md` with tracked upstream gaps. No silent bypass introduced.
