### PR TITLE
docs: describe packages by behavior, drop cross-kit provenance from comments

### DIFF
--- a/chain/README.md
+++ b/chain/README.md
@@ -2,7 +2,7 @@
 
 Typed, sequential chain execution: a statically typed sequence of steps where each step consumes the previous step's output and produces the next step's input type. Supports per-step progress reporting, cancellation at step boundaries, and automatic reverse-order cleanup of completed steps when a later step fails or the chain is canceled.
 
-Mirrors `rskit-chain` (Rust) and `pykit-chain` (Python) — the same typed `Step` / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
+Typed `Step` / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
 
 ## Install
 

--- a/chain/doc.go
+++ b/chain/doc.go
@@ -22,6 +22,5 @@
 //
 //	out, err := c.Execute(ctx, "21", nil) // out == 42
 //
-// Mirrors rskit-chain (Rust) and pykit-chain (Python):
-// the same typed Step / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
+// Provides typed Step / builder / cleanup-on-failure semantics, expressed idiomatically in Go.
 package chain

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 A parser-agnostic terminal-UX toolkit for gokit command-line programs. It is not a flag parser; it owns the presentation, input, and cancellation concerns a CLI shares, so every gokit CLI renders and behaves consistently.
 
-`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and leans on the standard library, with `go.yaml.in/yaml/v3` (for `render`'s YAML output) as its only external dependency. It is the **light** Go mirror of rskit's `rskit-cli`: theming, structured output, progress, prompts, signals, and a bounded live console. Heavy raw-mode rich widgets (arrow-key radio/checkbox lists) stay rskit-only by design.
+`cli` lives in the root module (`github.com/kbukum/gokit/cli`) and leans on the standard library, with `go.yaml.in/yaml/v3` (for `render`'s YAML output) as its only external dependency. It is a **light** Go CLI toolkit: theming, structured output, progress, prompts, signals, and a bounded live console. Heavy raw-mode rich widgets (arrow-key radio/checkbox lists) are out of scope by design.
 
 > This is the one gokit module where writing to stdout/stderr is expected.
 > Every renderer takes an injected `io.Writer`; every other module uses the injected logger.
@@ -58,4 +58,4 @@ Everything is testable without a real terminal:
 
 ## Capability split (light by design)
 
-gokit `cli` mirrors rskit's *surface* idiomatically but stays light: it lands theme/render/progress/prompt/signal plus a bounded live console. A full raw-mode rich TUI (live arrow-key navigation via a terminal driver dependency) stays rskit-only — the line-driven prompt path is always available and dependency-free.
+gokit `cli` stays light: it lands theme/render/progress/prompt/signal plus a bounded live console. A full raw-mode rich TUI (live arrow-key navigation via a terminal driver dependency) is out of scope by design — the line-driven prompt path is always available and dependency-free.

--- a/cli/signal/doc.go
+++ b/cli/signal/doc.go
@@ -1,6 +1,5 @@
 // Package signal maps interactive interrupts (Ctrl+C / SIGTERM) onto cooperative [context.Context] cancellation.
 //
-// Where rskit standardizes on a cancellation token,
 // Go's idiom is a cancelable context threaded through every remote call and goroutine.
 // This package builds that context from OS signals
 // so a CLI winds down gracefully on the first interrupt: spawned work observes ctx.Done()

--- a/config/watch.go
+++ b/config/watch.go
@@ -28,8 +28,7 @@ type ConfigChange struct {
 
 // ConfigWatch is the contract for configuration backends that emit change
 // notifications — a watched file, a remote config service, or an in-memory
-// store. It is the Go-idiomatic equivalent of rskit-config's ConfigWatch trait:
-// the returned channel is the bounded, owned change stream.
+// store. The returned channel is the bounded, owned change stream.
 //
 // The channel is buffered and best-effort; a consumer that cannot keep up may
 // miss events and should treat any received change as a signal to reload. The

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -1,6 +1,6 @@
 # dataset
 
-A streaming dataset-collection framework: bounded sources feed typed transforms and targets, with fail-closed schema validation, a manifest/cache layer, and spill-to-file for oversized payloads. It is the cross-kit Go mirror of rskit's `rskit-dataset`, kept **light**: heavy image/media transforms stay rskit-only by design.
+A streaming dataset-collection framework: bounded sources feed typed transforms and targets, with fail-closed schema validation, a manifest/cache layer, and spill-to-file for oversized payloads. It is kept **light**: heavy image/media transforms are out of scope by design.
 
 `dataset` is a sub-module (`github.com/kbukum/gokit/dataset`) so it can reuse the `schema` sub-module. It builds on gokit's canonical owners rather than a parallel stack — record streams are [`stream`](../stream) pipelines, bounded file reads go through [`fs`](../fs), and validation reuses [`schema`](../schema).
 

--- a/dataset/doc.go
+++ b/dataset/doc.go
@@ -1,7 +1,6 @@
 // Package dataset is a streaming dataset-collection toolkit:
 // it fetches records from heterogeneous sources, transforms and validates them, caches progress,
-// and publishes to configurable targets — mirroring rskit's dataset kit as a light,
-// generics-first Go port.
+// and publishes to configurable targets — a light, generics-first Go toolkit.
 //
 // It is split into focused sub-packages by concern:
 //

--- a/dataset/payload/limits.go
+++ b/dataset/payload/limits.go
@@ -1,7 +1,7 @@
 package payload
 
 // DefaultMaxInMemoryBytes is the default cap on a single in-memory payload
-// or bounded file read (8 MiB), mirroring rskit's dataset limits.
+// or bounded file read (8 MiB).
 const DefaultMaxInMemoryBytes int64 = 8 * 1024 * 1024
 
 // DefaultStreamBuffer is the default bound on a stage's in-flight buffer.

--- a/dataset/sample/doc.go
+++ b/dataset/sample/doc.go
@@ -1,7 +1,7 @@
 // Package sample is the blob item family of the dataset kit: a labeled,
 // offset-carrying [Item] whose bytes live in a bounded [github.com/kbukum/gokit/dataset/payload] payload,
 // plus the sources and target that stream it through the generic collector.
-// It is the gokit analog of rskit's blob DataItem, kept light: item bytes are read
+// It is a blob DataItem kept light: item bytes are read
 // and written through the payload owner
 // and confined to the output directory through [github.com/kbukum/gokit/fs] path safety.
 //

--- a/encryption/encryptor.go
+++ b/encryption/encryptor.go
@@ -35,7 +35,7 @@ func WithAlgorithm(alg Algorithm) Option {
 //
 // The passphrase is stretched with PBKDF2-SHA256 and each ciphertext is a
 // base64-encoded versioned envelope: version || algorithm || salt || nonce || ciphertext,
-// with the header authenticated as AEAD associated data (wire-compatible with rskit).
+// with the header authenticated as AEAD associated data (wire-compatible with the shared encryption envelope format).
 func New(key string, opts ...Option) (Encryptor, error) {
 	o := &options{algorithm: AlgorithmAESGCM}
 	for _, opt := range opts {

--- a/encryption/envelope.go
+++ b/encryption/envelope.go
@@ -14,7 +14,7 @@ import (
 //
 // The header (version, algorithm id, salt, nonce) is authenticated as AEAD
 // associated data, binding the algorithm and key-derivation inputs to the
-// sealed body. This format is wire-compatible with rskit's encryption envelope.
+// sealed body. This format is wire-compatible with the shared encryption envelope format.
 const (
 	envelopeVersion    byte = 1
 	nonceSize               = 12

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -21,7 +21,7 @@ type AppError struct {
 	// Details carries RFC 9457 problem-detail extension members. These are, by definition,
 	// arbitrary JSON and cannot be given a closed type without losing that openness,
 	// so map[string]any is a deliberate,
-	// documented opaque-value exception to the no-any rule (parity with rskit's HashMap<String, Value>).
+	// documented opaque-value exception to the no-any rule.
 	// Values should be JSON-encodable.
 	Details map[string]any `json:"details,omitempty"`
 	// Cause is the underlying error that caused this error.

--- a/grpc/mapping.go
+++ b/grpc/mapping.go
@@ -12,8 +12,7 @@ import (
 )
 
 // This file holds the canonical, lossless AppError <-> gRPC status mapping pair
-// (the cross-kit parity surface, equivalent to rskit's app_error_to_status /
-// status_to_app_error). It embeds the RFC 9457 ProblemDetail in the status
+// (the stable error-to-status mapping surface). It embeds the RFC 9457 ProblemDetail in the status
 // details so a round trip preserves the error code, message, and extension
 // members. The user-facing convenience helpers FromGRPC / ToGRPCStatus in
 // errors.go remap to friendlier client messages and are a separate concern.

--- a/llm/echo.go
+++ b/llm/echo.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kbukum/gokit/ai/chat"
 )
 
-// EchoName is the provider name advertised by [Echo], mirroring rskit's ECHO_NAME.
+// EchoName is the provider name advertised by [Echo].
 const EchoName = "echo"
 
 // Echo is a deterministic, dependency-free [Provider] that replies with the text of the most recent user message.

--- a/logging/README.md
+++ b/logging/README.md
@@ -12,7 +12,7 @@ The `Logger` is a thin ergonomic facade over `*slog.Logger`. All the value-add b
 - Rate-based log sampling (burst + thereafter), clock-injectable for deterministic tests
 - Per-module log level overrides
 - OpenTelemetry Logs bridge (OTLP export)
-- Unified log schema (consistent across gokit, pykit, rskit)
+- Unified log schema (stable structured field names)
 - Context propagation (trace ID, span ID, correlation ID)
 
 ## Quick Start
@@ -316,7 +316,7 @@ defer log.Close()
 
 ## Unified Schema
 
-All three kits (gokit, pykit, rskit) share the same structured field names:
+The structured field names are stable across releases:
 
 | Field | Constant | Description |
 |-------|----------|-------------|

--- a/logging/context.go
+++ b/logging/context.go
@@ -27,11 +27,10 @@ func LoggerFromContext(ctx context.Context) (*Logger, bool) {
 	return log, ok && log != nil
 }
 
-// Span-level context helpers — the gokit equivalent of rskit-logging's
-// context module (component tagging, request enrichment, identifier injection).
+// Span-level context helpers for component tagging, request enrichment, and
+// identifier injection.
 //
-// rskit records identifiers onto the current tracing span, which nested spans
-// inherit automatically. Go contexts are immutable and gokit's Logger reads
+// Go contexts are immutable and gokit's Logger reads
 // identifiers back out of the context (see (*Logger).WithContext), so each
 // ContextWith* helper returns a derived context carrying the identifier and the
 // *Span helpers fold those identifiers into structured log fields.
@@ -67,15 +66,13 @@ func ContextWithCorrelationID(ctx context.Context, id string) context.Context {
 }
 
 // ComponentSpan returns a logger tagged with the component name and enriched
-// with any identifiers already present in ctx — the gokit equivalent of
-// rskit-logging's component_span.
+// with any identifiers already present in ctx.
 func (l *Logger) ComponentSpan(ctx context.Context, name string) *Logger {
 	return l.WithContext(ctx).WithComponent(name)
 }
 
 // RequestSpan returns a logger enriched with HTTP request metadata and any
-// identifiers already present in ctx — the gokit equivalent of rskit-logging's
-// request_span.
+// identifiers already present in ctx.
 func (l *Logger) RequestSpan(ctx context.Context, method, path, requestID string) *Logger {
 	return l.WithContext(ctx).WithFields(map[string]any{
 		FieldHTTPMethod: method,

--- a/logging/fields.go
+++ b/logging/fields.go
@@ -24,7 +24,7 @@ const (
 	FieldHTTPMethod    = "http.method"
 	FieldHTTPPath      = "http.path"
 
-	// Unified schema fields — consistent across gokit, rskit, and pykit.
+	// Unified structured-log schema fields (stable field names).
 	FieldService     = "service"
 	FieldEnvironment = "environment"
 	FieldTimestamp   = "timestamp"
@@ -86,7 +86,7 @@ func MergeWithDuration(fields map[string]any, d time.Duration) map[string]any {
 }
 
 // ServiceFields creates the standard service identification fields
-// for the unified log schema (consistent across gokit, rskit, and pykit).
+// for the unified log schema (stable field names).
 func ServiceFields(service, environment, version string) map[string]any {
 	return map[string]any{
 		FieldService:     service,

--- a/logging/level.go
+++ b/logging/level.go
@@ -7,7 +7,7 @@ import (
 
 // Custom slog levels extending the four stdlib levels
 // ([slog.LevelDebug], [slog.LevelInfo], [slog.LevelWarn], [slog.LevelError])
-// with the trace and fatal levels the unified gokit/rskit/pykit schema uses.
+// with the trace and fatal levels the unified log schema uses.
 const (
 	// LevelTrace is more verbose than [slog.LevelDebug].
 	LevelTrace = slog.Level(-8)

--- a/media/README.md
+++ b/media/README.md
@@ -2,7 +2,7 @@
 
 Light, dependency-free media handling for Go: byte-signature type/format detection, container metadata reads, cheap pure-Go image ops, pure-Go time/spatial vocabulary, and subtitle (SRT/WebVTT) parsing. Zero external dependencies.
 
-`media` is a standalone module (`github.com/kbukum/gokit/media`). It is the **light** mirror of rskit's media capability: Go handles metadata, format and container inspection, cheap image ops, time/spatial math, and subtitle parsing; **heavy audio/video/matrix/DSP processing stays rskit-only by design**. This is a capability decision, not a parity gap — see [Capability split](#capability-split-light-by-design).
+`media` is a standalone module (`github.com/kbukum/gokit/media`). It is deliberately **light**: Go handles metadata, format and container inspection, cheap image ops, time/spatial math, and subtitle parsing; **heavy audio/video/matrix/DSP processing is out of scope by design**. This is a capability decision, not a parity gap — see [Capability split](#capability-split-light-by-design).
 
 ## Install
 
@@ -81,7 +81,7 @@ thumb := media.Thumbnail(img, 256, 256)       // nearest-neighbor, never upscale
 view := media.Crop(img, image.Rect(0, 0, 100, 100))
 ```
 
