### PR TITLE
docs(release): align release docs and config with current toven set-version flow

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -77,7 +77,9 @@ done
 
 The next version must be **strictly greater** than `$highest` — and note a prerelease sorts *below* its release (`X.Y.Z-alpha.N < X.Y.Z`), so it must still exceed everything already published. The CHANGELOG can lag or list versions that were never actually pushed; trust the proxy over the CHANGELOG for immutability.
 
-**First-release caveat:** if gokit genuinely has no reachable tag *and* nothing on the proxy, `release status`/`plan` fail closed as expected. `--set-version` is a **`release tag`/`release publish` flag only** (not `release bump`), so supply the explicit first version to the Phase 2 mutating cut — `toven release publish --set-version go:gokit=X.Y.Z --yes` (or `toven release tag --set-version go:gokit=X.Y.Z --yes` to tag without the hosted Release). Toven never fabricates a synthetic `0.0.0` baseline. See `docs/VERSIONING.md`.
+**Version baseline (gokit today):** the last published line is `v0.2.0`, immutable on the Go module proxy for the root and every module that existed then. Toven anchors on reachable git tags, so `release status`/`plan` **work** — a module carrying a `v0.2.0` tag auto-bumps from its Conventional-Commit history (e.g. `authz 0.2.0 → 0.2.1`). Only modules added since v0.2.0 (media, agent, ai, …) have no tag and no declared version, so `release plan` fails closed on them until you supply a first version. Note gokit's remote currently carries **no `v*` tags** even though the proxy cached up to `v0.2.0` — exactly the tags-diverge-from-proxy case above — so trust the proxy for immutability and pick a version strictly greater than everything published on every path.
+
+**Supplying versions with `--set-version`:** `--set-version <version>` (workspace-wide) or `--set-version go:<mod>=<version>` (per module) is accepted on `release bump`, `release tag`, **and** `release publish`. The version carries **no `v` prefix** — e.g. `--set-version 0.3.0-alpha.1`. A workspace-wide `--set-version 0.3.0-alpha.1` cuts every discovered module to that version in lock-step (one hosted prerelease `v0.3.0-alpha.1`). Toven never fabricates a synthetic `0.0.0` baseline. See `docs/VERSIONING.md`.
 
 ## Step 3 — Update the CHANGELOG
 
@@ -89,14 +91,16 @@ The next version must be **strictly greater** than `$highest` — and note a pre
 
 ## Step 4 — Phase 1: stage the version bump through a PR
 
-`toven release bump` rewrites every module's version and the inter-module dependency floors and **stages** the change — it never commits, tags, or pushes.
+`toven release bump` rewrites every module's version and the inter-module dependency floors and **stages** the change — it never commits, tags, or pushes. It computes versions from `main`'s baseline but writes into the working tree, so **branch off a clean `main` first, then run the bump on the branch** (no need to stage on `main` and carry it over). Because gokit has modules with no prior tag (added since v0.2.0), pass the workspace-wide first version so every module bumps in lock-step:
 
 ```bash
-toven release bump --yes                       # first release: nothing to bump — skip to Phase 2 with --set-version
-# Makefile wrapper: make release-bump
+git switch -c release/v0.3.0-alpha.1
+toven release bump --set-version 0.3.0-alpha.1 --yes   # no `v` prefix; workspace-wide
+# Or, if only specific new modules need a floor: --set-version go:media=0.3.0-alpha.1 (repeatable)
+# Makefile wrapper: make release-bump SET_VERSION=0.3.0-alpha.1
 ```
 
-Then, still on `main`: rotate the CHANGELOG (Step 3) if not already done, cut a `release/vX.Y.Z` branch carrying the staged bump, open a PR, and merge it after review.
+Then, on the branch: rotate the CHANGELOG (Step 3) if not already done, commit the staged bump, open a PR, and merge it into `main` after review.
 
 ## Step 5 — Phase 2: cut the tags and hosted Release (after the bump PR merges)
 
