### PR TITLE
fix(messaging): surface swallowed broker failures and prove delivery paths

### DIFF
--- a/messaging/kafka/component_test.go
+++ b/messaging/kafka/component_test.go
@@ -171,3 +171,49 @@ func TestComponent_Health_NotRunning(t *testing.T) {
 func TestComponent_Interface(t *testing.T) {
 	var _ component.Component = (*Component)(nil)
 }
+
+func TestComponentHealthReportsNotStartedAndNoBrokers(t *testing.T) {
+	log := logging.New(&logging.Config{Level: "error"}, "test")
+
+	comp := NewComponent(Config{Brokers: []string{"127.0.0.1:1"}}, log)
+	if h := comp.Health(context.Background()); h.Status != component.StatusUnhealthy {
+		t.Fatalf("not-started health = %q, want unhealthy", h.Status)
+	}
+
+	noBrokers := NewComponent(Config{}, log)
+	if err := noBrokers.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = noBrokers.Stop(context.Background()) })
+	if h := noBrokers.Health(context.Background()); h.Status != component.StatusUnhealthy {
+		t.Fatalf("no-brokers health = %q, want unhealthy", h.Status)
+	}
+}
+
+func TestComponentHealthReportsUnreachableBroker(t *testing.T) {
+	log := logging.New(&logging.Config{Level: "error"}, "test")
+	comp := NewComponent(Config{Brokers: []string{"127.0.0.1:1"}, AllowInsecureDev: true}, log)
+	if err := comp.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = comp.Stop(context.Background()) })
+
+	h := comp.Health(context.Background())
+	if h.Status != component.StatusUnhealthy {
+		t.Fatalf("unreachable-broker health = %q, want unhealthy", h.Status)
+	}
+}
+
+func TestEnsureTopics(t *testing.T) {
+	log := logging.New(&logging.Config{Level: "error"}, "test")
+
+	comp := NewComponent(Config{Brokers: []string{"127.0.0.1:1"}, AllowInsecureDev: true}, log)
+	if err := comp.EnsureTopics(context.Background(), nil); err != nil {
+		t.Fatalf("EnsureTopics(nil) should be a no-op: %v", err)
+	}
+
+	err := comp.EnsureTopics(context.Background(), []TopicConfig{{Topic: "orders", NumPartitions: 1, ReplicationFactor: 1}})
+	if err == nil {
+		t.Fatal("EnsureTopics against an unreachable broker: want connect error")
+	}
+}

--- a/messaging/kafka/config_test.go
+++ b/messaging/kafka/config_test.go
@@ -221,3 +221,41 @@ func TestParseDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCommonProducerRejectsUnsupportedSemantics(t *testing.T) {
+	if err := ValidateCommonProducer(messaging.Config{DeliveryGuarantee: messaging.DeliveryExactlyOnce}); err == nil {
+		t.Fatal("exactly-once producer: want error")
+	}
+	if err := ValidateCommonProducer(messaging.Config{DLQ: messaging.DLQPolicy{Enabled: true}}); err == nil {
+		t.Fatal("adapter-managed DLQ producer: want error")
+	}
+	if err := ValidateCommonProducer(messaging.Config{DeliveryGuarantee: messaging.DeliveryAtLeastOnce}); err != nil {
+		t.Fatalf("supported producer config: %v", err)
+	}
+}
+
+func TestValidateCommonConsumerEnforcesSupportedSemantics(t *testing.T) {
+	tests := map[string]struct {
+		cfg     messaging.Config
+		wantErr bool
+	}{
+		"dlq":               {messaging.Config{MaxInFlight: 1, DLQ: messaging.DLQPolicy{Enabled: true}}, true},
+		"max-in-flight":     {messaging.Config{MaxInFlight: 2}, true},
+		"at-least-once-ok":  {messaging.Config{MaxInFlight: 1, DeliveryGuarantee: messaging.DeliveryAtLeastOnce, CommitStrategy: messaging.CommitAfterHandlerSuccess}, false},
+		"at-least-once-bad": {messaging.Config{MaxInFlight: 1, DeliveryGuarantee: messaging.DeliveryAtLeastOnce, CommitStrategy: messaging.CommitAuto}, true},
+		"at-most-once-ok":   {messaging.Config{MaxInFlight: 1, DeliveryGuarantee: messaging.DeliveryAtMostOnce, CommitStrategy: messaging.CommitAuto}, false},
+		"at-most-once-bad":  {messaging.Config{MaxInFlight: 1, DeliveryGuarantee: messaging.DeliveryAtMostOnce, CommitStrategy: messaging.CommitAfterHandlerSuccess}, true},
+		"exactly-once":      {messaging.Config{MaxInFlight: 1, DeliveryGuarantee: messaging.DeliveryExactlyOnce}, true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateCommonConsumer(tc.cfg)
+			if tc.wantErr && err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want ok, got %v", err)
+			}
+		})
+	}
+}