-Formats outside the stdlib decoders (WebP, TIFF, HEIF, AVIF) are **detected** but not decoded here; decoding/processing those is rskit's or an external service's job. `Decode` reads the header first and rejects inputs above `MaxDecodePixels` to bound memory on untrusted content (decompression bombs).
+Formats outside the stdlib decoders (WebP, TIFF, HEIF, AVIF) are **detected** but not decoded here; decoding/processing those is an external service's job. `Decode` reads the header first and rejects inputs above `MaxDecodePixels` to bound memory on untrusted content (decompression bombs).
 
 ## Time & spatial types (pure Go)
 
@@ -112,7 +112,7 @@ vtt := clip.VTT()                         // convert SRT → WebVTT
 
 ## Capability split (light by design)
 
-| Capability | gokit `media` | rskit `media` |
+| Capability | gokit `media` | Heavy path (external) |
 |---|---|---|
 | Type/format detection (magic bytes) | ✅ | ✅ |
 | Container/metadata read (dimensions) | ✅ (stdlib image) | ✅ |
@@ -124,7 +124,7 @@ vtt := clip.VTT()                         // convert SRT → WebVTT
 | Matrix/DSP, scene detection, waveforms | ➖ (by design) | ✅ |
 | Codec/color/pipeline/output executor vocabulary | ➖ (backend-only) | ✅ |
 