@@ -104,10 +108,10 @@ Run only from a clean checkout of the merged commit. Toven creates signed path-p
 
 ```bash
 toven release readiness          # fail-closed go/no-go checks (clean-tree)
-toven release publish --dry-run  # mutation-free tag + hosted-Release rehearsal
-toven release publish --yes      # cut and push signed tags, then create the hosted Release
-# First release only (no reachable tag): pin the explicit version here, e.g.
-# toven release publish --set-version go:gokit=X.Y.Z --yes
+toven release publish --dry-run --set-version 0.3.0-alpha.1  # mutation-free rehearsal (verified: 50 modules → 0.3.0-alpha.1, tag-only)
+toven release publish --set-version 0.3.0-alpha.1 --yes      # cut and push signed tags, then create the hosted Release
+# --set-version carries no `v` prefix and is accepted on bump/tag/publish. Once every
+# module carries the new tag, later releases drop --set-version and auto-bump from history.
 ```
 
 `toven release tag --yes` cuts and pushes the signed tags without creating the Release; `toven release publish --yes` performs the full tag → push → hosted-Release sequence **idempotently** (safe to re-run to reconcile a partial push). Add `--no-push` to keep tags local for inspection. Makefile wrappers: `make release-readiness`, `make release-publish-dry-run`, `make release-tag`, `make release-publish`, `make list-tags`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
         id: toven
         # Pinned by immutable commit SHA; `version` independently pins the
         # installed binary (dual pin, both required). Same pin as toven-canary.yml.
-        uses: kbukum/toven/.github/actions/toven@d85aee8425fe0cc4584fb20356f0ec96fd44b22f # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/.github/workflows/toven-canary.yml
+++ b/.github/workflows/toven-canary.yml
@@ -57,7 +57,7 @@ jobs:
         # contract: on a cache miss it installs cosign and verifies the archive
         # checksum and the Sigstore signature over SHA256SUMS before extraction;
         # a version-exact cache hit reuses the already-verified binary.
-        uses: kbukum/toven/.github/actions/toven@d85aee8425fe0cc4584fb20356f0ec96fd44b22f # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/Makefile
+++ b/Makefile
@@ -120,23 +120,28 @@ release-readiness:
 ## the maintainer rotates the `[Unreleased]` CHANGELOG heading, cuts a
 ## `release/vX.Y.Z` branch carrying the staged bump, and opens a PR. The signed
 ## tags are cut by `release-tag` only after that PR merges into `main`.
+## Pass SET_VERSION for modules with no prior tag (added since v0.2.0) — it maps
+## to `--set-version` (no `v` prefix), e.g. `make release-bump SET_VERSION=0.3.0-alpha.1`
+## (workspace-wide) or `SET_VERSION=go:media=0.3.0-alpha.1` (per module).
 release-bump:
-	@$(TOVEN) release bump --yes
+	@$(TOVEN) release bump $(if $(SET_VERSION),--set-version $(SET_VERSION)) --yes
 
 ## Phase 2 — tag (run only after the release-bump PR merges into `main`): create and
 ## push the signed lock-step module tags on the merged commit. Toven owns tagging
-## and commit-derived release notes. (usage: make release-tag)
+## and commit-derived release notes. (usage: make release-tag [SET_VERSION=0.3.0-alpha.1])
 release-tag:
-	@$(TOVEN) release tag --yes
+	@$(TOVEN) release tag $(if $(SET_VERSION),--set-version $(SET_VERSION)) --yes
 
 ## Mutation-free registry + hosted-Release rehearsal (read-only)
+## (usage: make release-publish-dry-run [SET_VERSION=0.3.0-alpha.1])
 release-publish-dry-run:
-	@$(TOVEN) release publish --dry-run
+	@$(TOVEN) release publish --dry-run $(if $(SET_VERSION),--set-version $(SET_VERSION))
 
 ## Authoritative release: tag, push, and create the hosted GitHub Release; the pushed tag then
 ## triggers .github/workflows/release.yml (GoReleaser) to attach source archive + SBOM + signatures.
+## (usage: make release-publish [SET_VERSION=0.3.0-alpha.1])
 release-publish:
-	@$(TOVEN) release publish --yes
+	@$(TOVEN) release publish $(if $(SET_VERSION),--set-version $(SET_VERSION)) --yes
 
 ## List all version tags
 list-tags:
@@ -147,14 +152,12 @@ list-tags:
 ## graph, then exercise the mutation-free release previews (status + plan) with
 ## the candidate Toven binary. Toven owns the authoritative release tag/publish
 ## path; GoReleaser only attaches supply-chain artifacts to the Toven-created
-## Release. Toven never fabricates a synthetic 0.0.0, so before the first version
-## tag the release previews fail closed with "no reachable release tag" — that is
-## the expected outcome and is tolerated here. Once a version tag exists the
-## previews succeed instead; that success is the expected steady state and is
-## reported as a pass. A whole-workspace `release plan` may still fail closed
-## because a not-yet-released module declares no version — Toven requires an
-## explicit first `--set-version` rather than inventing one. That is the same
-## expected pre-first-release posture and is tolerated too. Only a failure for
+## Release. The last published line is v0.2.0, so `release status` succeeds and
+## `release plan` bumps tagged modules from history; but modules added since
+## v0.2.0 declare no version, so a whole-workspace `release plan` fails closed on
+## them ("has never been released and declares no version") until an explicit
+## `--set-version` is supplied — Toven never invents one. Both that fail-closed
+## posture and a fully-succeeding preview are tolerated here; only a failure for
 ## any other reason fails the canary.
 ## TOVEN selects the binary (see the TOVEN var).
 toven-canary:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 > breaking changes are documented in [`CHANGELOG.md`](CHANGELOG.md).
 > See [`docs/policy/SEMVER.md`](docs/policy/SEMVER.md).
 >
-> **Current development line — `v0.2.0-alpha.1`.** This is a prerelease for
-> evaluation and integration testing; APIs may change before `v0.2.0`.
+> **Latest release — `v0.2.0`.** The next development line being prepared is
+> `v0.3.0-alpha.1`, a prerelease for evaluation and integration testing; APIs
+> may change before the stable `v0.3.0`.
 
 > **Sibling projects.** gokit (Go, this repo) · [**rskit**](https://github.com/kbukum/rskit) (Rust) · [**pykit**](https://github.com/kbukum/pykit) (Python).
 > Public abstractions (`AppError`, `Component`, `Provider`, `Stream`, lifecycle hooks) are evaluated for parity across all three.

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -9,7 +9,7 @@ This file is the bird's-eye index.
 
 | Go version | gokit version |
 |------------|---------------|
-| 1.26+      | v0.2.0-alpha.1+ |
+| 1.26+      | v0.2.0+ |
 
 ## Core Packages
 
@@ -132,9 +132,9 @@ See [`docs/adr/0001-three-tier-layering.md`](adr/0001-three-tier-layering.md) fo
 Core and sub-modules are tagged in lock-step. Each sub-module has its own `go.mod` and path-scoped release tag:
 
 ```
-v0.2.0-alpha.1                  ← core module
-server/v0.2.0-alpha.1           ← server sub-module
-database/sqlite/v0.2.0-alpha.1  ← nested sub-module
+v0.3.0-alpha.1                  ← core module
+server/v0.3.0-alpha.1           ← server sub-module
+database/sqlite/v0.3.0-alpha.1  ← nested sub-module
 ```
 
 - Consumers pin only the modules they import.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -44,25 +44,31 @@ dependency floors — the `require github.com/kbukum/gokit/<mod> vX.Y.Z` lines t
 let a published consumer resolve one gokit module's dependency on another. Toven
 stages that rewrite for review; it never commits, tags, or pushes here.
 
-From a clean `main`:
+`release bump` computes the versions from `main`'s baseline (reachable tags plus
+Conventional-Commit history), but the mutation lands in your working tree — so
+branch off a clean `main` first, then run the bump on the branch. There is no
+need to stage on `main` and carry the change over.
 
 ```sh
-make release-bump   # toven release bump --yes
+git switch -c release/vX.Y.Z                       # branch off clean main
+make release-bump SET_VERSION=0.3.0-alpha.1         # omit SET_VERSION once every module carries a tag
 ```
 