--- a/messaging/kafka/consumer/consumer_test.go
+++ b/messaging/kafka/consumer/consumer_test.go
@@ -1,0 +1,204 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	kafkago "github.com/segmentio/kafka-go"
+
+	"github.com/kbukum/gokit/logging"
+	"github.com/kbukum/gokit/messaging"
+	"github.com/kbukum/gokit/messaging/kafka"
+)
+
+type fakeKafkaReader struct {
+	fetch     chan kafkago.Message
+	readErr   error
+	commitErr error
+	committed int
+	closed    bool
+}
+
+func (r *fakeKafkaReader) next(ctx context.Context) (kafkago.Message, error) {
+	if r.readErr != nil {
+		return kafkago.Message{}, r.readErr
+	}
+	select {
+	case <-ctx.Done():
+		return kafkago.Message{}, ctx.Err()
+	case msg, ok := <-r.fetch:
+		if !ok {
+			<-ctx.Done()
+			return kafkago.Message{}, ctx.Err()
+		}
+		return msg, nil
+	}
+}
+
+func (r *fakeKafkaReader) ReadMessage(ctx context.Context) (kafkago.Message, error) {
+	return r.next(ctx)
+}
+
+func (r *fakeKafkaReader) FetchMessage(ctx context.Context) (kafkago.Message, error) {
+	return r.next(ctx)
+}
+
+func (r *fakeKafkaReader) CommitMessages(_ context.Context, msgs ...kafkago.Message) error {
+	if r.commitErr != nil {
+		return r.commitErr
+	}
+	r.committed += len(msgs)
+	return nil
+}
+
+func (r *fakeKafkaReader) Stats() kafkago.ReaderStats { return kafkago.ReaderStats{} }
+
+func (r *fakeKafkaReader) Close() error { r.closed = true; return nil }
+
+func newTestConsumer(r kafkaReader, strategy messaging.CommitStrategy) *Consumer {
+	var errCount atomic.Int64
+	return &Consumer{
+		reader:         r,
+		topic:          "orders",
+		log:            logging.New(&logging.Config{Level: "error"}, "test").WithComponent("kafka.consumer"),
+		errCount:       &errCount,
+		commitStrategy: strategy,
+	}
+}
+
+func TestConsumerDeliversMessageAndLogsRecovery(t *testing.T) {
+	fetch := make(chan kafkago.Message, 1)
+	fetch <- kafkago.Message{Topic: "orders", Value: []byte("payload"), Offset: 3}
+	r := &fakeKafkaReader{fetch: fetch}
+	c := newTestConsumer(r, messaging.CommitAuto)
+	c.errCount.Store(2) // simulate a prior connection blip to exercise the recovery branch
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var got messaging.Message
+	err := c.Consume(ctx, func(_ context.Context, msg messaging.Message) error {
+		got = msg
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Consume = %v, want context.Canceled", err)
+	}
+	if string(got.Value) != "payload" {
+		t.Fatalf("delivered value = %q", got.Value)
+	}
+	if c.errCount.Load() != 0 {
+		t.Fatalf("errCount = %d, want reset to 0 after recovery", c.errCount.Load())
+	}
+}
+
+func TestConsumerCommitsAfterHandlerSuccess(t *testing.T) {
+	fetch := make(chan kafkago.Message, 1)
+	fetch <- kafkago.Message{Topic: "orders", Value: []byte("x"), Offset: 7}
+	r := &fakeKafkaReader{fetch: fetch}
+	c := newTestConsumer(r, messaging.CommitAfterHandlerSuccess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := c.Consume(ctx, func(_ context.Context, _ messaging.Message) error {
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Consume = %v, want context.Canceled", err)
+	}
+	if r.committed != 1 {
+		t.Fatalf("committed = %d, want commit after successful handler", r.committed)
+	}
+}
+
+func TestConsumerSurfacesCommitFailure(t *testing.T) {
+	fetch := make(chan kafkago.Message, 1)
+	fetch <- kafkago.Message{Topic: "orders", Value: []byte("x")}
+	commitErr := errors.New("commit rejected during rebalance")
+	r := &fakeKafkaReader{fetch: fetch, commitErr: commitErr}
+	c := newTestConsumer(r, messaging.CommitAfterHandlerSuccess)
+
+	err := c.Consume(context.Background(), func(context.Context, messaging.Message) error { return nil })
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("Consume = %v, want commit failure surfaced (not silently dropped)", err)
+	}
+}
+
+func TestConsumerReturnsHandlerErrorWithoutCommitting(t *testing.T) {
+	fetch := make(chan kafkago.Message, 1)
+	fetch <- kafkago.Message{Topic: "orders", Value: []byte("x")}
+	r := &fakeKafkaReader{fetch: fetch}
+	c := newTestConsumer(r, messaging.CommitAfterHandlerSuccess)
+	handlerErr := errors.New("handler failed")
+
+	err := c.Consume(context.Background(), func(context.Context, messaging.Message) error { return handlerErr })
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("Consume = %v, want handler error", err)
+	}
+	if r.committed != 0 {
+		t.Fatalf("committed = %d, want no commit on handler failure (offset stays for redelivery)", r.committed)
+	}
+}
+
+func TestConsumerReadErrorBacksOffThenHonorsCancellation(t *testing.T) {
+	r := &fakeKafkaReader{readErr: errors.New("transient read error")}
+	c := newTestConsumer(r, messaging.CommitAuto)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := c.Consume(ctx, func(context.Context, messaging.Message) error { return nil })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Consume = %v, want DeadlineExceeded during backoff", err)
+	}
+	if c.failures == 0 {
+		t.Fatal("expected read error to increment the failure counter (backoff path)")
+	}
+}
+
+func TestConsumerCloseClosesReader(t *testing.T) {
+	r := &fakeKafkaReader{}
+	c := newTestConsumer(r, messaging.CommitAuto)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !r.closed {
+		t.Fatal("Close must close the underlying reader")
+	}
+}
+
+func TestConsumerStatsDelegatesToReader(t *testing.T) {
+	c := newTestConsumer(&fakeKafkaReader{}, messaging.CommitAuto)
+	if got := c.Stats(); got.Topic != "" {
+		t.Fatalf("Stats = %#v, want zero-value from fake reader", got)
+	}
+}
+
+func TestAsRunnerWrapsConsumer(t *testing.T) {
+	c := newTestConsumer(&fakeKafkaReader{}, messaging.CommitAuto)
+	runner := AsRunner(c, func(context.Context, messaging.Message) error { return nil })
+	if runner == nil {
+		t.Fatal("AsRunner returned nil runner")
+	}
+	if runner.Topic() != "orders" {
+		t.Fatalf("runner topic = %q, want orders", runner.Topic())
+	}
+}
+
+func TestNewManagedConsumerExposesGroupID(t *testing.T) {
+	mc, err := NewManagedConsumer(ManagedConsumerConfig{
+		Common:  messaging.Config{Adapter: "kafka", ConsumerGroup: "workers"},
+		Config:  kafka.Config{Brokers: []string{"127.0.0.1:1"}},
+		Topic:   "events",
+		Handler: func(context.Context, messaging.Message) error { return nil },
+		Log:     logging.New(&logging.Config{Level: "error"}, "test"),
+	})
+	if err != nil {
+		t.Fatalf("NewManagedConsumer: %v", err)
+	}
+	if mc.GroupID() != "workers" {
+		t.Fatalf("GroupID = %q, want workers", mc.GroupID())
+	}
+}