-The heavy path is **rskit or an external service**, never a Go reimplementation. gokit deliberately has **no cgo, no ffmpeg, and no Go DSP/matrix code**. Backend-only vocabulary (codec, color, filter graphs, pipeline/output configs) is intentionally omitted: without a transcoding executor it would be dead surface.
+The heavy path is **an external service**, never a Go reimplementation. gokit deliberately has **no cgo, no ffmpeg, and no Go DSP/matrix code**. Backend-only vocabulary (codec, color, filter graphs, pipeline/output configs) is intentionally omitted: without a transcoding executor it would be dead surface.
 
 ## Supported formats (detection)
 

--- a/media/doc.go
+++ b/media/doc.go
@@ -2,12 +2,12 @@
 // byte-signature type/format detection, container metadata reads, cheap pure-Go image ops,
 // and pure-Go time/spatial vocabulary plus subtitle (SRT/WebVTT) parsing and serialization.
 //
-// It is the light mirror of rskit's media capability. The surface concepts read in parallel —
+// It deliberately covers only the light surface —
 // [Type]/[Info], the [Format]/[FormatInfo] catalog, an injected [Registry],
 // the [Prober] abstraction, [Timestamp]/[TimeRange]/[Resolution], and [SubtitleTrack] —
-// but heavy audio/video/matrix/DSP processing (transcoding, filters, resampling) is rskit-only by design:
+// while heavy audio/video/matrix/DSP processing (transcoding, filters, resampling) stays out of scope by design:
 // a capability decision, not a parity gap. gokit ships no cgo, no ffmpeg,
