### PR TITLE
fix(release): harden publish workflow and pin Toven to v0.1.0-alpha.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ permissions:
 # the same `command`-ecosystem task the Makefile uses (`toven run structure`).
 # Kept in lock-step with .github/workflows/toven-canary.yml; bump both together.
 env:
-  TOVEN_VERSION: v0.1.0-alpha.9
+  TOVEN_VERSION: v0.1.0-alpha.10
 
 # All third-party actions are pinned by 40-char SHA. Dependabot is configured
 # (see .github/dependabot.yml) to bump both the SHA and the trailing version
@@ -269,7 +269,7 @@ jobs:
         id: toven
         # Pinned by immutable commit SHA; `version` independently pins the
         # installed binary (dual pin, both required). Same pin as toven-canary.yml.
-        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@6683762a83098ffde6e5bc088090ffdfd2a1aa6b # v0.1.0-alpha.10
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  TOVEN_VERSION: v0.1.0-alpha.9
+  TOVEN_VERSION: v0.1.0-alpha.10
 
 jobs:
   # Mutation-free rehearsal: the exact plan a real publish would use, preserved
@@ -58,11 +58,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin the release toolchain to the repo's declared Go (go.mod), matching
+      # ci.yml, so the release never inherits the runner's incidental Go — a
+      # mismatch against the `toolchain` directive can otherwise perturb the
+      # module graph and leave the tree dirty before Toven's clean-tree guard.
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0
+        with:
+          go-version-file: go.mod
+
       - name: Install the pinned Toven release
         id: toven
         # Pinned by immutable commit SHA; `version` independently pins the
         # installed binary (dual pin, both required). Same pin as ci.yml.
-        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@6683762a83098ffde6e5bc088090ffdfd2a1aa6b # v0.1.0-alpha.10
         with:
           version: ${{ env.TOVEN_VERSION }}
           install-cosign: "true"
@@ -71,7 +80,9 @@ jobs:
         run: make TOVEN="${{ steps.toven.outputs.toven }}" toven-canary
 
       - name: Rehearse the publish (mutation-free)
+        shell: bash
         run: |
+          set -euo pipefail
           make TOVEN="${{ steps.toven.outputs.toven }}" \
             SET_VERSION="${{ inputs.set_version }}" \
             release-publish-dry-run | tee release-preview.txt
@@ -103,6 +114,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin the release toolchain to the repo's declared Go (go.mod), matching
+      # ci.yml and the preview job, so publish never inherits the runner's
+      # incidental Go — a mismatch against the `toolchain` directive can perturb
+      # the module graph and dirty the tree before Toven's clean-tree guard.
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0
+        with:
+          go-version-file: go.mod
+
       # Toven cuts annotated tags through the embedded git backend, which builds
       # the tagger/committer signature from git config. actions/checkout sets the
       # auth token but no identity, so without this the tag creation aborts. Use
@@ -114,18 +134,34 @@ jobs:
 
       - name: Install the pinned Toven release
         id: toven
-        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@6683762a83098ffde6e5bc088090ffdfd2a1aa6b # v0.1.0-alpha.10
         with:
           version: ${{ env.TOVEN_VERSION }}
           install-cosign: "true"
 
+      # Publish requires a pristine tree (Toven's clean-tree guard). Surface any
+      # residual working-tree change in the log before the guard trips, so a
+      # CI-only dirty file is diagnosable directly from this run.
+      - name: Assert a clean working tree before publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::working tree is not clean before publish:"
+            git status --porcelain
+            git --no-pager diff --stat
+            exit 1
+          fi
+
       - name: Publish the release
+        shell: bash
         env:
           # Toven's embedded git backend reads whichever of these is set to
           # authenticate the tag push and to create the hosted Release.
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           make TOVEN="${{ steps.toven.outputs.toven }}" \
             SET_VERSION="${{ inputs.set_version }}" \
             release-publish | tee release-publish.txt

--- a/.github/workflows/toven-canary.yml
+++ b/.github/workflows/toven-canary.yml
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   # Pin the canary to an immutable published Toven release. Bump deliberately.
-  TOVEN_VERSION: v0.1.0-alpha.9
+  TOVEN_VERSION: v0.1.0-alpha.10
 
 jobs:
   canary:
@@ -57,7 +57,7 @@ jobs:
         # contract: on a cache miss it installs cosign and verifies the archive
         # checksum and the Sigstore signature over SHA256SUMS before extraction;
         # a version-exact cache hit reuses the already-verified binary.
-        uses: kbukum/toven/.github/actions/toven@725f880affda10f0db823275802ce554b82a4e97 # v0.1.0-alpha.9
+        uses: kbukum/toven/.github/actions/toven@6683762a83098ffde6e5bc088090ffdfd2a1aa6b # v0.1.0-alpha.10
         with:
           version: ${{ env.TOVEN_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **workload/docker**: `Manager.Wait` now returns `context.Canceled`/`DeadlineExceeded` deterministically when the context is already done, instead of racing the container-wait result; removes a flaky test under the Go 1.26.6 toolchain.
+- **release**: the `Release (publish)` workflow no longer reports success when a release actually fails — both `make … | tee` steps now run under `set -euo pipefail` (`shell: bash`), so a failed `toven release publish` fails the job instead of being masked by `tee`'s zero exit code. Pin the release toolchain to the repo's declared Go via `actions/setup-go` (`go-version-file: go.mod`) on the preview and publish jobs so publishing no longer inherits the runner's incidental Go and cannot dirty the tree before Toven's clean-tree guard, add a pre-publish clean-tree assertion that prints `git status`/`diff --stat` when the tree is not pristine, and bump the pinned Toven to `v0.1.0-alpha.10` (whose clean-tree guard now names the offending paths) across `release.yml`, `ci.yml`, and `toven-canary.yml`.
 
 ### Changed — MCP go-sdk 1.7.0 / SEP-2322 multi round-trip
 - **mcp**: bump `modelcontextprotocol/go-sdk` to 1.7.0. Its default


### PR DESCRIPTION
## Description

The `Release (publish)` workflow reported success even when the release actually failed, and the publish job could dirty its own working tree before Toven's clean-tree guard ran. This hardens the release path so a failed publish fails the job, and the publish runs against the repo's declared Go toolchain on a pristine tree. Also bumps the pinned Toven to `v0.1.0-alpha.10`, whose clean-tree guard now names the offending paths.

## Motivation

The first `0.3.0-alpha.1` release run showed green in Actions while `toven release publish` had failed with a dirty-worktree error, so no tags were cut. Root cause: `make … | tee` runs under the default `bash -e` shell (no `pipefail`), so `tee`'s zero exit masked make's failure; and the publish job had no `setup-go`, inheriting the runner's Go which regenerated `go.sum` against gokit's declared `toolchain` before Toven's guard.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Module(s) Affected

- CI / release workflows (`release.yml`, `ci.yml`, `toven-canary.yml`)

## Changes Made

- **Fail on real failures**: both `make … | tee` steps (rehearse + publish) now run under `set -euo pipefail` with `shell: bash`, so a failed `toven release` fails the job instead of being masked by `tee`.
- **Deterministic toolchain**: add `actions/setup-go` (`go-version-file: go.mod`) to the preview and publish jobs so publishing uses the repo's declared Go and cannot dirty the tree before the guard.
- **Fail fast on dirt**: a pre-publish "clean working tree" assertion prints `git status --porcelain` / `git diff --stat` and exits non-zero if the tree isn't pristine.
- **Toven bump**: pin Toven to `v0.1.0-alpha.10` (clean-tree guard now names dirty paths) across `release.yml`, `ci.yml`, and `toven-canary.yml`.

## Testing

- [ ] `make test` (workflow-only change; no Go code touched)

### Test Evidence

Verified locally that `toven release publish --set-version 0.3.0-alpha.1 --yes` cuts all tags on a clean tree in a throwaway clone; the CI failure was environmental (missing `setup-go`), addressed here.

## Breaking Changes

None — CI/release workflow hardening only.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] CHANGELOG entry added under the in-progress `0.3.0-alpha.1` section

## Additional Notes

Toven-side fix (clean-tree guard now names the offending paths) shipped in https://github.com/kbukum/toven/pull/200 and is consumed here via the alpha.10 pin. This branch feeds the in-progress `0.3.0-alpha.1` release; re-running the release workflow after merge should cut the tags cleanly.