-Toven rewrites each module's version and dependency floors and stages the
-change. Then, still on `main`:
+Then, on the branch:
 
 1. Rotate the CHANGELOG as in step 2 (if not already done) and stage it.
-2. Cut a `release/vX.Y.Z` branch carrying the staged bump.
+2. Commit the staged bump + CHANGELOG.
 3. Open a pull request and merge it into `main` after review.
 
 The bump lands through a reviewed PR so `main` stays the source of truth; the
-signed tags are cut only after the PR merges (Phase 2). This is a first-release
-caveat: gokit has no reachable tag yet, so `release status` / `release plan`
-fail closed ("no reachable release tag") until the first version is cut — supply
-that first version explicitly to the mutating action, per
-[`VERSIONING.md`](VERSIONING.md); Toven never fabricates a synthetic `0.0.0`.
+signed tags are cut only after the PR merges (Phase 2). The last published line
+is `v0.2.0`, so `release status` / `release plan` work: modules carrying a
+`v0.2.0` tag auto-bump from their Conventional-Commit history. Modules added
+since v0.2.0 (media, agent, ai, …) carry no tag, so supply the first version to
+the mutating action with `--set-version` — accepted on `release bump`,
+`release tag`, and `release publish`, workspace-wide (`--set-version 0.3.0-alpha.1`,
+no `v` prefix) or per module (`--set-version go:media=0.3.0-alpha.1`), per
+[`VERSIONING.md`](VERSIONING.md). Toven never fabricates a synthetic `0.0.0`.
 
 ## 4. Cut the tags and hosted Release (Phase 2)
 
@@ -153,7 +159,7 @@ make list-tags         # every version tag currently on the remote
 
 ## Supply-chain artifacts (automated)
 
-Pushing a root `vX.Y.Z` tag (including pre-releases like `v0.2.0-alpha.1`) triggers `.github/workflows/release.yml`,
+Pushing a root `vX.Y.Z` tag (including pre-releases like `v0.3.0-alpha.1`) triggers `.github/workflows/release.yml`,
 which runs GoReleaser in library mode and produces, for every release:
 
 - a reproducible source archive (`gokit-<version>-source.tar.gz`) and a `checksums.txt`;

--- a/docs/VERSIONING-QUICK-FIX.md
+++ b/docs/VERSIONING-QUICK-FIX.md
@@ -19,17 +19,17 @@ Configure signing and cut the complete module tag family:
 ```bash
 git config tag.gpgsign true
 git config user.signingkey <KEY-ID>
-toven release publish --yes
+toven release publish --set-version 0.3.0-alpha.1 --yes
 ```
 
-Toven discovers all `go.mod` files automatically. It creates the root tag (`v0.2.0-alpha.1`) and path-scoped tags such as `auth/v0.2.0-alpha.1` and `database/sqlite/v0.2.0-alpha.1`.
+Toven discovers all `go.mod` files automatically. It creates the root tag (`v0.3.0-alpha.1`) and path-scoped tags such as `auth/v0.3.0-alpha.1` and `database/sqlite/v0.3.0-alpha.1`.
 
 Consumers can then request the published version:
 
 ```bash
-go get github.com/kbukum/gokit@v0.2.0-alpha.1
-go get github.com/kbukum/gokit/auth@v0.2.0-alpha.1
-go get github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
+go get github.com/kbukum/gokit@v0.2.0
+go get github.com/kbukum/gokit/auth@v0.2.0
+go get github.com/kbukum/gokit/database/sqlite@v0.2.0
 go mod tidy
 ```
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -10,31 +10,31 @@ Tags use Semantic Versioning:
 vMAJOR.MINOR.PATCH[-PRERELEASE]
 ```
 
-The current development line is `v0.2.0-alpha.1`. Prereleases are ordered as `alpha.1`, `alpha.2`, and so on; the stable `v0.2.0` follows the final prerelease.
+The last published line is `v0.2.0` (immutable on the Go module proxy). The next development line being prepared is `v0.3.0-alpha.1`; prereleases are ordered as `alpha.1`, `alpha.2`, and so on, and the stable `v0.3.0` follows the final prerelease.
 
 ## Module tags
 
 The root module uses the plain tag and every sub-module uses its directory prefix:
 
 ```