-// and no Go DSP/matrix code; the heavy path is rskit or an external service,
+// and no Go DSP/matrix code; the heavy path belongs to an external service,
 // never a Go reimplementation.
 //
 // The zero-value entry points classify content without decoding it:

--- a/media/format.go
+++ b/media/format.go
@@ -2,8 +2,7 @@ package media
 
 // Format is a container/codec format identifier (e.g. "mp4", "jpeg", "wav").
 //
-// It is the light-kit parallel of rskit's media Format enum:
-// a typed handle used across detection [Info], the [FormatInfo] catalog, and the [Registry].
+// It is a typed handle used across detection [Info], the [FormatInfo] catalog, and the [Registry].
 type Format string
 
 // Known formats recognized by the byte-signature detector.
@@ -48,8 +47,7 @@ const (
 // FormatInfo is the static catalog entry describing a known [Format]: its media category,
 // canonical extension, MIME type, and container family.
 //
-// It parallels rskit's media FormatInfo;
-// the light kit carries only the fields derivable without decoding the payload.
+// It carries only the fields derivable without decoding the payload.
 type FormatInfo struct {
 	Format    Format `json:"format"`
 	Type      Type   `json:"type"`

--- a/media/image.go
+++ b/media/image.go
@@ -9,7 +9,7 @@ import (
 	// Register the stdlib image decoders
 	// so DecodeConfig/Decode recognize the pure-Go formats the light kit supports.
 	// Heavier formats (webp, tiff, heif) are detected but intentionally not decoded here —
-	// that stays rskit-only.
+	// decoding them is out of scope by design.
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
@@ -96,7 +96,7 @@ func Crop(src image.Image, r image.Rectangle) image.Image {
 // Thumbnail downscales src to fit within maxW×maxH while preserving aspect ratio,
 // using nearest-neighbor sampling. It never upscales:
 // sources already within the bounds are returned unchanged.
-// It is a deliberately cheap pure-Go operation; high-quality resampling belongs in rskit.
+// It is a deliberately cheap pure-Go operation; high-quality resampling is out of scope.
 func Thumbnail(src image.Image, maxW, maxH int) image.Image {
 	b := src.Bounds()
 	w, h := b.Dx(), b.Dy()
@@ -122,7 +122,7 @@ func Thumbnail(src image.Image, maxW, maxH int) image.Image {
 	return dst
 }
 
-// stdlibFormat maps an image/... decoder name to the light-kit [Format].
+// stdlibFormat maps an image/... decoder name to the supported [Format].
 func stdlibFormat(name string) Format {
 	switch name {
 	case "jpeg":

--- a/media/prober.go
+++ b/media/prober.go
@@ -9,8 +9,7 @@ var ErrUnsupported = errors.New("media: unsupported content for prober")
 // Metadata is the enriched result of probing content:
 // the detection [Info] plus any lightweight properties a backend could extract without full processing.
 //
-// It is the light-kit parallel of rskit's media metadata;
-// the light surface carries only cheaply derivable fields (currently image/frame dimensions).
+// The light surface carries only cheaply derivable fields (currently image/frame dimensions).
 type Metadata struct {
 	Info
 	// Resolution is the pixel dimensions for images or video frames,
@@ -20,8 +19,7 @@ type Metadata struct {
 
 // Prober inspects the leading bytes of content
 // and enriches its detection with lightweight properties (e.g. pixel dimensions) for the formats it understands.
-// It is the light-kit parallel of rskit's MediaProbe abstraction —
-// a typed seam that backends implement,
+// It is a typed seam that backends implement,
 // injected into a [Registry] rather than registered through package globals.
 //
 // A [Registry] treats signature detection as authoritative for classification:

--- a/media/registry.go
+++ b/media/registry.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Registry is an application-owned knowledge base of known [Format]s plus a set of injected [Prober] backends.
-// It is the light-kit parallel of rskit's media registry:
+// It is
 // constructed explicitly with functional options, never mutated through package globals
 // and never populated by init side effects.
 //

--- a/media/spatial.go
+++ b/media/spatial.go
@@ -5,8 +5,7 @@ import (
 	"math"
 )
 
-// Resolution is a width × height in pixels.
-// It is the light-kit parallel of rskit's media Resolution and is used to enrich probe [Metadata].
+// Resolution is a width × height in pixels, used to enrich probe [Metadata].
 type Resolution struct {
 	Width  int `json:"width"`
 	Height int `json:"height"`

--- a/media/subtitle.go
+++ b/media/subtitle.go
@@ -31,7 +31,7 @@ type SubtitleEntry struct {
 }
 
 // SubtitleTrack is an ordered collection of subtitle cues.
-// It is the light-kit parallel of rskit's SubtitleTrack, covering the pure-Go concerns —
+// It covers the pure-Go concerns —
 // parsing, serialization, and time math — plus a styling vocabulary
 // ([SubtitleStyle] via [SubtitleTrack.DefaultStyle] and [SubtitleEntry.Style]),
 // but no renderer: it does not rasterize or burn cues into frames.

--- a/media/subtitle_style.go
+++ b/media/subtitle_style.go
@@ -37,7 +37,7 @@ func (a SubtitleAnchor) String() string {
 
 // SubtitlePosition is where a cue is displayed on screen.
 //
-// It is the light-kit parallel of rskit's SubtitlePosition. The zero value is the
+// The zero value is the
 // bottom anchor; X and Y are pixel coordinates that apply only when Anchor is
 // [AnchorCustom] (they are ignored otherwise).
 type SubtitlePosition struct {
@@ -53,7 +53,7 @@ func CustomPosition(x, y uint32) SubtitlePosition {
 
 // SubtitleStyle is the visual styling applied to a cue.
 //
-// It is the light-kit parallel of rskit's SubtitleStyle: it carries the styling
+// It carries the styling
 // vocabulary (font, colors, weight, position) without a renderer. Optional fields
 // use their zero value to mean "unset" — an empty font family or color and a zero
 // font size are renderer defaults. Style resolution ([SubtitleTrack.EffectiveStyle])

--- a/media/time.go
+++ b/media/time.go
@@ -12,8 +12,6 @@ import (
 // and codec formats, avoiding precision loss during conversion. A Timestamp is never negative:
 // constructors and arithmetic clamp at zero
 // and saturate at the maximum representable value on overflow.
-//
-// It is the light-kit parallel of rskit's media Timestamp.
 type Timestamp int64
 
 // TimestampFromMillis builds a [Timestamp] from a millisecond value.
@@ -155,7 +153,6 @@ func (r TimeRange) Shift(offset time.Duration) TimeRange {
 }
 
 // Segment is a labeled time range, useful for chapters, scenes, or detected spans.
-// It is the light-kit parallel of rskit's media Segment, without the backend-specific metadata bag.
 type Segment struct {
 	Range TimeRange `json:"range"`
 	// Label is an optional human-readable name (e.g. "intro", "chorus").

--- a/media/types.go
+++ b/media/types.go
@@ -2,8 +2,8 @@ package media
 
 // Type is the broad media category a piece of content belongs to.
 //
-// It mirrors rskit's media type vocabulary (video/audio/image)
-// and adds the light-kit-specific [Text] category used by the byte-signature detector.
+// It covers the video/audio/image categories
+// and adds the [Text] category used by the byte-signature detector.
 type Type int
 
 const (

--- a/process/io.go
+++ b/process/io.go
@@ -22,8 +22,8 @@ const (
 
 // InputPolicy selects how a subprocess's standard input is wired.
 //
-// When Command.Stdin is non-nil it always takes precedence (the Bytes policy in
-// rskit terms): the reader is fed to the child and then closed. Otherwise the
+// When Command.Stdin is non-nil it always takes precedence (the Bytes
+// policy): the reader is fed to the child and then closed. Otherwise the
 // policy chooses between a closed stdin and inheriting the parent's stdin.
 type InputPolicy int
 

--- a/resilience/backoff.go
+++ b/resilience/backoff.go
@@ -51,8 +51,8 @@ func CalculateJitteredBackoff(attempt int, minDelay, maxDelay time.Duration, jit
 
 // BackoffCalculator is a reusable, immutable exponential-backoff configuration over
 // CalculateBackoff and CalculateJitteredBackoff. It is the stateless-math counterpart
-// to the RetryConfig-driven Retry loop; the type is named BackoffCalculator rather
-// than mirroring rskit's ExponentialBackoff because ExponentialBackoff is already the
+// to the RetryConfig-driven Retry loop; the type is named BackoffCalculator to avoid
+// colliding with ExponentialBackoff, which is already the
 // name of a BackoffStrategy constant in this package.
 type BackoffCalculator struct {
 	minDelay time.Duration

--- a/server/middleware/auth_policy.go
+++ b/server/middleware/auth_policy.go
@@ -3,8 +3,7 @@ package middleware
 // MissingTokenPolicy governs how the auth middleware treats a request that carries no credentials.
 // It never affects invalid credentials: a token that is present
 // but fails validation is always rejected with 401, regardless of policy.
-// This mirrors rskit's MissingCredentialPolicy
-// so both kits express the AcceptMissing / reject-invalid split identically.
+// It expresses the AcceptMissing / reject-invalid split explicitly.
 type MissingTokenPolicy int
 
 const (

--- a/stream/README.md
+++ b/stream/README.md
@@ -4,7 +4,7 @@
 
 `stream` provides lazy, backpressure-aware data processing for Go. Pipelines pull values on demand — no work happens until you call `Collect`, `Drain`, or `ForEach`. This design naturally handles flow control without buffering or blocking. For the genuinely push-shaped "one source, many observers" case, `Broadcaster` fans events out to independent subscribers with bounded, drop-on-overflow buffers.
 
-gokit converges on the [`rskit-stream`](https://github.com/kbukum/rskit/tree/main/core/rskit-stream) operator vocabulary (`map`/`filter`/`fan_out`/`window`/`batch`/`parallel`/`merge`/`partition`/…) and its `Broadcaster`, expressed idiomatically in Go: a pull iterator for transformation pipelines and a bounded channel bus for fan-out. No operator buffers without bound.
+gokit provides a stream operator vocabulary (`map`/`filter`/`fan_out`/`window`/`batch`/`parallel`/`merge`/`partition`/…) and a `Broadcaster`, expressed idiomatically in Go: a pull iterator for transformation pipelines and a bounded channel bus for fan-out. No operator buffers without bound.
 
 ## Features
 

--- a/stream/doc.go
+++ b/stream/doc.go
@@ -3,14 +3,14 @@
 //
 // # Canonical shape
 //
-// gokit converges on the rskit-stream operator vocabulary (map/filter/fan_out/window/batch/parallel/merge/partition/…)
-// but keeps an idiomatic Go pull-iterator model for transformation pipelines: pipelines are lazy —
+// The operator vocabulary (map/filter/fan_out/window/batch/parallel/merge/partition/…)
+// uses an idiomatic Go pull-iterator model for transformation pipelines: pipelines are lazy —
 // no work happens until values are pulled via Collect, Drain, or ForEach,
 // and each stage pulls from the previous stage on demand. Pull gives natural,
 // allocation-free backpressure without an explicit flow-control protocol.
 //
 // The genuinely push-shaped concern — fanning one source out to many independent observers —
-// is served by Broadcaster, mirroring rskit's Broadcaster<T>.
+// is served by Broadcaster.
 // Every subscriber owns a private bounded channel;
 // a subscriber that lags beyond its buffer drops overflow (backpressure by drop)
 // but never blocks the broadcaster or its peers.

--- a/util/hash.go
+++ b/util/hash.go
@@ -13,8 +13,8 @@ import (
 // digest, backed by BLAKE3. Feed bytes with Update (raw) or UpdateFramed
 // (domain-separated), then read the digest with FinalizeHex. Finalizing does not
 // consume the hasher, so it may be reused. BLAKE3 is the canonical content hash for
-// cache keys, change detection, and deduplication; the digest identity matches the
-// rskit and pykit content hashers.
+// cache keys, change detection, and deduplication; the digest identity is a stable
+// content-hash format.
 type ContentHasher struct {
 	inner *blake3.Hasher
 }

--- a/util/secret.go
+++ b/util/secret.go
@@ -10,8 +10,8 @@ const secretMask = "***"
 // SecretString wraps a string so it does not leak through logging, formatting, or
 // JSON serialization. The plaintext is reachable only through Expose, marshals as
 // the mask "***", and unmarshals from plaintext so a SecretString can be populated
-// from config. Go provides no guaranteed in-memory zeroization, so unlike the rskit
-// counterpart the backing bytes are not scrubbed on drop; treat process memory as a
+// from config. Go provides no guaranteed in-memory zeroization, so the backing
+// bytes are not scrubbed on drop; treat process memory as a
 // separate trust boundary.
 type SecretString struct {
 	value string


### PR DESCRIPTION
## Description

Makes gokit read as a standalone project by removing unnecessary cross-kit provenance from godoc, inline comments, and package READMEs. Comments that only narrated how a package is "the light-kit parallel of rskit's X" or "mirrors rskit's Y" are rewritten to describe what the gokit code actually does. This follows the baseline rule that comments describe the code as it is now, not the process that produced it.

## Motivation

A reader of gokit source should understand it without needing to know rskit or pykit exists. Parity is tracked deliberately in dedicated places (PARITY-MATRIX, README positioning, ADRs); it should not leak sibling names into every package's doc headers.

## Type of Change

- [x] Documentation update

## Module(s) Affected

- media, chain, stream, dataset, logging, config, resilience, errors, grpc, encryption, util, llm, process, server/middleware, cli

## Changes Made

- Rewrote "mirror/parallel of rskit's X" godoc and README prose to describe each package's own responsibility.
- Reframed genuine contracts as format/schema/wire contracts rather than sibling references: bench schema, encryption envelope wire format, unified structured-log field names, error-to-status mapping surface.
- Preserved intentional-divergence rationale in `media`/`dataset` (light-by-design, capability decision not a parity gap) — only the bare "mirror of rskit" lead-ins were dropped.
- Left intact: PARITY-MATRIX, README positioning, ADRs, tooling docs, and the `IMPROVE-RSKIT` backlog tag.

## Testing

- [x] `make fmt` reports no diffs (`gofmt` clean on touched files)
- [x] `make lint` clean (`go vet` passes for touched packages)
- [ ] `govulncheck ./...` (not run — comment-only change, no dependency/code change)

Comment/doc-only change; verified every `.go` edit is comment-only and touched packages build and vet cleanly.

## Breaking Changes

None. Documentation-only; no code, identifiers, signatures, or public API changed.

## Sibling Parity

- [x] Sibling-parity not required (documentation-only; no public abstraction changed). The same decoupling is applied in rskit (https://github.com/kbukum/rskit/pull/339) and pykit as parallel PRs.

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
