### PR TITLE
test(ai): harden AI-layer trust-boundary paths and add shared llm fake provider

### DIFF
--- a/agent/memory/policy_test.go
+++ b/agent/memory/policy_test.go
@@ -3,11 +3,14 @@ package memory_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/kbukum/gokit/agent/memory"
+	"github.com/kbukum/gokit/ai"
 	"github.com/kbukum/gokit/ai/chat"
 	"github.com/kbukum/gokit/llm"
+	llmtestutil "github.com/kbukum/gokit/llm/testutil"
 )
 
 func TestRingBuffer(t *testing.T) {
@@ -43,6 +46,70 @@ func TestSlidingWindow(t *testing.T) {
 	}
 }
 
+// TestSlidingWindowDropsUntilFitPreservingSystem proves the drop-until-fit loop
+// removes the oldest non-system messages one at a time and stops as soon as the
+// window fits, keeping the leading system message anchored throughout.
+func TestSlidingWindowDropsUntilFitPreservingSystem(t *testing.T) {
+	msgs := []chat.Message{
+		chat.System("sys"),
+		chat.User("1"), chat.User("2"), chat.User("3"), chat.User("4"),
+	}
+	// Each non-system message counts as 1 token; the system message is free.
+	counter := func(ms []chat.Message) int {
+		n := 0
+		for _, m := range ms {
+			if _, ok := m.(chat.SystemMessage); !ok {
+				n++
+			}
+		}
+		return n
+	}
+	got, err := (memory.SlidingWindow{TokenCounter: counter}).Compact(context.Background(), msgs, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// system + last two non-system messages == 3 messages, within budget 2.
+	if len(got) != 3 {
+		t.Fatalf("expected system + 2 messages, got %d: %#v", len(got), got)
+	}
+	if _, ok := got[0].(chat.SystemMessage); !ok {
+		t.Fatalf("system message must stay first, got %T", got[0])
+	}
+	if u, ok := got[2].(chat.UserMessage); !ok || ai.TextOf(u.Content) != "4" {
+		t.Fatalf("last message unexpected: %#v", got[2])
+	}
+}
+
+// TestSlidingWindowKeepsLastWhenSingleMessageStillTooLarge proves the loop
+// terminates and returns the anchored system plus the final message even when
+// no window satisfies the budget, rather than looping unbounded.
+func TestSlidingWindowKeepsLastWhenSingleMessageStillTooLarge(t *testing.T) {
+	msgs := []chat.Message{chat.System("sys"), chat.User("1"), chat.User("2"), chat.User("3")}
+	got, err := (memory.SlidingWindow{TokenCounter: func([]chat.Message) int { return 999 }}).Compact(context.Background(), msgs, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected system + last message, got %d", len(got))
+	}
+	if _, ok := got[0].(chat.SystemMessage); !ok {
+		t.Fatalf("system message must be preserved, got %T", got[0])
+	}
+}
+
+// TestSlidingWindowNoSystemMessage covers the branch where there is no leading
+// system message to anchor.
+func TestSlidingWindowNoSystemMessage(t *testing.T) {
+	msgs := []chat.Message{chat.User("1"), chat.User("2"), chat.User("3")}
+	got, err := (memory.SlidingWindow{TokenCounter: func([]chat.Message) int { return 999 }}).Compact(context.Background(), msgs, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected single last message, got %d", len(got))
+	}
+}
+
 func TestFail(t *testing.T) {
 	if _, err := (memory.Fail{}).Compact(context.Background(), nil, 0); !errors.Is(err, memory.ErrContextExceeded) {
 		t.Fatalf("fail strategy err=%v", err)
@@ -51,7 +118,11 @@ func TestFail(t *testing.T) {
 
 func TestSummarize(t *testing.T) {
 	msgs := []chat.Message{chat.System("sys"), chat.User("old"), chat.Assistant("recent")}
-	p := &summaryProvider{text: "summary"}
+	p := llmtestutil.NewFakeProvider(llmtestutil.WithResponder(
+		func(_ context.Context, _ llm.CompletionRequest) (llm.CompletionResponse, error) {
+			return llmtestutil.TextResponse("summary"), nil
+		},
+	))
 	got, err := (memory.Summarize{Provider: p, KeepLast: 1}).Compact(context.Background(), msgs, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -68,21 +139,113 @@ func TestSummarize(t *testing.T) {
 	}
 }
 
-// summaryProvider is a minimal llm.Provider returning a fixed completion.
-type summaryProvider struct{ text string }
-
-func (p *summaryProvider) Name() string                       { return "summary" }
-func (p *summaryProvider) IsAvailable(_ context.Context) bool { return true }
-func (p *summaryProvider) Execute(_ context.Context, _ llm.CompletionRequest) (llm.CompletionResponse, error) {
-	return llm.CompletionResponse{Message: chat.Assistant(p.text), StopReason: chat.FinishReasonStop}, nil
+// TestSummarizeIncludesAllRoleTranscripts proves the pre-summary transcript
+// renders user, assistant, and tool-result turns before handing them to the
+// provider, and that the returned summary is anchored after the system message.
+func TestSummarizeIncludesAllRoleTranscripts(t *testing.T) {
+	msgs := []chat.Message{
+		chat.System("sys"),
+		chat.User("question"),
+		chat.Assistant("answer"),
+		chat.ToolResultMsg("call_1", "tool output", false),
+		chat.User("recent-1"),
+		chat.User("recent-2"),
+	}
+	var captured string
+	p := llmtestutil.NewFakeProvider(llmtestutil.WithResponder(
+		func(_ context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			captured = transcriptOf(req)
+			return llmtestutil.TextResponse("SUMMARY"), nil
+		},
+	))
+	got, err := (memory.Summarize{Provider: p, KeepLast: 2}).Compact(context.Background(), msgs, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got[0].(chat.SystemMessage); !ok {
+		t.Fatalf("system message must remain first, got %T", got[0])
+	}
+	sm, ok := got[1].(chat.SystemMessage)
+	if !ok || sm.Content == "" {
+		t.Fatalf("summary must be inserted as a system message, got %#v", got[1])
+	}
+	for _, want := range []string{"User: question", "Assistant: answer", "Tool(call_1): tool output"} {
+		if !strings.Contains(captured, want) {
+			t.Fatalf("transcript missing %q; got:\n%s", want, captured)
+		}
+	}
 }
 
-func (p *summaryProvider) Stream(_ context.Context, _ llm.CompletionRequest) (<-chan llm.StreamEvent, error) {
-	ch := make(chan llm.StreamEvent)
-	close(ch)
-	return ch, nil
+// TestSummarizeFallsBackWhenProviderFails proves a provider error keeps the
+// recent messages verbatim (no summary injected) rather than failing the turn.
+func TestSummarizeFallsBackWhenProviderFails(t *testing.T) {
+	msgs := []chat.Message{
+		chat.System("sys"),
+		chat.User("old"),
+		chat.User("recent-1"),
+		chat.User("recent-2"),
+	}
+	p := llmtestutil.NewFakeProvider(llmtestutil.WithError(errors.New("provider unavailable")))
+	got, err := (memory.Summarize{Provider: p, KeepLast: 2}).Compact(context.Background(), msgs, 0)
+	if err != nil {
+		t.Fatalf("provider failure must not fail compaction: %v", err)
+	}
+	// system + 2 recent, no summary message inserted.
+	if len(got) != 3 {
+		t.Fatalf("expected system + 2 recent, got %d", len(got))
+	}
+	if _, ok := got[1].(chat.SystemMessage); ok {
+		t.Fatal("no summary should be inserted when the provider fails")
+	}
 }
-func (p *summaryProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
-func (p *summaryProvider) CountTokens(msgs []chat.Message) int {
-	return chat.CountTokensApprox(msgs)
+
+// transcriptOf extracts the rendered conversation transcript the Summarize
+// policy sends to the provider (a single user message carrying the transcript).
+func transcriptOf(req llm.CompletionRequest) string {
+	var b strings.Builder
+	for _, m := range req.Messages {
+		if u, ok := m.(chat.UserMessage); ok {
+			b.WriteString(ai.TextOf(u.Content))
+		}
+	}
+	return b.String()
+}
+
+// TestRingBufferDefaultKeepAndNoSystem covers the default KeepLast (20) and the
+// no-leading-system branch of RingBuffer.
+func TestRingBufferDefaultKeepAndNoSystem(t *testing.T) {
+	// KeepLast<=0 defaults to 20: a 5-message history is returned unchanged.
+	short := []chat.Message{chat.User("1"), chat.User("2"), chat.User("3")}
+	got, err := (memory.RingBuffer{}).Compact(context.Background(), short, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("default keep dropped messages: got %d", len(got))
+	}
+
+	// Without a leading system message, only the last KeepLast are kept.
+	msgs := []chat.Message{chat.User("1"), chat.User("2"), chat.User("3")}
+	got, err = (memory.RingBuffer{KeepLast: 1}).Compact(context.Background(), msgs, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got))
+	}
+	if _, ok := got[0].(chat.SystemMessage); ok {
+		t.Fatal("no system message should be synthesized")
+	}
+}
+
+// TestTruncateSmallHistoryUnchanged covers the below-threshold branch.
+func TestTruncateSmallHistoryUnchanged(t *testing.T) {
+	msgs := []chat.Message{chat.User("1"), chat.User("2")}
+	got, err := (memory.Truncate{KeepLast: 5}).Compact(context.Background(), msgs, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected unchanged history, got %d", len(got))
+	}
 }

--- a/agent/memory/store_test.go
+++ b/agent/memory/store_test.go
@@ -2,6 +2,7 @@ package memory_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -265,5 +266,64 @@ func TestSlidingWindowStore_Clear(t *testing.T) {
 	loaded, _ := sw.Load(ctx, "s1")
 	if loaded != nil {
 		t.Errorf("expected nil after clear, got %v", loaded)
+	}
+}
+
+// TestMapStore_DeepCopyToolCallsAndVariants proves Save/Load deep-copy the raw
+// JSON of assistant tool-call arguments and tool-use content blocks, so a later
+// mutation of the caller's bytes cannot corrupt stored history, and that system
+// and tool-result message variants survive the round trip.
+func TestMapStore_DeepCopyToolCallsAndVariants(t *testing.T) {
+	store := memory.NewMapStore()
+	ctx := context.Background()
+
+	input := json.RawMessage(`{"q":"go"}`)
+	original := []chat.Message{
+		chat.System("system prompt"),
+		chat.AssistantMessage{
+			Content:   []ai.ContentPart{ai.ToolUseBlock{ID: "c1", Name: "search", Input: json.RawMessage(`{"c":1}`)}},
+			ToolCalls: []ai.ToolUseBlock{{ID: "c1", Name: "search", Input: input}},
+			Usage:     &ai.Usage{InputTokens: 5},
+		},
+		chat.ToolResultMsg("c1", "result body", false),
+	}
+	if err := store.Save(ctx, "s1", original); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Mutate the caller's argument bytes after saving; stored copy must be intact.
+	for i := range input {
+		input[i] = 'X'
+	}
+
+	loaded, err := store.Load(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(loaded))
+	}
+	if _, ok := loaded[0].(chat.SystemMessage); !ok {
+		t.Errorf("msg[0] = %T, want SystemMessage", loaded[0])
+	}
+	asst, ok := loaded[1].(chat.AssistantMessage)
+	if !ok {
+		t.Fatalf("msg[1] = %T, want AssistantMessage", loaded[1])
+	}
+	if got := string(asst.ToolCalls[0].Input); got != `{"q":"go"}` {
+		t.Errorf("tool-call input aliased caller bytes: got %q", got)
+	}
+	if got := string(asst.Content[0].(ai.ToolUseBlock).Input); got != `{"c":1}` {
+		t.Errorf("tool-use content block not preserved: got %q", got)
+	}
+	if asst.Usage == nil || asst.Usage.InputTokens != 5 {
+		t.Errorf("usage not copied: %#v", asst.Usage)
+	}
+	// The copied usage pointer must be distinct from the original.
+	if asst.Usage == original[1].(chat.AssistantMessage).Usage {
+		t.Error("usage pointer was aliased, not deep-copied")
+	}
+	if tr, ok := loaded[2].(chat.ToolResultMessage); !ok || tr.Content != "result body" {
+		t.Errorf("msg[2] = %#v, want ToolResultMessage", loaded[2])
 	}
 }

--- a/ai/lifecycle_test.go
+++ b/ai/lifecycle_test.go
@@ -1,0 +1,74 @@
+package ai_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kbukum/gokit/ai"
+)
+
+func TestLifecycleReadyTransitions(t *testing.T) {
+	t.Parallel()
+	var lc ai.Lifecycle
+
+	if lc.Ready() {
+		t.Fatal("zero-value lifecycle must not be ready")
+	}
+	if !lc.LastCall().IsZero() {
+		t.Fatalf("zero-value LastCall must be zero, got %v", lc.LastCall())
+	}
+
+	lc.MarkReady()
+	if !lc.Ready() {
+		t.Fatal("MarkReady must make the lifecycle ready")
+	}
+
+	lc.MarkStopped()
+	if lc.Ready() {
+		t.Fatal("MarkStopped must clear readiness")
+	}
+
+	// A restart returns to ready (stopped flag cleared).
+	lc.MarkReady()
+	if !lc.Ready() {
+		t.Fatal("MarkReady after stop must restore readiness")
+	}
+}
+
+func TestLifecycleTouchRecordsLastCall(t *testing.T) {
+	t.Parallel()
+	var lc ai.Lifecycle
+
+	before := time.Now()
+	lc.Touch()
+	last := lc.LastCall()
+	if last.Before(before) {
+		t.Fatalf("Touch must record a timestamp at or after the call, got %v < %v", last, before)
+	}
+}
+
+// TestLifecycleConcurrentAccess proves the mixin is race-free under concurrent
+// readers and writers (run under -race).
+func TestLifecycleConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	var lc ai.Lifecycle
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			if id%2 == 0 {
+				lc.MarkReady()
+				lc.Touch()
+			} else {
+				lc.MarkStopped()
+			}
+			_ = lc.Ready()
+			_ = lc.LastCall()
+		}(i)
+	}
+	wg.Wait()
+}

--- a/ai/stream_test.go
+++ b/ai/stream_test.go
@@ -1,0 +1,52 @@
+package ai_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kbukum/gokit/ai"
+)
+
+func TestStreamErrorWrapsCause(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("upstream reset")
+	streamErr := ai.Error{Err: cause}
+
+	if streamErr.Error() != "upstream reset" {
+		t.Fatalf("Error() = %q, want %q", streamErr.Error(), "upstream reset")
+	}
+	if !errors.Is(streamErr, cause) {
+		t.Fatal("errors.Is must unwrap the terminal stream error to its cause")
+	}
+	if got := streamErr.Unwrap(); !errors.Is(got, cause) {
+		t.Fatalf("Unwrap() = %v, want %v", got, cause)
+	}
+}
+
+func TestStreamErrorNilCause(t *testing.T) {
+	t.Parallel()
+	var streamErr ai.Error
+	if streamErr.Error() != "ai: unknown stream error" {
+		t.Fatalf("nil-cause Error() = %q", streamErr.Error())
+	}
+	if streamErr.Unwrap() != nil {
+		t.Fatal("nil-cause Unwrap() must be nil")
+	}
+}
+
+// TestStreamEventVariantsSeal proves each concrete stream event satisfies the
+// sealed StreamEvent interface and carries its payload.
+func TestStreamEventVariantsSeal(t *testing.T) {
+	t.Parallel()
+	events := []ai.StreamEvent{
+		ai.TextDelta{Index: 1, Text: "hi"},
+		ai.UsageDelta{InputTokens: 2, OutputTokens: 3},
+		ai.Error{Err: errors.New("x")},
+	}
+	if td, ok := events[0].(ai.TextDelta); !ok || td.Text != "hi" {
+		t.Fatalf("event[0] = %#v", events[0])
+	}
+	if ud, ok := events[1].(ai.UsageDelta); !ok || ud.OutputTokens != 3 {
+		t.Fatalf("event[1] = %#v", events[1])
+	}
+}

--- a/llm/testutil/doc.go
+++ b/llm/testutil/doc.go
@@ -1,0 +1,16 @@
+// Package testutil provides deterministic test doubles for the gokit/llm
+// package so tests across the AI layer (llm, agent, mcp, embedding consumers)
+// share one hardened fake provider instead of hand-rolling per-test mocks.
+//
+// [FakeProvider] implements [llm.Provider] and is configured with functional
+// options: a fixed or queued set of responses, a dynamic responder, an injected
+// error, capabilities, a token counter, and a block-until-cancel mode for
+// exercising context cancellation. It is safe for concurrent use.
+//
+// Example:
+//
+//	p := testutil.NewFakeProvider(
+//		testutil.WithResponses(testutil.TextResponse("hello")),
+//	)
+//	resp, err := p.Execute(ctx, llm.CompletionRequest{})
+package testutil

--- a/llm/testutil/provider.go
+++ b/llm/testutil/provider.go
@@ -1,0 +1,175 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/kbukum/gokit/ai/chat"
+	"github.com/kbukum/gokit/llm"
+)
+
+// FakeProvider is a deterministic, concurrency-safe [llm.Provider] test double.
+//
+// Configure it with functional options. Response selection resolves in order:
+// an injected error is returned first; then a dynamic responder if set; then the
+// next queued response; otherwise an error signaling the queue is exhausted.
+// Block-until-cancel mode overrides all of these and waits for ctx cancellation.
+type FakeProvider struct {
+	name         string
+	caps         llm.Capabilities
+	tokenCounter func([]chat.Message) int
+
+	err           error
+	responder     func(context.Context, llm.CompletionRequest) (llm.CompletionResponse, error)
+	blockOnCancel bool
+
+	mu        sync.Mutex
+	responses []llm.CompletionResponse
+	queueIdx  int
+	calls     int
+	lastReq   llm.CompletionRequest
+}
+
+// FakeOption configures a [FakeProvider].
+type FakeOption func(*FakeProvider)
+
+// WithName sets the provider name reported by Name.
+func WithName(name string) FakeOption {
+	return func(p *FakeProvider) { p.name = name }
+}
+
+// WithResponses queues responses returned by successive Execute/Stream calls.
+func WithResponses(responses ...llm.CompletionResponse) FakeOption {
+	return func(p *FakeProvider) { p.responses = responses }
+}
+
+// WithResponder installs a dynamic response function, evaluated per call.
+// It takes precedence over queued responses.
+func WithResponder(fn func(context.Context, llm.CompletionRequest) (llm.CompletionResponse, error)) FakeOption {
+	return func(p *FakeProvider) { p.responder = fn }
+}
+
+// WithError makes every Execute/Stream call fail with err.
+func WithError(err error) FakeOption {
+	return func(p *FakeProvider) { p.err = err }
+}
+
+// WithCapabilities overrides the reported capabilities.
+func WithCapabilities(caps llm.Capabilities) FakeOption {
+	return func(p *FakeProvider) { p.caps = caps }
+}
+
+// WithTokenCounter overrides the CountTokens implementation.
+func WithTokenCounter(fn func([]chat.Message) int) FakeOption {
+	return func(p *FakeProvider) { p.tokenCounter = fn }
+}
+
+// WithBlockUntilCancel makes Execute block until ctx is canceled, then return
+// ctx.Err(); Stream propagates the same cancellation. Used to exercise timeout
+// and cancellation paths deterministically without sleeps.
+func WithBlockUntilCancel() FakeOption {
+	return func(p *FakeProvider) { p.blockOnCancel = true }
+}
+
+// NewFakeProvider builds a FakeProvider with sensible defaults (streaming and
+// tool-use capable, approximate token counting), overridden by opts.
+func NewFakeProvider(opts ...FakeOption) *FakeProvider {
+	p := &FakeProvider{
+		name: "fake",
+		caps: llm.Capabilities{
+			Streaming:       true,
+			ToolUse:         true,
+			MaxInputTokens:  100000,
+			MaxOutputTokens: 4096,
+		},
+		tokenCounter: chat.CountTokensApprox,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Name reports the configured provider name.
+func (p *FakeProvider) Name() string { return p.name }
+
+// IsAvailable always reports true.
+func (p *FakeProvider) IsAvailable(context.Context) bool { return true }
+
+// Execute returns the next configured response, honoring cancellation.
+func (p *FakeProvider) Execute(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+	if p.blockOnCancel {
+		<-ctx.Done()
+		return llm.CompletionResponse{}, ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return llm.CompletionResponse{}, err
+	}
+
+	p.mu.Lock()
+	p.lastReq = req
+	p.calls++
+	p.mu.Unlock()
+
+	if p.err != nil {
+		return llm.CompletionResponse{}, p.err
+	}
+	if p.responder != nil {
+		return p.responder(ctx, req)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.queueIdx >= len(p.responses) {
+		return llm.CompletionResponse{}, fmt.Errorf("testutil: fake provider has no more responses (call %d)", p.calls)
+	}
+	resp := p.responses[p.queueIdx]
+	p.queueIdx++
+	return resp, nil
+}
+
+// Stream returns the next response as a two-event stream (usage then the
+// assembled completion). An Execute error surfaces as a Stream setup error.
+func (p *FakeProvider) Stream(ctx context.Context, req llm.CompletionRequest) (<-chan llm.StreamEvent, error) {
+	resp, err := p.Execute(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.UsageDelta{InputTokens: resp.Usage.InputTokens, OutputTokens: resp.Usage.OutputTokens}
+	ch <- llm.MessageComplete{Response: resp}
+	close(ch)
+	return ch, nil
+}
+
+// Capabilities reports the configured capabilities.
+func (p *FakeProvider) Capabilities() llm.Capabilities { return p.caps }
+
+// CountTokens counts tokens with the configured counter.
+func (p *FakeProvider) CountTokens(messages []chat.Message) int {
+	return p.tokenCounter(messages)
+}
+
+// Calls reports how many times Execute has been invoked.
+func (p *FakeProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// LastRequest returns the most recent request passed to Execute.
+func (p *FakeProvider) LastRequest() llm.CompletionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastReq
+}
+
+// TextResponse builds a CompletionResponse carrying a single assistant text
+// message and a stop finish reason — the common case for a fake completion.
+func TextResponse(text string) llm.CompletionResponse {
+	return llm.CompletionResponse{
+		Message:    chat.Assistant(text),
+		StopReason: chat.FinishReasonStop,
+	}
+}

--- a/llm/testutil/provider_test.go
+++ b/llm/testutil/provider_test.go
@@ -1,0 +1,116 @@
+package testutil_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kbukum/gokit/ai/chat"
+	"github.com/kbukum/gokit/llm"
+	"github.com/kbukum/gokit/llm/testutil"
+)
+
+func TestFakeProviderQueuedResponses(t *testing.T) {
+	t.Parallel()
+	p := testutil.NewFakeProvider(
+		testutil.WithName("q"),
+		testutil.WithResponses(testutil.TextResponse("one"), testutil.TextResponse("two")),
+	)
+	if p.Name() != "q" || !p.IsAvailable(context.Background()) {
+		t.Fatalf("name/availability = %q/%v", p.Name(), p.IsAvailable(context.Background()))
+	}
+	first, err := p.Execute(context.Background(), llm.CompletionRequest{})
+	if err != nil || first.Text() != "one" {
+		t.Fatalf("first = %q, %v", first.Text(), err)
+	}
+	second, err := p.Execute(context.Background(), llm.CompletionRequest{})
+	if err != nil || second.Text() != "two" {
+		t.Fatalf("second = %q, %v", second.Text(), err)
+	}
+	if _, err := p.Execute(context.Background(), llm.CompletionRequest{}); err == nil {
+		t.Fatal("exhausted queue must return an error")
+	}
+	if p.Calls() != 3 {
+		t.Fatalf("Calls() = %d, want 3", p.Calls())
+	}
+}
+
+func TestFakeProviderInjectedError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("provider down")
+	p := testutil.NewFakeProvider(testutil.WithError(sentinel))
+	if _, err := p.Execute(context.Background(), llm.CompletionRequest{}); !errors.Is(err, sentinel) {
+		t.Fatalf("Execute err = %v, want %v", err, sentinel)
+	}
+	if _, err := p.Stream(context.Background(), llm.CompletionRequest{}); !errors.Is(err, sentinel) {
+		t.Fatalf("Stream err = %v, want %v", err, sentinel)
+	}
+}
+
+func TestFakeProviderResponderReceivesRequest(t *testing.T) {
+	t.Parallel()
+	p := testutil.NewFakeProvider(testutil.WithResponder(
+		func(_ context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			return testutil.TextResponse("saw:" + req.SystemPrompt), nil
+		},
+	))
+	resp, err := p.Execute(context.Background(), llm.CompletionRequest{SystemPrompt: "hi"})
+	if err != nil || resp.Text() != "saw:hi" {
+		t.Fatalf("responder = %q, %v", resp.Text(), err)
+	}
+	if got := p.LastRequest().SystemPrompt; got != "hi" {
+		t.Fatalf("LastRequest = %q", got)
+	}
+}
+
+func TestFakeProviderStreamEmitsUsageThenComplete(t *testing.T) {
+	t.Parallel()
+	resp := testutil.TextResponse("hello")
+	resp.Usage = llm.Usage{InputTokens: 3, OutputTokens: 2}
+	p := testutil.NewFakeProvider(testutil.WithResponses(resp))
+	ch, err := p.Stream(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	var events []llm.StreamEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if _, ok := events[0].(llm.UsageDelta); !ok {
+		t.Fatalf("event[0] = %T, want UsageDelta", events[0])
+	}
+	done, ok := events[1].(llm.MessageComplete)
+	if !ok || done.Response.Text() != "hello" {
+		t.Fatalf("event[1] = %#v", events[1])
+	}
+}
+
+func TestFakeProviderBlockUntilCancel(t *testing.T) {
+	t.Parallel()
+	p := testutil.NewFakeProvider(testutil.WithBlockUntilCancel())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := p.Execute(ctx, llm.CompletionRequest{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("blocked execute err = %v, want context.Canceled", err)
+	}
+}
+
+func TestFakeProviderCapabilitiesAndTokens(t *testing.T) {
+	t.Parallel()
+	p := testutil.NewFakeProvider(
+		testutil.WithCapabilities(llm.Capabilities{JSONMode: true}),
+		testutil.WithTokenCounter(func([]chat.Message) int { return 42 }),
+	)
+	if !p.Capabilities().JSONMode {
+		t.Fatal("capabilities override lost")
+	}
+	if got := p.CountTokens([]chat.Message{chat.User("x")}); got != 42 {
+		t.Fatalf("CountTokens = %d, want 42", got)
+	}
+}
+
+// FakeProvider must satisfy llm.Provider at compile time.
+var _ llm.Provider = (*testutil.FakeProvider)(nil)

--- a/mcp/handlers/interactive_test.go
+++ b/mcp/handlers/interactive_test.go
@@ -1,0 +1,251 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kbukum/gokit/authz"
+	"github.com/kbukum/gokit/mcp/security"
+	"github.com/kbukum/gokit/schema"
+)
+
+// finalResult builds a completed (non-round-trip) interactive tool result.
+func finalResult(text string) *sdkmcp.CallToolResult {
+	return &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}},
+	}
+}
+
+// invokeInteractive drives the hardened interactive handler once with the given
+// arguments and (optional) input responses, asserting no protocol-level error.
+func invokeInteractive(t *testing.T, h *Handler, toolName string, inputSchema schema.JSON, fn InteractiveToolHandler, params *sdkmcp.CallToolParamsRaw) *sdkmcp.CallToolResult {
+	t.Helper()
+	handler := h.interactiveToolHandler(toolName, toolName, inputSchema, fn)
+	res, err := handler(context.Background(), &sdkmcp.CallToolRequest{Params: params})
+	if err != nil {
+		t.Fatalf("interactive handler returned protocol error (must be nil): %v", err)
+	}
+	if res == nil {
+		t.Fatal("interactive handler returned nil result")
+	}
+	return res
+}
+
+func okInteractive(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+	return finalResult("done"), nil
+}
+
+func TestInteractiveHandlerSuccess(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	res := invokeInteractive(t, h, "chat", nil, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat", Arguments: []byte(`{"x":1}`)})
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeSuccess {
+		t.Errorf("expected success outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerAllowListDenies(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{
+		AllowedTools: security.ToSet([]string{"other"}),
+		Auditor:      sink,
+	})
+	res := invokeInteractive(t, h, "chat", nil, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError || !strings.Contains(resultText(res), "not allowed") {
+		t.Fatalf("expected allow-list denial, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeDenied {
+		t.Errorf("expected denied outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerInputTooLarge(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{MaxInputBytes: 4, Auditor: sink})
+	res := invokeInteractive(t, h, "chat", nil, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat", Arguments: []byte(`{"prompt":"way too long"}`)})
+	if !res.IsError || !strings.Contains(resultText(res), "input too large") {
+		t.Fatalf("expected input-too-large, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeInputTooLarge {
+		t.Errorf("expected input_too_large outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerSchemaValidation(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	inputSchema := schema.JSON{"type": "object", "required": []any{"prompt"}}
+	res := invokeInteractive(t, h, "chat", inputSchema, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat", Arguments: []byte(`{"other":1}`)})
+	if !res.IsError || !strings.Contains(resultText(res), "validation error") {
+		t.Fatalf("expected schema validation error, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeInvalidInput {
+		t.Errorf("expected invalid_input outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+// TestInteractiveHandlerReinvocationSkipsValidation proves a retry carrying
+// InputResponses bypasses schema validation on the echoed original arguments.
+func TestInteractiveHandlerReinvocationSkipsValidation(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	inputSchema := schema.JSON{"type": "object", "required": []any{"prompt"}}
+	params := &sdkmcp.CallToolParamsRaw{
+		Name:      "chat",
+		Arguments: []byte(`{"other":1}`), // would fail validation on a first call
+		InputResponses: sdkmcp.InputResponseMap{
+			"roots": &sdkmcp.ListRootsResult{},
+		},
+	}
+	res := invokeInteractive(t, h, "chat", inputSchema, okInteractive, params)
+	if res.IsError {
+		t.Fatalf("re-invocation must skip validation, got error %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeSuccess {
+		t.Errorf("expected success outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerAuthzDeny(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	decider := authz.DeciderFunc(func(_ context.Context, _ authz.Request) (authz.Decision, error) {
+		return authz.Decision{Allowed: false, Reason: "denied by policy"}, nil
+	})
+	h := newHandler(t, nil, &security.Policy{Decider: decider, Auditor: sink})
+	res := invokeInteractive(t, h, "chat", nil, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError || !strings.Contains(resultText(res), "denied by policy") {
+		t.Fatalf("expected authz denial, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeDenied {
+		t.Errorf("expected denied outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerAuthzBackendErrorDoesNotLeak(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	decider := authz.DeciderFunc(func(_ context.Context, _ authz.Request) (authz.Decision, error) {
+		return authz.Decision{}, errors.New("policy backend unreachable at 10.0.0.9")
+	})
+	h := newHandler(t, nil, &security.Policy{Decider: decider, Auditor: sink})
+	res := invokeInteractive(t, h, "chat", nil, okInteractive,
+		&sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if got := resultText(res); got != "authorization error" {
+		t.Fatalf("expected generic authorization error, got %q", got)
+	}
+	last := sink.last()
+	if last.Attributes["outcome"] != security.OutcomeAuthorizationError {
+		t.Errorf("expected authorization_error outcome, got %q", last.Attributes["outcome"])
+	}
+	if !strings.Contains(last.Attributes["error"], "10.0.0.9") {
+		t.Errorf("audit must record the real backend error, got %q", last.Attributes["error"])
+	}
+}
+
+// TestInteractiveHandlerInputRequiredRoundTrip proves a result carrying a
+// non-nil InputRequests map is passed through as an input-required round trip
+// and audited as such, without a result-size check.
+func TestInteractiveHandlerInputRequiredRoundTrip(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{MaxResultBytes: 1, Auditor: sink})
+	fn := func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return &sdkmcp.CallToolResult{InputRequests: sdkmcp.InputRequestMap{}}, nil
+	}
+	res := invokeInteractive(t, h, "chat", nil, fn, &sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if res.IsError {
+		t.Fatalf("input-required round trip must not be an error result: %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeInputRequired {
+		t.Errorf("expected input_required outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerResultTooLarge(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{MaxResultBytes: 3, Auditor: sink})
+	fn := func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return finalResult("a very large final payload"), nil
+	}
+	res := invokeInteractive(t, h, "chat", nil, fn, &sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError || !strings.Contains(resultText(res), "result too large") {
+		t.Fatalf("expected result-too-large, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeResultTooLarge {
+		t.Errorf("expected result_too_large outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerFnError(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	fn := func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return nil, errors.New("handler blew up")
+	}
+	res := invokeInteractive(t, h, "chat", nil, fn, &sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError || !strings.Contains(resultText(res), "handler blew up") {
+		t.Fatalf("expected fn error surfaced, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeToolError {
+		t.Errorf("expected tool_error outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerNilResultFailsClosed(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	fn := func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return nil, nil //nolint:nilnil // models an interactive tool returning no result
+	}
+	res := invokeInteractive(t, h, "chat", nil, fn, &sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError || !strings.Contains(resultText(res), "no result") {
+		t.Fatalf("nil interactive result must fail closed, got %q", resultText(res))
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeToolError {
+		t.Errorf("expected tool_error outcome, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestInteractiveHandlerErrorResultPassthrough(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	fn := func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return &sdkmcp.CallToolResult{
+			IsError: true,
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "tool-side failure"}},
+		}, nil
+	}
+	res := invokeInteractive(t, h, "chat", nil, fn, &sdkmcp.CallToolParamsRaw{Name: "chat"})
+	if !res.IsError {
+		t.Fatal("error result must pass through as error")
+	}
+	last := sink.last()
+	if last.Attributes["outcome"] != security.OutcomeToolError {
+		t.Errorf("expected tool_error outcome, got %q", last.Attributes["outcome"])
+	}
+	if !strings.Contains(last.Attributes["error"], "tool-side failure") {
+		t.Errorf("audit must record the interactive error text, got %q", last.Attributes["error"])
+	}
+}

--- a/mcp/handlers/server_calls_test.go
+++ b/mcp/handlers/server_calls_test.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kbukum/gokit/mcp/security"
+)
+
+// reqWithInputResponses builds a re-invocation request carrying the given
+// server input responses keyed by label.
+func reqWithInputResponses(responses sdkmcp.InputResponseMap) *sdkmcp.CallToolRequest {
+	return &sdkmcp.CallToolRequest{Params: &sdkmcp.CallToolParamsRaw{InputResponses: responses}}
+}
+
+func TestSampleResponseExtractsAndAudits(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	want := &sdkmcp.CreateMessageWithToolsResult{
+		Model:   "m",
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "sampled"}},
+	}
+	got, err := h.SampleResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"draft": want}), "draft")
+	if err != nil {
+		t.Fatalf("SampleResponse: %v", err)
+	}
+	if got.Model != "m" {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeSuccess {
+		t.Errorf("expected success audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestSampleResponseMissingFailsClosed(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	_, err := h.SampleResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{}), "draft")
+	if err == nil {
+		t.Fatal("missing input response must fail closed")
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeToolError {
+		t.Errorf("expected tool_error audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+// TestSampleResponseOversizedContentFailsClosed proves untrusted sampled model
+// output that exceeds the configured result-size limit is rejected, not returned.
+func TestSampleResponseOversizedContentFailsClosed(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{MaxResultBytes: 8, Auditor: sink})
+	big := &sdkmcp.CreateMessageWithToolsResult{
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: strings.Repeat("x", 256)}},
+	}
+	_, err := h.SampleResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"draft": big}), "draft")
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected oversized rejection, got %v", err)
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeResultTooLarge {
+		t.Errorf("expected result_too_large audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+func TestElicitResponseExtractsAndAudits(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	want := &sdkmcp.ElicitResult{Action: "accept", Content: map[string]any{"name": "go"}}
+	got, err := h.ElicitResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"form": want}), "form")
+	if err != nil {
+		t.Fatalf("ElicitResponse: %v", err)
+	}
+	if got.Action != "accept" {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeSuccess {
+		t.Errorf("expected success audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+// TestElicitResponseWrongTypeFailsClosed proves a response of an unexpected
+// concrete type for the label is rejected rather than mis-cast.
+func TestElicitResponseWrongTypeFailsClosed(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	// A roots result stored under the label the caller reads as an elicitation.
+	_, err := h.ElicitResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"form": &sdkmcp.ListRootsResult{}}), "form")
+	if err == nil || !strings.Contains(err.Error(), "unexpected type") {
+		t.Fatalf("expected type-mismatch rejection, got %v", err)
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeToolError {
+		t.Errorf("expected tool_error audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+// TestElicitResponseTypedNilFailsClosed proves a typed-nil pointer (which
+// satisfies the interface but would panic on deref) is rejected.
+func TestElicitResponseTypedNilFailsClosed(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t, nil, &security.Policy{})
+	var typedNil *sdkmcp.ElicitResult
+	_, err := h.ElicitResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"form": typedNil}), "form")
+	if err == nil || !strings.Contains(err.Error(), "is nil") {
+		t.Fatalf("expected typed-nil rejection, got %v", err)
+	}
+}
+
+func TestRootsResponseExtractsAndAudits(t *testing.T) {
+	t.Parallel()
+	sink := &auditSink{}
+	h := newHandler(t, nil, &security.Policy{Auditor: sink})
+	want := &sdkmcp.ListRootsResult{Roots: []*sdkmcp.Root{{URI: "file:///workspace"}}}
+	got, err := h.RootsResponse(context.Background(),
+		reqWithInputResponses(sdkmcp.InputResponseMap{"roots": want}), "roots")
+	if err != nil {
+		t.Fatalf("RootsResponse: %v", err)
+	}
+	if len(got.Roots) != 1 {
+		t.Fatalf("unexpected roots: %#v", got.Roots)
+	}
+	if sink.last().Attributes["outcome"] != security.OutcomeSuccess {
+		t.Errorf("expected success audit, got %q", sink.last().Attributes["outcome"])
+	}
+}
+
+// TestServerToClientCallsRequireSession proves every server-driven call fails
+// closed with a typed error when there is no active session, rather than
+// dereferencing a nil session.
+func TestServerToClientCallsRequireSession(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t, nil, &security.Policy{})
+	ctx := context.Background()
+
+	if _, err := h.Sample(ctx, nil, &sdkmcp.CreateMessageParams{}); err == nil {
+		t.Error("Sample with nil session must error")
+	}
+	if _, err := h.Elicit(ctx, nil, &sdkmcp.ElicitParams{}); err == nil {
+		t.Error("Elicit with nil session must error")
+	}
+	if _, err := h.ListRoots(ctx, nil, &sdkmcp.ListRootsParams{}); err == nil {
+		t.Error("ListRoots with nil session must error")
+	}
+	if err := h.Log(ctx, nil, &sdkmcp.LoggingMessageParams{}); err == nil {
+		t.Error("Log with nil session must error")
+	}
+	if err := h.NotifyProgress(ctx, nil, &sdkmcp.ProgressNotificationParams{}); err == nil {
+		t.Error("NotifyProgress with nil session must error")
+	}
+}


### PR DESCRIPTION
## Description

Behavior-driven hardening of the AI layer (L7). Adds the missing behavioral tests for the layer's under-proven, security-relevant paths and introduces a shared `llm.Provider` test double so tests across the AI layer stop hand-rolling one-off fakes. The AI-layer production code was already root-hardened — no latent defects surfaced — so this change is proof of the trust-boundary paths plus a reusable test-tooling product, not a bug fix.

## Motivation

`mcp/handlers` was the single lowest-covered package in the tree (30.6%) and treats model/tool output as a trust boundary, so its untested paths were both defect-prone and security-relevant. `ai` core (58.0%) and `agent/memory` (68.4%) had untested failure and boundary paths. Multiple packages independently hand-rolled `llm.Provider` fakes, duplicating test scaffolding that should be a shared, shipped helper.

## Type of Change

- [x] Test coverage improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Module(s) Affected

- `llm` (new `llm/testutil` package)
- `mcp` (`mcp/handlers` tests)
- `ai` (core tests)
- `agent` (`agent/memory` tests)

## Changes Made

- **Shared test tooling:** new `llm/testutil.FakeProvider` — a deterministic, concurrency-safe `llm.Provider` double with functional options (queued responses, dynamic responder, injected error, capabilities, token counter, block-until-cancel). Replaces the hand-rolled fake in `agent/memory`; available to `ai`/`mcp`/`agent`.
- **`mcp/handlers` (30.6% → 88.3% CI-attributed):** proved the interactive tool handler's fail-closed gates (allow-list, input-too-large, schema validation, authz denial, authz backend-error non-leak, input-required round-trip, result-too-large, nil/error results, re-invocation skipping validation); untrusted server input-response extraction (missing / oversized / wrong-type / typed-nil rejection); nil-session fail-closed on every server-to-client call.
- **`ai` core (58.0% → 100%):** `Lifecycle` mixin transitions + concurrency, terminal stream `Error` wrap/unwrap.
- **`agent/memory` (68.4% → 89.9%):** `SlidingWindow` drop-until-fit boundaries, `Summarize` transcript rendering + provider-error fallback, `RingBuffer`/`Truncate` defaults, and a deep-copy regression isolating tool-call raw JSON and the `Usage` pointer from later caller mutation.
- **`embedding`:** confirmed already covered via `embedding/inmem` (98.2%) — the raw `0.0%` is a per-module measurement artifact (pure sealed types); no tests written.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [x] `make lint` is clean (includes `vet` + `depguard` layering)
- [x] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [x] `make check-<domain>` passes for the affected domain
- [ ] Manual testing performed (describe below if applicable)

All affected modules green under `-race -shuffle=on -count=1`; `golangci-lint` 0 issues on `ai`/`agent`/`mcp`/`llm`; `make structure` ok (only pre-existing advisory warnings).

### Test Evidence

```
$ make check-ai
...
ok  github.com/kbukum/gokit/ai
ok  github.com/kbukum/gokit/embedding
ok  github.com/kbukum/gokit/agent/memory
ok  github.com/kbukum/gokit/mcp/handlers
ok  github.com/kbukum/gokit/tool
ok  github.com/kbukum/gokit/skill
```

## Breaking Changes

None. Test-only additions plus a new test-support package; no production code or public abstraction changed.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

No public abstraction changed. `llm/testutil` is a test-support helper.

## Checklist

- [x] Code follows the [coding standards](../CONTRIBUTING.md#coding-standards) in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [x] Bug fixes include a regression test that fails without the fix
- [x] Suite is green under `-race -shuffle=on`; coverage meets the per-package floors (≥80% pkg, ≥85% security-load-bearing) and the CI Codecov gate
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [ ] `make tidy` run so go.mod/go.sum are clean for affected modules
- [ ] CHANGELOG entry added under `[Unreleased]`
- [ ] New dependencies (if any) are justified, minimal, and pass `govulncheck`

## Additional Notes

Deliberately out of scope to keep this a focused, reviewable test-only change: the plural→singular package renames (`mcp/handlers`, `llm/providers`) and crowded-package sub-package lifts (`tool`, `agent`, `mcp/handlers`, `llm`) are large cross-cutting refactors that belong in their own structure PRs; they remain tracked in the tdd-hardening inventory. No dependency changes, so `make tidy` was not required; no CHANGELOG entry as there is no user-facing behavior change (test-only, plus a new `testutil` helper).