-v0.2.0-alpha.1
-auth/v0.2.0-alpha.1
-database/sqlite/v0.2.0-alpha.1
-messaging/kafka/v0.2.0-alpha.1
+v0.3.0-alpha.1
+auth/v0.3.0-alpha.1
+database/sqlite/v0.3.0-alpha.1
+messaging/kafka/v0.3.0-alpha.1
 ```
 
 Toven discovers every `go.mod` file, so the module list is never maintained in documentation. Releases tag all modules in lock-step, while consumers still import and pin only the modules they use.
 
 ## Prerelease workflow
 
-1. Add the completed changes to a dated `## [0.2.0-alpha.N]` section in `CHANGELOG.md` and leave an empty `## [Unreleased]` section above it.
+1. Add the completed changes to a dated `## [0.3.0-alpha.N]` section in `CHANGELOG.md` and leave an empty `## [Unreleased]` section above it.
 2. Run the complete release gates on a clean `main` checkout.
-3. Stage the lock-step version + dependency-floor bump and land it through a reviewed PR (Phase 1) — `make release-bump` rewrites each module's version and its inter-module `require` floors without committing; cut a `release/vX.Y.Z` branch carrying the staged bump and merge it into `main`. See [`RELEASING.md`](RELEASING.md) for the full mechanics.
+3. Branch off a clean `main`, then stage the lock-step version + dependency-floor bump on the branch (Phase 1) — `release bump` computes versions from main's baseline but writes into the working tree, so there is no need to stage on `main` first: `git switch -c release/vX.Y.Z && make release-bump SET_VERSION=0.3.0-alpha.1` (drop `SET_VERSION` once every module carries a tag). Rotate the CHANGELOG, commit, open a PR, and merge into `main`. See [`RELEASING.md`](RELEASING.md) for the full mechanics.
 4. Preview the exact tag set without creating tags:
 
    ```bash
    toven release plan
-   toven release publish --dry-run
+   toven release publish --dry-run --set-version 0.3.0-alpha.1
    ```
 
 5. Configure a GPG signing key, then cut and push the signed tags and the hosted Release (Phase 2, after the bump PR merges):
@@ -42,12 +42,12 @@ Toven discovers every `go.mod` file, so the module list is never maintained in d
    ```bash
    git config tag.gpgsign true
    git config user.signingkey <KEY-ID>
-   toven release publish --yes
+   toven release publish --set-version 0.3.0-alpha.1 --yes
    ```
 
 6. Cutting the tags creates the hosted GitHub prerelease with commit-derived notes; the pushed root tag then triggers the release workflow, where GoReleaser attaches the source archive, checksums, SBOM, signatures, and provenance to that Release.
 
-Subsequent prereleases repeat the same flow with `alpha.2`, `alpha.3`, or `beta.N`. Once the API and behavior are ready for consumers, cut `v0.2.0` from the same release line.
+Subsequent prereleases repeat the same flow with `alpha.2`, `alpha.3`, or `beta.N`. Once the API and behavior are ready for consumers, cut `v0.3.0` from the same release line.
 
 ## Stable and patch releases
 
@@ -58,9 +58,9 @@ Hotfixes for an older line use a dedicated hotfix branch and the same Toven rele
 ## Consumer usage
 
 ```bash
-go get github.com/kbukum/gokit@v0.2.0-alpha.1
-go get github.com/kbukum/gokit/auth@v0.2.0-alpha.1
-go get github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
+go get github.com/kbukum/gokit@v0.2.0
+go get github.com/kbukum/gokit/auth@v0.2.0
+go get github.com/kbukum/gokit/database/sqlite@v0.2.0
 ```
 
 Use local `replace` directives only for development against an unreleased checkout. Published consumers should use a tag so Go does not select a pseudo-version.
