### PR TITLE
fix(ci): align retry error-contract test and tidy stateful module

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -182,12 +182,19 @@ func TestIntegration_Errors_Resilience_RetryPreservesAppError(t *testing.T) {
 	if attempts != 3 {
 		t.Errorf("expected 3 attempts, got %d", attempts)
 	}
-	// The underlying error should still be our AppError
+	// Exhausting retries surfaces ErrMaxRetriesExceeded while preserving the
+	// original AppError as the cause, so callers can branch on the sentinel and
+	// still unwrap the underlying failure.
+	if !errors.Is(err, resilience.ErrMaxRetriesExceeded) {
+		t.Errorf("expected ErrMaxRetriesExceeded, got %v", err)
+	}
 	var appErr *appErrors.AppError
-	if errors.As(err, &appErr) {
+	if errors.As(errors.Unwrap(err), &appErr) {
 		if appErr.Code != appErrors.ErrCodeTimeout {
-			t.Errorf("expected TIMEOUT code, got %s", appErr.Code)
+			t.Errorf("expected TIMEOUT code on cause, got %s", appErr.Code)
 		}
+	} else {
+		t.Errorf("expected cause to be an AppError, got %v", errors.Unwrap(err))
 	}
 }
 

--- a/stateful/go.mod
+++ b/stateful/go.mod
@@ -3,3 +3,13 @@ module github.com/kbukum/gokit/stateful
 go 1.26.0
 
 toolchain go1.26.6
+
+require github.com/kbukum/gokit v0.2.0
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/zeebo/blake3 v0.2.4 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+)
+
+replace github.com/kbukum/gokit => ..

--- a/stateful/go.sum
+++ b/stateful/go.sum
@@ -1,0 +1,10 @@
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Description

Fixes the two failing gates on `main` CI: the root integration suite and the Preflight tidy check.

The `Retry` helper now surfaces `ErrMaxRetriesExceeded` (SERVICE_UNAVAILABLE) and preserves the original error as its cause, so the integration assertion that expected the outer error to carry the TIMEOUT code was stale. It now branches on the sentinel and unwraps the cause to verify the underlying `AppError`. Separately, the `stateful` module's `go.mod` was missing its intra-repo require and local replace, so `go mod tidy` was dirty in CI.

## Motivation

`main` CI was red on Integration (`TestIntegration_Errors_Resilience_RetryPreservesAppError`) and Preflight ("Verify modules are tidy"). Both are hard gates and block the pipeline.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Module(s) Affected

- root (integration suite)
- stateful (module metadata)

## Changes Made

- Align the retry integration assertion with the current error contract: expect `ErrMaxRetriesExceeded`, then unwrap to confirm the cause is the original TIMEOUT `AppError`.
- Tidy the `stateful` module: add the `github.com/kbukum/gokit` require, the local `replace => ..` (via `gomod.sh replace-sync`), and the resulting `go.sum`.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally

### Test Evidence

```
$ go test -tags integration .
ok  	github.com/kbukum/gokit

$ ./gomod.sh replace-sync --check
replace graph complete: every intra-repo require has a local replace

$ ./gomod.sh tidy   # clean, no diff
✓ All modules completed successfully.
```

## Breaking Changes

None.

## Sibling Parity

- [x] Sibling-parity not required (internal change)

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] Bug fixes include a regression test that fails without the fix
- [x] `make tidy` run so go.mod/go.sum are clean for affected modules

## Additional Notes

The Fuzz-smoke annotation in the referenced run is a self-reported harness-deadline race that is treated as a pass; it is not addressed here.