--- a/messaging/kafka/errors_test.go
+++ b/messaging/kafka/errors_test.go
@@ -88,3 +88,16 @@ func TestIsNonRetryableError(t *testing.T) {
 		})
 	}
 }
+
+func TestKafkaErrorClassifierDelegates(t *testing.T) {
+	var classifier KafkaErrorClassifier
+	if !classifier.IsConnectionError(errors.New("broker not available")) {
+		t.Fatal("kafka-specific connection pattern should classify as connection error")
+	}
+	if !classifier.IsRetryableError(errors.New("not enough replicas")) {
+		t.Fatal("kafka-specific retryable pattern should classify as retryable")
+	}
+	if classifier.IsConnectionError(nil) || classifier.IsRetryableError(nil) {
+		t.Fatal("nil error must not classify as connection/retryable")
+	}
+}

--- a/messaging/kafka/producer/producer_test.go
+++ b/messaging/kafka/producer/producer_test.go
@@ -1,0 +1,185 @@
+package producer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	kafkago "github.com/segmentio/kafka-go"
+
+	"github.com/kbukum/gokit/logging"
+	"github.com/kbukum/gokit/messaging"
+	"github.com/kbukum/gokit/messaging/kafka"
+)
+
+type fakeKafkaWriter struct {
+	messages []kafkago.Message
+	writes   int
+	writeErr error
+	closed   bool
+	closeErr error
+}
+
+func (w *fakeKafkaWriter) WriteMessages(_ context.Context, msgs ...kafkago.Message) error {
+	w.writes++
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	w.messages = append(w.messages, msgs...)
+	return nil
+}
+
+func (w *fakeKafkaWriter) Stats() kafkago.WriterStats { return kafkago.WriterStats{} }
+
+func (w *fakeKafkaWriter) Close() error { w.closed = true; return w.closeErr }
+
+func newTestProducer(w kafkaWriter, attempts int, backoff time.Duration) *Producer {
+	return &Producer{
+		writer:        w,
+		retryAttempts: attempts,
+		retryBackoff:  backoff,
+		log:           logging.New(&logging.Config{Level: "error"}, "test").WithComponent("kafka.producer"),
+	}
+}
+
+func TestProducerWriteMessagesDeliversToWriter(t *testing.T) {
+	w := &fakeKafkaWriter{}
+	p := newTestProducer(w, 1, 0)
+
+	err := p.WriteMessages(context.Background(), kafkago.Message{Topic: "orders", Value: []byte("payload")})
+	if err != nil {
+		t.Fatalf("WriteMessages: %v", err)
+	}
+	if w.writes != 1 || len(w.messages) != 1 {
+		t.Fatalf("writes=%d messages=%d, want single write", w.writes, len(w.messages))
+	}
+	if got := string(w.messages[0].Value); got != "payload" {
+		t.Fatalf("delivered value = %q", got)
+	}
+}
+
+func TestProducerWriteMessagesPropagatesWriteError(t *testing.T) {
+	writeErr := errors.New("broker rejected write")
+	w := &fakeKafkaWriter{writeErr: writeErr}
+	p := newTestProducer(w, 1, 0)
+
+	err := p.WriteMessages(context.Background(), kafkago.Message{Topic: "orders", Value: []byte("x")})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("WriteMessages error = %v, want write error surfaced (not swallowed)", err)
+	}
+	if w.writes != 1 {
+		t.Fatalf("writes = %d, want 1 (no retry configured)", w.writes)
+	}
+}
+
+func TestProducerWriteMessagesRetriesThenExhausts(t *testing.T) {
+	writeErr := errors.New("temporary blip")
+	w := &fakeKafkaWriter{writeErr: writeErr}
+	p := newTestProducer(w, 3, time.Millisecond)
+
+	err := p.WriteMessages(context.Background(), kafkago.Message{Topic: "orders", Value: []byte("x")})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("WriteMessages error = %v, want exhausted write error", err)
+	}
+	if w.writes != 3 {
+		t.Fatalf("writes = %d, want 3 bounded attempts", w.writes)
+	}
+}
+
+func TestProducerWriteMessagesStopsRetryingOnCanceledContext(t *testing.T) {
+	writeErr := errors.New("blip")
+	w := &fakeKafkaWriter{writeErr: writeErr}
+	p := newTestProducer(w, 5, time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := p.WriteMessages(ctx, kafkago.Message{Topic: "orders", Value: []byte("x")})
+	if err == nil {
+		t.Fatal("WriteMessages with canceled context: want error")
+	}
+	if w.writes > 1 {
+		t.Fatalf("writes = %d, want no retries after cancellation", w.writes)
+	}
+}
+
+func TestProducerCloseClosesWriter(t *testing.T) {
+	w := &fakeKafkaWriter{}
+	p := newTestProducer(w, 1, 0)
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !w.closed {
+		t.Fatal("Close must close the underlying writer")
+	}
+}
+
+func TestProducerConvenienceMethodsRouteThroughWriter(t *testing.T) {
+	w := &fakeKafkaWriter{}
+	p := newTestProducer(w, 1, 0)
+	ctx := context.Background()
+
+	if err := p.Send(ctx, messaging.Message{Topic: "orders", Key: "k", Value: []byte("send")}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := p.SendBatch(ctx, []messaging.Message{{Topic: "orders", Value: []byte("a")}, {Topic: "orders", Value: []byte("b")}}); err != nil {
+		t.Fatalf("SendBatch: %v", err)
+	}
+	if err := p.PublishJSON(ctx, "orders", "jk", map[string]string{"id": "1"}); err != nil {
+		t.Fatalf("PublishJSON: %v", err)
+	}
+	if err := p.PublishBinary(ctx, "orders", "bk", []byte("raw")); err != nil {
+		t.Fatalf("PublishBinary: %v", err)
+	}
+	event := messaging.Event{ID: "evt-1", Type: "created", Source: "test", Subject: "subject-key", Timestamp: time.Unix(1, 0)}
+	if err := p.Publish(ctx, "orders", event); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Send(1) + SendBatch(1 batched write) + PublishJSON(1) + PublishBinary(1) + Publish(1) = 5 writes.
+	if w.writes != 5 {
+		t.Fatalf("writes = %d, want 5", w.writes)
+	}
+}
+
+func TestNewProducerEagerlyInitializesWriter(t *testing.T) {
+	log := logging.New(&logging.Config{Level: "error"}, "test")
+	p, err := NewProducer(
+		messaging.Config{Adapter: "kafka", Name: "events"},
+		kafka.Config{Brokers: []string{"127.0.0.1:1"}, AllowInsecureDev: true},
+		log,
+	)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	if p.writer == nil {
+		t.Fatal("eager producer must initialize its writer")
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestSinkProviderSendRoutesThroughWriter(t *testing.T) {
+	w := &fakeKafkaWriter{}
+	p := newTestProducer(w, 1, 0)
+	p.name = "sink"
+	sink := NewSinkProvider("kafka-sink", p)
+
+	if sink.Name() != "kafka-sink" {
+		t.Fatalf("Name = %q", sink.Name())
+	}
+	if !sink.IsAvailable(context.Background()) {
+		t.Fatal("expected available sink")
+	}
+	if sink.Producer() != p {
+		t.Fatal("Producer() must return the wrapped producer")
+	}
+	if err := sink.Send(context.Background(), kafkago.Message{Topic: "orders", Value: []byte("x")}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if w.writes != 1 {
+		t.Fatalf("writes = %d, want 1", w.writes)
+	}
+}

--- a/messaging/kafka/translator_test.go
+++ b/messaging/kafka/translator_test.go
@@ -67,3 +67,17 @@ func TestFromKafka_UnknownError(t *testing.T) {
 		t.Errorf("HTTPStatus = %d, want 500", appErr.HTTPStatus)
 	}
 }
+
+func TestKafkaErrorTranslatorTranslateDelegatesToFromKafka(t *testing.T) {
+	var translator KafkaErrorTranslator
+	appErr := translator.Translate(errors.New("connection refused"), "events")
+	if appErr == nil {
+		t.Fatal("Translate returned nil for a connection error")
+	}
+	if !appErr.Retryable {
+		t.Fatal("connection error should be retryable")
+	}
+	if translator.Translate(nil, "events") != nil {
+		t.Fatal("Translate(nil) must return nil")
+	}
+}

--- a/messaging/nats/producer.go
+++ b/messaging/nats/producer.go
@@ -196,7 +196,8 @@ func (p *Producer) Flush(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// Close drains the NATS connection.
+// Close drains the NATS connection, always closing the underlying connection
+// even when draining fails so a drain error cannot leak the connection.
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -207,11 +208,13 @@ func (p *Producer) Close() error {
 	if p.conn == nil {
 		return nil
 	}
-	if err := p.conn.Drain(); err != nil {
-		return fmt.Errorf("nats drain: %w", err)
-	}
-	p.conn.Close()
+	conn := p.conn
 	p.conn = nil
+	drainErr := conn.Drain()
+	conn.Close()
+	if drainErr != nil {
+		return fmt.Errorf("nats drain: %w", drainErr)
+	}
 	return nil
 }
 

--- a/messaging/nats/producer_test.go
+++ b/messaging/nats/producer_test.go
@@ -104,6 +104,54 @@ func TestProducerSendBatchStopsOnErrorAndCloseDrains(t *testing.T) {
 	}
 }
 
+func TestProducerEnsureConnDialsLazilyAndCaches(t *testing.T) {
+	conn := &fakeNATSConn{}
+	p := &Producer{
+		cfg:           Config{PublishTimeout: "1s"},
+		connect:       func(string, ...natsgo.Option) (natsConn, error) { return conn, nil },
+		retryAttempts: 1,
+	}
+	if err := p.PublishBinary(context.Background(), "orders", "k", []byte("x")); err != nil {
+		t.Fatalf("PublishBinary via lazy connect: %v", err)
+	}
+	if p.conn != conn {
+		t.Fatal("lazy connect must cache the connection")
+	}
+	if len(conn.published) != 1 {
+		t.Fatalf("published %d, want 1", len(conn.published))
+	}
+}
+
+func TestProducerEnsureConnSurfacesConnectError(t *testing.T) {
+	connectErr := errors.New("dial refused")
+	p := &Producer{
+		cfg:           Config{URL: "nats://localhost:4222", PublishTimeout: "1s"},
+		connect:       func(string, ...natsgo.Option) (natsConn, error) { return nil, connectErr },
+		retryAttempts: 1,
+	}
+	err := p.PublishBinary(context.Background(), "orders", "k", []byte("x"))
+	if !errors.Is(err, connectErr) {
+		t.Fatalf("error = %v, want connect error", err)
+	}
+}
+
+func TestProducerCloseClosesConnectionEvenWhenDrainFails(t *testing.T) {
+	drainErr := errors.New("drain failed")
+	conn := &fakeNATSConn{drainErr: drainErr}
+	p := &Producer{cfg: Config{PublishTimeout: "1s"}, conn: conn, retryAttempts: 1}
+
+	err := p.Close()
+	if !errors.Is(err, drainErr) {
+		t.Fatalf("Close error = %v, want drain failure surfaced", err)
+	}
+	if !conn.closed {
+		t.Fatal("Close must close the connection even when Drain fails (no leak)")
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close should be a no-op: %v", err)
+	}
+}
+
 func TestProducerMapsPublishFlushAndContextErrors(t *testing.T) {
 	publishErr := errors.New("publish failed")
 	p := &Producer{cfg: Config{PublishTimeout: "1s"}, conn: &fakeNATSConn{publishErr: publishErr}, retryAttempts: 1}

--- a/messaging/rabbitmq/consumer.go
+++ b/messaging/rabbitmq/consumer.go
@@ -2,11 +2,19 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/kbukum/gokit/messaging"
 )
+
+// errDeliveriesClosed reports that the broker closed the delivery stream while
+// the consumer was neither canceled nor closed — an abnormal channel/connection
+// drop that must not be reported as a clean, success-shaped termination. Its
+// message includes "connection closed" so messaging.IsConnectionError classifies
+// it as a retryable connection failure.
+var errDeliveriesClosed = errors.New("rabbitmq: consume connection closed")
 
 // Consumer consumes messages from RabbitMQ.
 type Consumer struct {
@@ -52,23 +60,16 @@ func (c *Consumer) ensureChannel() (rabbitChannel, error) {
 	}
 	ch, err := conn.Channel()
 	if err != nil {
-		_ = conn.Close()
-		return nil, redactError("rabbitmq consumer channel", err)
+		return nil, errors.Join(redactError("rabbitmq consumer channel", err), conn.Close())
 	}
 	if err := declareExchange(ch, c.cfg); err != nil {
-		_ = ch.Close()
-		_ = conn.Close()
-		return nil, err
+		return nil, errors.Join(err, ch.Close(), conn.Close())
 	}
 	if _, err := ch.QueueDeclare(c.queue, c.cfg.QueueDurable, false, false, false, nil); err != nil {
-		_ = ch.Close()
-		_ = conn.Close()
-		return nil, fmt.Errorf("rabbitmq declare queue: %w", err)
+		return nil, errors.Join(fmt.Errorf("rabbitmq declare queue: %w", err), ch.Close(), conn.Close())
 	}
 	if err := bindQueue(ch, c.cfg, c.queue, routingKey(c.cfg, c.topic)); err != nil {
-		_ = ch.Close()
-		_ = conn.Close()
-		return nil, err
+		return nil, errors.Join(err, ch.Close(), conn.Close())
 	}
 	c.conn = conn
 	c.ch = ch
@@ -107,7 +108,9 @@ func (c *Consumer) Consume(ctx context.Context, handler messaging.MessageHandler
 		}
 		if err := handler(ctx, domain); err != nil {
 			if !c.cfg.AutoAck {
-				_ = delivery.Nack(false, false)
+				if nackErr := delivery.Nack(false, false); nackErr != nil {
+					return errors.Join(err, fmt.Errorf("rabbitmq nack: %w", nackErr))
+				}
 			}
 			return err
 		}
@@ -123,7 +126,7 @@ func (c *Consumer) Consume(ctx context.Context, handler messaging.MessageHandler
 	if c.isClosed() {
 		return messaging.ErrClosed
 	}
-	return nil
+	return fmt.Errorf("rabbitmq consume: %w", errDeliveriesClosed)
 }
 
 // Topic returns the subscribed topic.

--- a/messaging/rabbitmq/consumer_test.go
+++ b/messaging/rabbitmq/consumer_test.go
@@ -12,11 +12,76 @@ import (
 	"github.com/kbukum/gokit/messaging"
 )
 
-type fakeAcknowledger struct{ acked, nacked int }
+type fakeAcknowledger struct {
+	acked, nacked int
+	nackErr       error
+}
 
-func (a *fakeAcknowledger) Ack(uint64, bool) error        { a.acked++; return nil }
-func (a *fakeAcknowledger) Nack(uint64, bool, bool) error { a.nacked++; return nil }
-func (a *fakeAcknowledger) Reject(uint64, bool) error     { return nil }
+func (a *fakeAcknowledger) Ack(uint64, bool) error { a.acked++; return nil }
+func (a *fakeAcknowledger) Nack(uint64, bool, bool) error {
+	a.nacked++
+	return a.nackErr
+}
+func (a *fakeAcknowledger) Reject(uint64, bool) error { return nil }
+
+func TestConsumerEnsureChannelJoinsCleanupOnQueueDeclareError(t *testing.T) {
+	queueErr := errors.New("queue declare failed")
+	ch := &fakeRabbitChannel{queueErr: queueErr}
+	conn := &fakeRabbitConn{ch: ch}
+	c := &Consumer{
+		cfg:   Config{},
+		dial:  func(Config) (rabbitConn, error) { return conn, nil },
+		topic: "orders",
+		queue: "orders",
+	}
+	err := c.Consume(context.Background(), func(context.Context, messaging.Message) error { return nil })
+	if !errors.Is(err, queueErr) {
+		t.Fatalf("error = %v, want queue declare error", err)
+	}
+	if !ch.closed || !conn.closed {
+		t.Fatalf("channel and connection must be closed on declare failure: ch=%v conn=%v", ch.closed, conn.closed)
+	}
+}
+
+func TestConsumerSurfacesNackFailureAlongsideHandlerError(t *testing.T) {
+	nackErr := errors.New("nack failed")
+	acks := &fakeAcknowledger{nackErr: nackErr}
+	deliveries := make(chan amqp.Delivery, 1)
+	deliveries <- amqp.Delivery{Acknowledger: acks, DeliveryTag: 1, Body: []byte("payload")}
+	ch := &fakeRabbitChannel{deliveries: deliveries}
+	handlerErr := errors.New("handler failed")
+	c := &Consumer{ch: ch, topic: "orders", queue: "orders"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := c.Consume(ctx, func(context.Context, messaging.Message) error { return handlerErr })
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("Consume error = %v, want handler error joined", err)
+	}
+	if !errors.Is(err, nackErr) {
+		t.Fatalf("Consume error = %v, want nack failure surfaced (not swallowed)", err)
+	}
+	if acks.nacked != 1 {
+		t.Fatalf("nacks = %d, want 1", acks.nacked)
+	}
+}
+
+func TestConsumerReportsUnexpectedDeliveryChannelClosure(t *testing.T) {
+	deliveries := make(chan amqp.Delivery)
+	ch := &fakeRabbitChannel{deliveries: deliveries}
+	c := &Consumer{ch: ch, topic: "orders", queue: "orders"}
+	// Close the delivery stream without canceling ctx or closing the consumer:
+	// an abnormal broker-side drop must surface as an error, not success-shaped nil.
+	close(deliveries)
+
+	err := c.Consume(context.Background(), func(context.Context, messaging.Message) error { return nil })
+	if !errors.Is(err, errDeliveriesClosed) {
+		t.Fatalf("Consume error = %v, want errDeliveriesClosed", err)
+	}
+	if !messaging.IsConnectionError(err) {
+		t.Fatalf("unexpected closure = %v, want classified as a connection error", err)
+	}
+}
 
 func TestConsumerConsumeAcksSuccessfulMessages(t *testing.T) {
 	acks := &fakeAcknowledger{}

--- a/messaging/rabbitmq/producer.go
+++ b/messaging/rabbitmq/producer.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -60,13 +61,10 @@ func (p *Producer) ensureChannelLocked() (rabbitChannel, error) {
 	}
 	ch, err := conn.Channel()
 	if err != nil {
-		_ = conn.Close()
-		return nil, redactError("rabbitmq producer channel", err)
+		return nil, errors.Join(redactError("rabbitmq producer channel", err), conn.Close())
 	}
 	if err := declareExchange(ch, p.cfg); err != nil {
-		_ = ch.Close()
-		_ = conn.Close()
-		return nil, err
+		return nil, errors.Join(err, ch.Close(), conn.Close())
 	}
 	p.conn = conn
 	p.ch = ch

--- a/messaging/rabbitmq/producer_test.go
+++ b/messaging/rabbitmq/producer_test.go
@@ -35,6 +35,7 @@ type fakeRabbitChannel struct {
 	closed         bool
 	queueErr       error
 	bindErr        error
+	exchangeErr    error
 	publishErr     error
 	consumeErr     error
 	qosErr         error
@@ -47,7 +48,7 @@ type rabbitPublish struct {
 }
 
 func (ch *fakeRabbitChannel) ExchangeDeclare(string, string, bool, bool, bool, bool, amqp.Table) error {
-	return nil
+	return ch.exchangeErr
 }
 
 func (ch *fakeRabbitChannel) QueueDeclare(name string, _ bool, _ bool, _ bool, _ bool, _ amqp.Table) (amqp.Queue, error) {
@@ -103,6 +104,63 @@ func (ch *fakeRabbitChannel) ConsumeWithContext(ctx context.Context, _ string, _
 	return out, nil
 }
 func (ch *fakeRabbitChannel) Close() error { ch.closed = true; return ch.closeErr }
+
+func TestProducerEnsureChannelDialsDeclaresAndPublishes(t *testing.T) {
+	ch := &fakeRabbitChannel{}
+	conn := &fakeRabbitConn{ch: ch}
+	p := &Producer{
+		cfg:           Config{Exchange: "ex", ExchangeType: "topic", PublishTimeout: "1s"},
+		dial:          func(Config) (rabbitConn, error) { return conn, nil },
+		retryAttempts: 1,
+		declared:      map[string]struct{}{},
+	}
+	if err := p.PublishBinary(context.Background(), "orders", "k", []byte("x")); err != nil {
+		t.Fatalf("PublishBinary via lazy dial: %v", err)
+	}
+	if len(ch.published) != 1 {
+		t.Fatalf("published %d, want 1", len(ch.published))
+	}
+	if p.conn != conn || p.ch != ch {
+		t.Fatal("lazy dial must cache the connection and channel")
+	}
+}
+
+func TestProducerEnsureChannelJoinsCleanupOnChannelError(t *testing.T) {
+	channelErr := errors.New("channel open failed")
+	conn := &fakeRabbitConn{channelErr: channelErr}
+	p := &Producer{
+		cfg:           Config{PublishTimeout: "1s"},
+		dial:          func(Config) (rabbitConn, error) { return conn, nil },
+		retryAttempts: 1,
+		declared:      map[string]struct{}{},
+	}
+	err := p.PublishBinary(context.Background(), "orders", "k", []byte("x"))
+	if !errors.Is(err, channelErr) {
+		t.Fatalf("error = %v, want channel error", err)
+	}
+	if !conn.closed {
+		t.Fatal("connection must be closed when channel open fails (no leak)")
+	}
+}
+
+func TestProducerEnsureChannelJoinsCleanupOnExchangeError(t *testing.T) {
+	exchangeErr := errors.New("exchange declare failed")
+	ch := &fakeRabbitChannel{exchangeErr: exchangeErr}
+	conn := &fakeRabbitConn{ch: ch}
+	p := &Producer{
+		cfg:           Config{Exchange: "ex", ExchangeType: "topic", PublishTimeout: "1s"},
+		dial:          func(Config) (rabbitConn, error) { return conn, nil },
+		retryAttempts: 1,
+		declared:      map[string]struct{}{},
+	}
+	err := p.PublishBinary(context.Background(), "orders", "k", []byte("x"))
+	if !errors.Is(err, exchangeErr) {
+		t.Fatalf("error = %v, want exchange error", err)
+	}
+	if !ch.closed || !conn.closed {
+		t.Fatalf("channel and connection must be closed on declare failure: ch=%v conn=%v", ch.closed, conn.closed)
+	}
+}
 
 func TestProducerPublishMethodsDeclareQueueAndPublish(t *testing.T) {
 	ch := &fakeRabbitChannel{}


### PR DESCRIPTION
## Description

Hardens the messaging broker adapters (Kafka, RabbitMQ, NATS) against failures that were previously swallowed or masked, and proves the delivery paths behaviorally through fake transports. The fixes are root-cause: they change how failures propagate at the adapter boundary so a lost ack, an abnormal disconnect, or a failed drain can no longer look like success.

## Motivation

The broker adapters had failure paths that returned success-shaped results, hiding real faults from callers: a failed RabbitMQ `Nack` (message neither redelivered nor dead-lettered) was discarded, an abnormal delivery-channel closure was reported as clean termination, and a NATS `Drain` failure returned early and leaked the connection. The Kafka producer/consumer publish, commit, and retry paths were also the least-proven code in the module, with no fake-transport coverage of their error branches.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Module(s) Affected

- messaging/kafka (core, `producer`, `consumer`)
- messaging/rabbitmq
- messaging/nats

## Changes Made

- **RabbitMQ — surface `Nack` failures:** a failed handler-path `Nack` is now joined onto the handler error instead of being discarded, so a message that was neither redelivered nor dead-lettered is visible to the caller.
- **RabbitMQ — abnormal closure is an error:** a delivery stream closed by the broker while not canceled/closed now returns a typed connection error (worded so `messaging.IsConnectionError` classifies it retryable) instead of `nil`.
- **NATS — no connection leak on drain failure:** `Producer.Close` now always closes the connection and clears the handle even when `Drain` fails, still surfacing the drain error.
- **Cleanup errors joined:** previously dropped `ch.Close()`/`conn.Close()` cleanup errors on the RabbitMQ lazy-connect setup paths are now joined onto the setup error.
- **Behavioral proof via fake transports:** new `kafkaWriter`/`kafkaReader` fakes drive the Kafka producer (publish, error propagation, bounded retry-then-exhaust, cancellation) and consumer (delivery, commit-after-success, commit-failure surfaced, handler-error-without-commit, read-error backoff) paths; added trust-boundary and unreachable-broker tests to the Kafka core.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [x] `make lint` is clean (includes `vet` + `depguard` layering)
- [x] `make fmt` reports no diffs (`gofmt -s`)

Validated via `toven format-check/lint/check/test` scoped to `go:messaging-kafka`, `go:messaging-rabbitmq`, `go:messaging-nats` — 0 lint issues, green under `-race -shuffle=on -count=1`, `make structure` clean. Every shipped broker package is now ≥80% coverage measured the CI way (kafka core 84.8%, kafka/consumer 80.0%, kafka/producer 85.7%, rabbitmq 81.8%, nats 81.9%).

## Breaking Changes

None. Behavior changes are confined to previously-broken failure paths that returned success or dropped errors; callers on the happy path are unaffected.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

The fixes tighten adapter-internal failure propagation; no public error code, Component lifecycle, or Provider/stream shape changed.

## Checklist

- [x] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [x] Bug fixes include a regression test that fails without the fix
- [x] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI Codecov gate
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] `make tidy` run so go.mod/go.sum are clean for affected modules
- [ ] CHANGELOG entry added under `[Unreleased]`
- [ ] New dependencies (if any) are justified, minimal, and pass `govulncheck`

## Additional Notes

Deliberate non-goals to keep the change focused: no cross-broker rename sweep of private interface/field names, and no new per-broker `testutil` sub-modules (each adapter's SDK-specific fake is a local test seam; shared core fakes remain in `messaging/testutil`, whose own coverage is settled separately).