@@ -70,8 +70,8 @@ Use local `replace` directives only for development against an unreleased checko
 After publication, verify the root and representative nested modules through the Go proxy:
 
 ```bash
-GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit@v0.2.0-alpha.1
-GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit/database/sqlite@v0.2.0-alpha.1
+GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit@v0.2.0
+GOPROXY=https://proxy.golang.org go list -m github.com/kbukum/gokit/database/sqlite@v0.2.0
 ```
 
 The complete mechanical procedure is in [`RELEASING.md`](RELEASING.md), and the SemVer compatibility rules are in [`policy/SEMVER.md`](policy/SEMVER.md).
@@ -82,7 +82,7 @@ The complete mechanical procedure is in [`RELEASING.md`](RELEASING.md), and the 
 
 | Versioning behavior | Toven command | Expected output |
 |---|---|---|
-| Next version selection | `toven release plan` / `toven release status` | fails closed until the first tag exists — with no reachable release tag Toven reports "no reachable release tag; set an explicit release version before the first Go release" rather than fabricating a `0.0.0` baseline. The first version is supplied to the mutating `release tag`/`release publish` cut |
+| Next version selection | `toven release plan` / `toven release status` | anchors on reachable git tags. Tagged modules auto-bump from Conventional-Commit history (e.g. `authz 0.2.0 → 0.2.1`); modules with no prior tag report "has never been released and declares no version" until an explicit `--set-version` is supplied to the mutating `bump`/`tag`/`publish` cut. Toven never fabricates a `0.0.0` baseline |
 | Per-module tag names | `toven release plan` / `toven release publish --dry-run` | path-prefixed tag names (`auth/v…`, `database/sqlite/v…`, `messaging/nats/v…`) |
 | Lock-step tagging of every `go.mod` | `toven modules` + `toven release plan` | all 50 modules discovered; every module deliberately included and tagged in lock-step. Toven does support a per-module `exclude`, but gokit's contract withholds none — inclusion is explicit, not a missing mechanism |
 | Dependency-aware cascade | `toven release plan` (`dependency-cascade` reason column) | dependents shown as `cascade` when a dependency changes |

--- a/docs/policy/SEMVER.md
+++ b/docs/policy/SEMVER.md
@@ -49,12 +49,12 @@ The following are explicitly **not** part of the public API and may change in an
 
 ## Module-level version skew
 
-Sub-modules may temporarily be at different versions when a focused fix ships (e.g. `storage/v0.2.0-alpha.2` while the rest of the workspace stays at `v0.2.0-alpha.1`).
+Sub-modules may temporarily be at different versions when a focused fix ships (e.g. `storage/v0.3.0-alpha.2` while the rest of the workspace stays at `v0.3.0-alpha.1`).
 The next root-level release brings everything back into lock-step.
 
 ## Pre-release identifiers
 
-Pre-releases use SemVer suffixes: `v0.2.0-alpha.1`, `v0.2.0-beta.1`.
+Pre-releases use SemVer suffixes: `v0.3.0-alpha.1`, `v0.3.0-beta.1`.
 Pre-release tags do not require CHANGELOG entries
 but **must** be reproducible builds (no moving Go-toolchain reference, no floating action SHAs).
 

--- a/toven.toml
+++ b/toven.toml
@@ -41,11 +41,20 @@ line = 80.0
 # not the absence of a mechanism. The Go tag grammar is fixed (Toven rejects a
 # `tag_format` override).
 #
-# First-release note — gokit has no reachable release tags yet, so the version
-# is tag-derived from none and the mutation-free previews (`release status` /
-# `plan`) fail closed ("no reachable release tag") until the first version is
-# cut. That first version is supplied explicitly to the mutating `release tag`
-# action in step 04/05; Toven never fabricates a synthetic `0.0.0` baseline.
+# Version baseline — the last published line is `v0.2.0` (immutable on the Go
+# module proxy for the root and every module that existed then). Toven anchors
+# on reachable git tags, so `release status` / `release plan` work: modules that
+# carry a `v0.2.0` tag auto-bump from their Conventional-Commit history (e.g.
+# `authz 0.2.0 → 0.2.1`). Modules added since v0.2.0 (media, agent, ai, …) have
+# no tag and no declared version, so `release plan` fails closed on them until a
+# first version is supplied. Cross-check the proxy before choosing a version:
+# gokit's remote currently carries no `v*` tags even though the proxy has cached
+# up to `v0.2.0`, so the next version must be strictly greater than everything
+# published on every module path. Supply the version to the mutating action —
+# `--set-version <version>` (workspace-wide) or `--set-version go:<mod>=<version>`
+# is accepted on `release bump`, `release tag`, and `release publish`, and the
+# version carries no `v` prefix (e.g. `--set-version 0.3.0-alpha.1`). Toven never
+# fabricates a synthetic `0.0.0` baseline.
 [ecosystems.go.release]
 readiness = ["clean-tree"]
 


### PR DESCRIPTION
## Description

Aligns gokit's release documentation, config, and Make targets with the current Toven (`v0.1.0-alpha.9`) `--set-version` flow, and repins the Toven GitHub Action to the commit its `v0.1.0-alpha.9` tag now points at.

The prior docs described gokit as a fail-closed "first release" with no reachable tag. That is stale: `v0.2.0` is published on the Go module proxy for the root and every module that existed then, so `toven release status`/`plan` work and tagged modules auto-bump from Conventional-Commit history. Only modules added since v0.2.0 (media, agent, ai, …) lack a version and need one supplied. In current Toven, `--set-version` is accepted on `release bump`/`tag`/`publish` (not just tag/publish) and its value carries no `v` prefix.

## Motivation

The release docs would have led a maintainer to run the wrong commands (expecting fail-closed previews, passing `--set-version` only to tag/publish, using a `v`-prefixed value) and to believe the workflow requires a GitHub-UI release step. Correcting them unblocks cutting the next line, `v0.3.0-alpha.1`. The action was also pinned to a SHA one commit behind its `v0.1.0-alpha.9` tag after the tag was re-cut.

## Type of Change

- [x] Documentation update
- [x] Refactoring (no functional changes) — release Make targets gain a `SET_VERSION` passthrough

## Module(s) Affected

- Release tooling / docs only (no Go modules): `toven.toml`, `Makefile`, `docs/*`, `.github/skills/release`, `.github/workflows/{ci,toven-canary}.yml`

## Changes Made

- Correct the first-release framing in `toven.toml`, `RELEASING.md`, `VERSIONING.md`, and the release skill: v0.2.0 published, tagged modules auto-bump, new modules need `--set-version`
- Document `--set-version` as valid on `bump`/`tag`/`publish` with no `v` prefix (workspace-wide or per-module)
- Clarify the two-phase flow: branch off clean `main` then run the bump on the branch (no stage-on-main-and-carry-over)
- Add a `SET_VERSION` passthrough to `release-bump`/`tag`/`publish`/`publish-dry-run` Make targets; refresh the `toven-canary` comment
- Refresh the version line across docs/README: latest `v0.2.0`, next `v0.3.0-alpha.1`
- Repin the Toven action SHA to the current `v0.1.0-alpha.9` tag commit in both workflows

## Testing

No Go code changed, so the Go gates do not apply. Verified against the installed `toven v0.1.0-alpha.9`:

### Test Evidence

```
$ make release-publish-dry-run SET_VERSION=0.3.0-alpha.1
... Finished release (dry run): 0 would publish, 50 tag only
  hosted release: github  v0.3.0-alpha.1  prerelease=true

$ toven tasks   # toven.toml still parses
OK
```

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (docs/tooling change; no public abstraction touched)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
- [x] Code split by concern into focused files — not piled into one file

## Additional Notes

Follow-up (maintainer, separate step): after this merges, cut the release from clean `main` with `make release-publish SET_VERSION=0.3.0-alpha.1`, which cuts+pushes all 50 signed tags and creates the hosted Release; the pushed root `v0.3.0-alpha.1` tag then triggers `release.yml` (GoReleaser) to attach supply-chain artifacts. No GitHub-UI release step.
