### PR TITLE
refactor(transport): align config and JSON wire shapes across kits

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -289,6 +289,7 @@ func loadFromResolvedFiles(cfg any, plan loadPlan) error {
 			logging.OutputDecodeHook(),
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
+			mapstructure.TextUnmarshallerHookFunc(),
 		),
 	)); err != nil {
 		return fmt.Errorf("failed to unmarshal config for service %s: %w", serviceName, err)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -15,17 +16,42 @@ var (
 )
 
 // ServiceInstance represents a discovered service endpoint.
+//
+// Its JSON encoding is gokit's stable discovery contract: snake_case field
+// names, a tri-state Health that is always one of "unknown"/"healthy"/
+// "unhealthy", and an omitted Weight that decodes to 1. It is the shape gokit
+// emits and accepts across its discovery backends; cross-kit alignment with
+// rskit is tracked separately and is not yet byte-for-byte identical.
 type ServiceInstance struct {
-	ID       string
-	Name     string
-	Address  string
-	Port     int
-	Protocol string
-	Tags     []string
-	Metadata map[string]string
-	Health   HealthStatus
-	Weight   int
-	LastSeen time.Time
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Address  string            `json:"address"`
+	Port     int               `json:"port"`
+	Protocol string            `json:"protocol"`
+	Tags     []string          `json:"tags"`
+	Metadata map[string]string `json:"metadata"`
+	Health   HealthStatus      `json:"health"`
+	Weight   int               `json:"weight"`
+	LastSeen time.Time         `json:"last_seen"`
+}
+
+// UnmarshalJSON decodes a ServiceInstance, defaulting an omitted Weight to 1 so
+// weighted balancing treats an unspecified instance as a single unit of load
+// (an explicit "weight": 0 is preserved as-is), and an omitted Health to
+// HealthUnknown so the field is always one of the tri-state values. A present
+// but out-of-range Health is rejected so a malformed payload cannot enter the
+// model.
+func (s *ServiceInstance) UnmarshalJSON(data []byte) error {
+	type alias ServiceInstance
+	tmp := alias{Weight: 1, Health: HealthUnknown}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if !tmp.Health.valid() {
+		return fmt.Errorf("discovery: invalid health status %q", string(tmp.Health))
+	}
+	*s = ServiceInstance(tmp)
+	return nil
 }
 
 // Endpoint is an alias for ServiceInstance, providing a shorter name
@@ -33,7 +59,7 @@ type ServiceInstance struct {
 type Endpoint = ServiceInstance
 
 // HostPort returns the host:port string (e.g., "192.168.1.5:8080").
-// Use this to set client Config.Addr from a discovered endpoint.
+// Use this to set a client's target address from a discovered endpoint.
 func (s ServiceInstance) HostPort() string {
 	return fmt.Sprintf("%s:%d", s.Address, s.Port)
 }
@@ -46,6 +72,29 @@ const (
 	HealthHealthy   HealthStatus = "healthy"
 	HealthUnhealthy HealthStatus = "unhealthy"
 )
+
+// valid reports whether h is one of the defined tri-state values.
+func (h HealthStatus) valid() bool {
+	switch h {
+	case HealthUnknown, HealthHealthy, HealthUnhealthy:
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalJSON encodes HealthStatus, mapping the zero value to "unknown" so the
+// wire form is always populated. Any other out-of-range value is rejected so an
+// invalid in-memory status cannot be emitted as a valid-looking payload.
+func (h HealthStatus) MarshalJSON() ([]byte, error) {
+	if h == "" {
+		h = HealthUnknown
+	}
+	if !h.valid() {
+		return nil, fmt.Errorf("discovery: invalid health status %q", string(h))
+	}
+	return json.Marshal(string(h))
+}
 
 // Discovery defines the contract for discovering service instances.
 type Discovery interface {

--- a/discovery/instance_json_test.go
+++ b/discovery/instance_json_test.go
@@ -1,0 +1,153 @@
+package discovery_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kbukum/gokit/contracttest/golden"
+	"github.com/kbukum/gokit/discovery"
+)
+
+// The ServiceInstance wire shape is gokit's stable discovery contract:
+// snake_case fields, tri-state health (unknown/healthy/unhealthy), an explicit
+// protocol and last_seen, and an omitted weight that decodes to 1.
+
+func TestServiceInstanceGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	inst := discovery.ServiceInstance{
+		ID:       "orders-10.0.0.5-8080",
+		Name:     "orders",
+		Address:  "10.0.0.5",
+		Port:     8080,
+		Protocol: "http",
+		Tags:     []string{"canary", "us-east-1"},
+		Metadata: map[string]string{"zone": "a"},
+		Health:   discovery.HealthHealthy,
+		Weight:   5,
+		LastSeen: time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("marshal ServiceInstance: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"id": "orders-10.0.0.5-8080",
+		"name": "orders",
+		"address": "10.0.0.5",
+		"port": 8080,
+		"protocol": "http",
+		"tags": ["canary", "us-east-1"],
+		"metadata": {"zone": "a"},
+		"health": "healthy",
+		"weight": 5,
+		"last_seen": "2026-03-05T10:00:00Z"
+	}`)
+}
+
+func TestServiceInstanceOmittedWeightDefaultsToOne(t *testing.T) {
+	t.Parallel()
+
+	var inst discovery.ServiceInstance
+	if err := json.Unmarshal([]byte(`{
+		"id": "a",
+		"name": "svc",
+		"address": "10.0.0.1",
+		"port": 9090,
+		"protocol": "grpc",
+		"health": "unknown"
+	}`), &inst); err != nil {
+		t.Fatalf("unmarshal ServiceInstance: %v", err)
+	}
+	if inst.Weight != 1 {
+		t.Errorf("omitted weight: got %d want 1", inst.Weight)
+	}
+	if inst.Health != discovery.HealthUnknown {
+		t.Errorf("health: got %q want unknown", inst.Health)
+	}
+}
+
+func TestServiceInstanceExplicitZeroWeightPreserved(t *testing.T) {
+	t.Parallel()
+
+	var inst discovery.ServiceInstance
+	if err := json.Unmarshal([]byte(`{"id":"a","name":"svc","weight":0}`), &inst); err != nil {
+		t.Fatalf("unmarshal ServiceInstance: %v", err)
+	}
+	if inst.Weight != 0 {
+		t.Errorf("explicit zero weight: got %d want 0", inst.Weight)
+	}
+}
+
+func TestServiceInstanceZeroHealthMarshalsUnknown(t *testing.T) {
+	t.Parallel()
+
+	// A zero-value Health must serialize as the tri-state "unknown", never "".
+	data, err := json.Marshal(discovery.ServiceInstance{ID: "a", Name: "svc"})
+	if err != nil {
+		t.Fatalf("marshal ServiceInstance: %v", err)
+	}
+	var decoded struct {
+		Health string `json:"health"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if decoded.Health != "unknown" {
+		t.Errorf("zero health: got %q want %q", decoded.Health, "unknown")
+	}
+}
+
+func TestServiceInstanceOmittedHealthDefaultsToUnknown(t *testing.T) {
+	t.Parallel()
+
+	var inst discovery.ServiceInstance
+	if err := json.Unmarshal([]byte(`{"id":"a","name":"svc"}`), &inst); err != nil {
+		t.Fatalf("unmarshal ServiceInstance: %v", err)
+	}
+	if inst.Health != discovery.HealthUnknown {
+		t.Errorf("omitted health: got %q want unknown", inst.Health)
+	}
+}
+
+func TestServiceInstanceUnmarshalRejectsInvalidHealth(t *testing.T) {
+	t.Parallel()
+
+	var inst discovery.ServiceInstance
+	err := json.Unmarshal([]byte(`{"id":"x","health":"degraded"}`), &inst)
+	if err == nil {
+		t.Fatal("expected error decoding out-of-range health, got nil")
+	}
+}
+
+func TestServiceInstanceUnmarshalDefaultsHealthUnknown(t *testing.T) {
+	t.Parallel()
+
+	var inst discovery.ServiceInstance
+	if err := json.Unmarshal([]byte(`{"id":"x"}`), &inst); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if inst.Health != discovery.HealthUnknown {
+		t.Fatalf("omitted health: got %q want unknown", inst.Health)
+	}
+	if inst.Weight != 1 {
+		t.Fatalf("omitted weight: got %d want 1", inst.Weight)
+	}
+}
+
+func TestHealthStatusMarshalRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	if _, err := json.Marshal(discovery.HealthStatus("degraded")); err == nil {
+		t.Fatal("expected error marshaling out-of-range health, got nil")
+	}
+	got, err := json.Marshal(discovery.HealthStatus(""))
+	if err != nil {
+		t.Fatalf("marshal zero health: %v", err)
+	}
+	if string(got) != `"unknown"` {
+		t.Fatalf("zero health: got %s want \"unknown\"", got)
+	}
+}

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -71,15 +71,14 @@ func buildDialOptions(cfg grpccfg.Config, log *logging.Logger) ([]grpc.DialOptio
 		}),
 		// Message size limits
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize),
-			grpc.MaxCallSendMsgSize(cfg.MaxSendMsgSize),
+			grpc.MaxCallRecvMsgSize(cfg.MaxMessageSize),
+			grpc.MaxCallSendMsgSize(cfg.MaxSendMessageSize),
 		),
 	)
 
 	// Unary interceptors: logging → resilience
 	unary := []grpc.UnaryClientInterceptor{interceptor.UnaryClientLoggingInterceptor(log)}
-	if cfg.CallTimeout > 0 {
-		policy := resilience.NewPolicy().WithTimeoutIfUnset(cfg.CallTimeout)
+	if policy := resiliencePolicyFor(cfg); policy != nil {
 		unary = append(unary, interceptor.UnaryClientResilienceInterceptor(policy))
 	}
 	opts = append(opts,
@@ -91,6 +90,26 @@ func buildDialOptions(cfg grpccfg.Config, log *logging.Logger) ([]grpc.DialOptio
 	)
 
 	return opts, nil
+}
+
+// resiliencePolicyFor returns the unary resilience policy for a client config.
+// An explicit ResiliencePolicy is used as-is (its retry block, if present,
+// defaults to the gRPC-aware IsRetryable predicate); otherwise a timeout-only
+// policy is derived from Timeout, and nil is returned when neither is set.
+func resiliencePolicyFor(cfg grpccfg.Config) *resilience.Policy {
+	if p := cfg.ResiliencePolicy; p != nil {
+		if p.Retry != nil && p.Retry.RetryIf == nil {
+			p.Retry.RetryIf = interceptor.IsRetryable
+		}
+		if p.Timeout == 0 && cfg.Timeout > 0 {
+			p.WithTimeoutIfUnset(cfg.Timeout)
+		}
+		return p
+	}
+	if cfg.Timeout > 0 {
+		return resilience.NewPolicy().WithTimeoutIfUnset(cfg.Timeout)
+	}
+	return nil
 }
 
 // transportCredentials returns the appropriate transport credentials.

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -29,15 +29,15 @@ func testLogger() *logging.Logger { return logging.NewDefault("test") }
 
 func validInsecureConfig() grpccfg.Config {
 	return grpccfg.Config{
-		Name:           "test-svc",
-		Addr:           "passthrough:///localhost:50051",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
+		Name:               "test-svc",
+		Target:             "passthrough:///localhost:50051",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
 		Keepalive: grpccfg.KeepaliveConfig{
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,
 		},
-		CallTimeout: 5 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 }
 
@@ -137,7 +137,7 @@ func TestNewClient_AppliesDefaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := grpccfg.Config{
-		Addr: "passthrough:///localhost:9090",
+		Target: "passthrough:///localhost:9090",
 	}
 	log := testLogger()
 
@@ -150,28 +150,28 @@ func TestNewClient_AppliesDefaults(t *testing.T) {
 func TestNewClient_ValidationFailure_EmptyAddr(t *testing.T) {
 	t.Parallel()
 
-	// ApplyDefaults will fill Addr, so we need zero MaxRecvMsgSize to cause failure.
+	// ApplyDefaults will fill Addr, so we need zero MaxMessageSize to cause failure.
 	// Actually, ApplyDefaults is called first, so Addr will be set.
 	// The only way to fail validation after defaults is negative msg size.
 	cfg := grpccfg.Config{
-		MaxRecvMsgSize: -1,
+		MaxMessageSize: -1,
 	}
 	log := testLogger()
 
 	conn, err := NewClient(cfg, log)
 	require.Error(t, err)
 	assert.Nil(t, conn)
-	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
+	assert.Contains(t, err.Error(), "max_message_size must be positive")
 }
 
 func TestNewClient_ValidationFailure_BadTLS(t *testing.T) {
 	t.Parallel()
 
 	cfg := grpccfg.Config{
-		Addr:           "passthrough:///localhost:50051",
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-		TLS:            &security.TLSConfig{CertFile: "/nonexistent.pem"},
+		Target:             "passthrough:///localhost:50051",
+		MaxMessageSize:     1024,
+		MaxSendMessageSize: 1024,
+		TLS:                &security.TLSConfig{CertFile: "/nonexistent.pem"},
 	}
 	log := testLogger()
 
@@ -180,11 +180,11 @@ func TestNewClient_ValidationFailure_BadTLS(t *testing.T) {
 	assert.Nil(t, conn)
 }
 
-func TestNewClient_WithCallTimeout(t *testing.T) {
+func TestNewClient_WithTimeout(t *testing.T) {
 	t.Parallel()
 
 	cfg := validInsecureConfig()
-	cfg.CallTimeout = 2 * time.Second
+	cfg.Timeout = 2 * time.Second
 	log := testLogger()
 
 	conn, err := NewClient(cfg, log)
@@ -242,7 +242,7 @@ func TestNewAdapter_InsecureConfig(t *testing.T) {
 func TestNewAdapter_ValidationFailure(t *testing.T) {
 	t.Parallel()
 
-	cfg := grpccfg.Config{MaxRecvMsgSize: -1}
+	cfg := grpccfg.Config{MaxMessageSize: -1}
 	log := testLogger()
 
 	adapter, err := NewAdapter(cfg, log)
@@ -289,8 +289,8 @@ func TestAdapter_GetConfig(t *testing.T) {
 
 	got := adapter.GetConfig()
 	assert.Equal(t, cfg.Name, got.Name)
-	// Addr may have been modified by ApplyDefaults inside NewClient
-	assert.NotEmpty(t, got.Addr)
+	// Target may have been modified by ApplyDefaults inside NewClient
+	assert.NotEmpty(t, got.Target)
 }
 
 func TestAdapter_IsAvailable(t *testing.T) {
@@ -673,7 +673,7 @@ func TestClientOptionsBuilder_GetDialTimeout(t *testing.T) {
 	t.Parallel()
 
 	cfg := validInsecureConfig()
-	cfg.CallTimeout = 15 * time.Second
+	cfg.Timeout = 15 * time.Second
 	builder := NewClientOptionsBuilder(&cfg)
 	assert.Equal(t, 15*time.Second, builder.GetDialTimeout())
 }
@@ -682,7 +682,7 @@ func TestClientOptionsBuilder_GetDialTimeout_Default(t *testing.T) {
 	t.Parallel()
 
 	cfg := validInsecureConfig()
-	cfg.CallTimeout = 0
+	cfg.Timeout = 0
 	builder := NewClientOptionsBuilder(&cfg)
 	assert.Equal(t, 10*time.Second, builder.GetDialTimeout())
 }
@@ -836,4 +836,34 @@ func TestTryOpenStream_Timeout(t *testing.T) {
 	result, err := TryOpenStream(context.Background(), conn, 50*time.Millisecond, opener)
 	require.Error(t, err)
 	assert.Equal(t, 0, result)
+}
+
+func TestResiliencePolicyFor_ConfigPolicyDefaultsRetryPredicate(t *testing.T) {
+	t.Parallel()
+
+	cfg := grpccfg.Config{
+		Target:  "localhost:50051",
+		Timeout: 2 * time.Second,
+		ResiliencePolicy: resilience.NewPolicy().WithRetry(resilience.RetryConfig{
+			MaxAttempts: 3,
+		}),
+	}
+
+	policy := resiliencePolicyFor(cfg)
+	require.NotNil(t, policy)
+	require.NotNil(t, policy.Retry)
+	require.NotNil(t, policy.Retry.RetryIf, "config retry block should default to the gRPC-aware predicate")
+	// Timeout is seeded from Timeout when the policy leaves it unset.
+	assert.Equal(t, 2*time.Second, policy.Timeout)
+}
+
+func TestResiliencePolicyFor_TimeoutOnlyWhenNoPolicy(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, resiliencePolicyFor(grpccfg.Config{Target: "x:1"}))
+
+	policy := resiliencePolicyFor(grpccfg.Config{Target: "x:1", Timeout: time.Second})
+	require.NotNil(t, policy)
+	assert.Nil(t, policy.Retry)
+	assert.Equal(t, time.Second, policy.Timeout)
 }

--- a/grpc/client/discovery_factory.go
+++ b/grpc/client/discovery_factory.go
@@ -147,8 +147,8 @@ func (f *DiscoveryConnectionFactory) buildDialOptions() ([]grpc.DialOption, erro
 		}),
 		// Message size limits
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(f.gRPCCfg.MaxRecvMsgSize),
-			grpc.MaxCallSendMsgSize(f.gRPCCfg.MaxSendMsgSize),
+			grpc.MaxCallRecvMsgSize(f.gRPCCfg.MaxMessageSize),
+			grpc.MaxCallSendMsgSize(f.gRPCCfg.MaxSendMessageSize),
 		),
 	)
 

--- a/grpc/client/discovery_factory_test.go
+++ b/grpc/client/discovery_factory_test.go
@@ -74,9 +74,9 @@ func TestDiscoveryConnectionFactory_NewConn_Success(t *testing.T) {
 	})
 
 	cfg := grpccfg.Config{
-		Addr:           "localhost:50055",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
+		Target:             "localhost:50055",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
 	}
 	dc := discovery.NewClient(mockDisc, discovery.ClientConfig{CacheTTL: 30}, log)
 	factory := NewDiscoveryConnectionFactory(dc, cfg, log)
@@ -101,14 +101,14 @@ func TestDiscoveryConnectionFactory_NewConn_InvalidConfig(t *testing.T) {
 		Weight:  1,
 	})
 
-	cfg := grpccfg.Config{MaxRecvMsgSize: -1}
+	cfg := grpccfg.Config{MaxMessageSize: -1}
 	dc := discovery.NewClient(mockDisc, discovery.ClientConfig{CacheTTL: 30}, log)
 	factory := NewDiscoveryConnectionFactory(dc, cfg, log)
 
 	conn, err := factory.NewConn("orders")
 	require.Error(t, err)
 	require.Nil(t, conn)
-	require.Contains(t, err.Error(), "max_recv_msg_size must be positive")
+	require.Contains(t, err.Error(), "max_message_size must be positive")
 }
 
 // TestDiscoveryConnectionFactory_NewConn_TLS covers the TLS transport-credentials
@@ -125,10 +125,10 @@ func TestDiscoveryConnectionFactory_NewConn_TLS(t *testing.T) {
 	})
 
 	cfg := grpccfg.Config{
-		Addr:           "localhost:50055",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
-		TLS:            &security.TLSConfig{SkipVerify: true, ServerName: "orders.internal"},
+		Target:             "localhost:50055",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
+		TLS:                &security.TLSConfig{SkipVerify: true, ServerName: "orders.internal"},
 	}
 	dc := discovery.NewClient(mockDisc, discovery.ClientConfig{CacheTTL: 30}, log)
 	factory := NewDiscoveryConnectionFactory(dc, cfg, log)
@@ -145,9 +145,9 @@ func TestNewDiscoveryConnectionFactory(t *testing.T) {
 	mockDisc := NewMockDiscovery()
 
 	cfg := grpccfg.Config{
-		Addr:           "localhost:50051",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
+		Target:             "localhost:50051",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
 	}
 
 	// Create a real discovery.Client wrapping the mock
@@ -165,9 +165,9 @@ func TestDiscoveryConnectionFactoryDiscoveryFailure(t *testing.T) {
 	mockDisc := NewMockDiscovery().WithFailure(true)
 
 	cfg := grpccfg.Config{
-		Addr:           "localhost:50051",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
+		Target:             "localhost:50051",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
 	}
 	cfg.ApplyDefaults()
 
@@ -224,9 +224,9 @@ func BenchmarkDiscoveryConnectionFactoryNewConn(b *testing.B) {
 	mockDisc.WithService("bench-service", inst)
 
 	cfg := grpccfg.Config{
-		Addr:           "localhost:50051",
-		MaxRecvMsgSize: 4 * 1024 * 1024,
-		MaxSendMsgSize: 4 * 1024 * 1024,
+		Target:             "localhost:50051",
+		MaxMessageSize:     4 * 1024 * 1024,
+		MaxSendMessageSize: 4 * 1024 * 1024,
 	}
 	cfg.ApplyDefaults()
 

--- a/grpc/client/options.go
+++ b/grpc/client/options.go
@@ -31,11 +31,19 @@ func DefaultRetryPolicy() *resilience.RetryConfig {
 }
 
 // NewClientOptionsBuilder creates a new options builder from gokit gRPC config.
+// A ResiliencePolicy set on the config is honored as the client's policy;
+// otherwise the builder seeds a timeout-plus-default-retry policy.
 func NewClientOptionsBuilder(cfg *grpccfg.Config) *ClientOptionsBuilder {
+	policy := cfg.ResiliencePolicy
+	if policy == nil {
+		policy = resilience.NewPolicy().WithTimeoutIfUnset(cfg.Timeout).WithRetry(*DefaultRetryPolicy())
+	} else if policy.Timeout == 0 && cfg.Timeout > 0 {
+		policy.WithTimeoutIfUnset(cfg.Timeout)
+	}
 	return &ClientOptionsBuilder{
 		config:           cfg,
 		enableLogging:    true,
-		resiliencePolicy: resilience.NewPolicy().WithTimeoutIfUnset(cfg.CallTimeout).WithRetry(*DefaultRetryPolicy()),
+		resiliencePolicy: policy,
 	}
 }
 
@@ -48,7 +56,7 @@ func (b *ClientOptionsBuilder) WithLogging(enabled bool) *ClientOptionsBuilder {
 // WithRetryPolicy sets or disables the retry portion of the client resilience policy.
 func (b *ClientOptionsBuilder) WithRetryPolicy(cfg *resilience.RetryConfig) *ClientOptionsBuilder {
 	if b.resiliencePolicy == nil {
-		b.resiliencePolicy = resilience.NewPolicy().WithTimeoutIfUnset(b.config.CallTimeout)
+		b.resiliencePolicy = resilience.NewPolicy().WithTimeoutIfUnset(b.config.Timeout)
 	}
 	if cfg == nil {
 		b.resiliencePolicy.Retry = nil
@@ -131,8 +139,8 @@ func (b *ClientOptionsBuilder) buildStreamInterceptors() []grpc.StreamClientInte
 
 // GetDialTimeout returns the configured call timeout as dial timeout.
 func (b *ClientOptionsBuilder) GetDialTimeout() time.Duration {
-	if b.config.CallTimeout > 0 {
-		return b.config.CallTimeout
+	if b.config.Timeout > 0 {
+		return b.config.Timeout
 	}
 	return 10 * time.Second
 }

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kbukum/gokit/resilience"
 	"github.com/kbukum/gokit/security"
 )
 
@@ -21,13 +22,13 @@ type KeepaliveConfig struct {
 type Config struct {
 	// Name identifies this adapter instance (used by provider.Provider interface).
 	Name string `mapstructure:"name"`
-	// Addr is the gRPC server target (e.g., "localhost:50051"). Set statically via config
+	// Target is the gRPC server target (e.g., "localhost:50051"). Set statically via config
 	// or dynamically via discovery (endpoint.HostPort()).
-	Addr string `mapstructure:"addr"`
-	// MaxRecvMsgSize is the maximum message size the client can receive (bytes).
-	MaxRecvMsgSize int `mapstructure:"max_recv_msg_size"`
-	// MaxSendMsgSize is the maximum message size the client can send (bytes).
-	MaxSendMsgSize int `mapstructure:"max_send_msg_size"`
+	Target string `mapstructure:"target"`
+	// MaxMessageSize is the maximum message size the client can receive (bytes).
+	MaxMessageSize int `mapstructure:"max_message_size"`
+	// MaxSendMessageSize is the maximum message size the client can send (bytes).
+	MaxSendMessageSize int `mapstructure:"max_send_message_size"`
 	// Keepalive holds keepalive configuration.
 	Keepalive KeepaliveConfig `mapstructure:"keepalive"`
 	// TLS holds TLS configuration.
@@ -35,29 +36,34 @@ type Config struct {
 	TLS *security.TLSConfig `mapstructure:"tls"`
 	// Enabled controls whether gRPC is active.
 	Enabled bool `mapstructure:"enabled"`
-	// CallTimeout is the default timeout for unary RPCs.
-	CallTimeout time.Duration `mapstructure:"call_timeout"`
+	// Timeout is the default timeout for unary RPCs.
+	Timeout time.Duration `mapstructure:"timeout"`
+	// ResiliencePolicy configures the retry / circuit-breaker / rate-limiter
+	// stack applied to unary RPCs via the client resilience interceptor. Nil
+	// applies timeout-only behavior derived from Timeout. It uses the shared
+	// resilience.Policy vocabulary, the same block understood by the httpclient
+	// transport.
+	ResiliencePolicy *resilience.Policy `mapstructure:"resilience_policy"`
 }
 
 const (
-	defaultAddr             = "localhost:50051"
-	defaultMaxRecvMsgSize   = 4 * 1024 * 1024 // 4 MB
-	defaultMaxSendMsgSize   = 4 * 1024 * 1024 // 4 MB
+	defaultTarget           = "localhost:50051"
+	defaultMaxMessageSize   = 4 * 1024 * 1024 // 4 MB
 	defaultKeepaliveTime    = 30 * time.Second
 	defaultKeepaliveTimeout = 10 * time.Second
-	defaultCallTimeout      = 30 * time.Second
+	defaultTimeout          = 30 * time.Second
 )
 
 // ApplyDefaults fills in zero-value fields with sensible defaults.
 func (c *Config) ApplyDefaults() {
-	if c.Addr == "" {
-		c.Addr = defaultAddr
+	if c.Target == "" {
+		c.Target = defaultTarget
 	}
-	if c.MaxRecvMsgSize == 0 {
-		c.MaxRecvMsgSize = defaultMaxRecvMsgSize
+	if c.MaxMessageSize == 0 {
+		c.MaxMessageSize = defaultMaxMessageSize
 	}
-	if c.MaxSendMsgSize == 0 {
-		c.MaxSendMsgSize = defaultMaxSendMsgSize
+	if c.MaxSendMessageSize == 0 {
+		c.MaxSendMessageSize = defaultMaxMessageSize
 	}
 	if c.Keepalive.Time == 0 {
 		c.Keepalive.Time = defaultKeepaliveTime
@@ -65,21 +71,21 @@ func (c *Config) ApplyDefaults() {
 	if c.Keepalive.Timeout == 0 {
 		c.Keepalive.Timeout = defaultKeepaliveTimeout
 	}
-	if c.CallTimeout == 0 {
-		c.CallTimeout = defaultCallTimeout
+	if c.Timeout == 0 {
+		c.Timeout = defaultTimeout
 	}
 }
 
 // Validate checks that the configuration is valid.
 func (c *Config) Validate() error {
-	if c.Addr == "" {
-		return fmt.Errorf("grpc: addr must not be empty")
+	if c.Target == "" {
+		return fmt.Errorf("grpc: target must not be empty")
 	}
-	if c.MaxRecvMsgSize <= 0 {
-		return fmt.Errorf("grpc: max_recv_msg_size must be positive, got %d", c.MaxRecvMsgSize)
+	if c.MaxMessageSize <= 0 {
+		return fmt.Errorf("grpc: max_message_size must be positive, got %d", c.MaxMessageSize)
 	}
-	if c.MaxSendMsgSize <= 0 {
-		return fmt.Errorf("grpc: max_send_msg_size must be positive, got %d", c.MaxSendMsgSize)
+	if c.MaxSendMessageSize <= 0 {
+		return fmt.Errorf("grpc: max_send_message_size must be positive, got %d", c.MaxSendMessageSize)
 	}
 	if c.TLS != nil {
 		if err := c.TLS.Validate(); err != nil {
@@ -91,5 +97,5 @@ func (c *Config) Validate() error {
 
 // Address returns the dial target for gRPC connections.
 func (c *Config) Address() string {
-	return c.Addr
+	return c.Target
 }

--- a/grpc/config_test.go
+++ b/grpc/config_test.go
@@ -20,50 +20,50 @@ func TestApplyDefaults_AllZeroValues(t *testing.T) {
 	cfg := Config{}
 	cfg.ApplyDefaults()
 
-	assert.Equal(t, "localhost:50051", cfg.Addr, "default addr")
-	assert.Equal(t, 4*1024*1024, cfg.MaxRecvMsgSize, "default max recv")
-	assert.Equal(t, 4*1024*1024, cfg.MaxSendMsgSize, "default max send")
+	assert.Equal(t, "localhost:50051", cfg.Target, "default addr")
+	assert.Equal(t, 4*1024*1024, cfg.MaxMessageSize, "default max recv")
+	assert.Equal(t, 4*1024*1024, cfg.MaxSendMessageSize, "default max send")
 	assert.Equal(t, 30*time.Second, cfg.Keepalive.Time, "default keepalive time")
 	assert.Equal(t, 10*time.Second, cfg.Keepalive.Timeout, "default keepalive timeout")
-	assert.Equal(t, 30*time.Second, cfg.CallTimeout, "default call timeout")
+	assert.Equal(t, 30*time.Second, cfg.Timeout, "default call timeout")
 }
 
 func TestApplyDefaults_PreservesExistingValues(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:           "custom:9090",
-		MaxRecvMsgSize: 8 * 1024 * 1024,
-		MaxSendMsgSize: 8 * 1024 * 1024,
+		Target:             "custom:9090",
+		MaxMessageSize:     8 * 1024 * 1024,
+		MaxSendMessageSize: 8 * 1024 * 1024,
 		Keepalive: KeepaliveConfig{
 			Time:    60 * time.Second,
 			Timeout: 20 * time.Second,
 		},
-		CallTimeout: 5 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 	cfg.ApplyDefaults()
 
-	assert.Equal(t, "custom:9090", cfg.Addr)
-	assert.Equal(t, 8*1024*1024, cfg.MaxRecvMsgSize)
-	assert.Equal(t, 8*1024*1024, cfg.MaxSendMsgSize)
+	assert.Equal(t, "custom:9090", cfg.Target)
+	assert.Equal(t, 8*1024*1024, cfg.MaxMessageSize)
+	assert.Equal(t, 8*1024*1024, cfg.MaxSendMessageSize)
 	assert.Equal(t, 60*time.Second, cfg.Keepalive.Time)
 	assert.Equal(t, 20*time.Second, cfg.Keepalive.Timeout)
-	assert.Equal(t, 5*time.Second, cfg.CallTimeout)
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
 }
 
 func TestApplyDefaults_PartiallySet(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:        "myhost:443",
-		CallTimeout: 15 * time.Second,
+		Target:  "myhost:443",
+		Timeout: 15 * time.Second,
 	}
 	cfg.ApplyDefaults()
 
-	assert.Equal(t, "myhost:443", cfg.Addr, "explicit addr preserved")
-	assert.Equal(t, 4*1024*1024, cfg.MaxRecvMsgSize, "default max recv")
-	assert.Equal(t, 4*1024*1024, cfg.MaxSendMsgSize, "default max send")
+	assert.Equal(t, "myhost:443", cfg.Target, "explicit addr preserved")
+	assert.Equal(t, 4*1024*1024, cfg.MaxMessageSize, "default max recv")
+	assert.Equal(t, 4*1024*1024, cfg.MaxSendMessageSize, "default max send")
 	assert.Equal(t, 30*time.Second, cfg.Keepalive.Time, "default keepalive time")
 	assert.Equal(t, 10*time.Second, cfg.Keepalive.Timeout, "default keepalive timeout")
-	assert.Equal(t, 15*time.Second, cfg.CallTimeout, "explicit call timeout preserved")
+	assert.Equal(t, 15*time.Second, cfg.Timeout, "explicit call timeout preserved")
 }
 
 func TestApplyDefaults_KeepalivePermitWithoutStream(t *testing.T) {
@@ -91,7 +91,7 @@ func TestApplyDefaults_Idempotent(t *testing.T) {
 
 func TestValidate_ValidConfig(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024}
+	cfg := Config{Target: "host:50051", MaxMessageSize: 1024, MaxSendMessageSize: 1024}
 	require.NoError(t, cfg.Validate())
 }
 
@@ -104,51 +104,51 @@ func TestValidate_AfterApplyDefaults(t *testing.T) {
 
 func TestValidate_EmptyAddr(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024}
+	cfg := Config{Target: "", MaxMessageSize: 1024, MaxSendMessageSize: 1024}
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "addr must not be empty")
+	assert.Contains(t, err.Error(), "target must not be empty")
 }
 
-func TestValidate_NegativeMaxRecvMsgSize(t *testing.T) {
+func TestValidate_NegativeMaxMessageSize(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: -1, MaxSendMsgSize: 1024}
+	cfg := Config{Target: "host:50051", MaxMessageSize: -1, MaxSendMessageSize: 1024}
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
+	assert.Contains(t, err.Error(), "max_message_size must be positive")
 }
 
-func TestValidate_ZeroMaxRecvMsgSize(t *testing.T) {
+func TestValidate_ZeroMaxMessageSize(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 0, MaxSendMsgSize: 1024}
+	cfg := Config{Target: "host:50051", MaxMessageSize: 0, MaxSendMessageSize: 1024}
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max_recv_msg_size must be positive")
+	assert.Contains(t, err.Error(), "max_message_size must be positive")
 }
 
-func TestValidate_NegativeMaxSendMsgSize(t *testing.T) {
+func TestValidate_NegativeMaxSendMessageSize(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: -1}
+	cfg := Config{Target: "host:50051", MaxMessageSize: 1024, MaxSendMessageSize: -1}
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max_send_msg_size must be positive")
+	assert.Contains(t, err.Error(), "max_send_message_size must be positive")
 }
 
-func TestValidate_ZeroMaxSendMsgSize(t *testing.T) {
+func TestValidate_ZeroMaxSendMessageSize(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 0}
+	cfg := Config{Target: "host:50051", MaxMessageSize: 1024, MaxSendMessageSize: 0}
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max_send_msg_size must be positive")
+	assert.Contains(t, err.Error(), "max_send_message_size must be positive")
 }
 
 func TestValidate_TLSCertWithoutKey(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:           "host:50051",
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-		TLS:            &security.TLSConfig{CertFile: "/cert.pem"},
+		Target:             "host:50051",
+		MaxMessageSize:     1024,
+		MaxSendMessageSize: 1024,
+		TLS:                &security.TLSConfig{CertFile: "/cert.pem"},
 	}
 	err := cfg.Validate()
 	require.Error(t, err)
@@ -158,10 +158,10 @@ func TestValidate_TLSCertWithoutKey(t *testing.T) {
 func TestValidate_TLSKeyWithoutCert(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:           "host:50051",
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-		TLS:            &security.TLSConfig{KeyFile: "/key.pem"},
+		Target:             "host:50051",
+		MaxMessageSize:     1024,
+		MaxSendMessageSize: 1024,
+		TLS:                &security.TLSConfig{KeyFile: "/key.pem"},
 	}
 	err := cfg.Validate()
 	require.Error(t, err)
@@ -170,17 +170,17 @@ func TestValidate_TLSKeyWithoutCert(t *testing.T) {
 
 func TestValidate_NilTLS(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "host:50051", MaxRecvMsgSize: 1024, MaxSendMsgSize: 1024, TLS: nil}
+	cfg := Config{Target: "host:50051", MaxMessageSize: 1024, MaxSendMessageSize: 1024, TLS: nil}
 	require.NoError(t, cfg.Validate())
 }
 
 func TestValidate_ValidTLSSkipVerify(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:           "host:50051",
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-		TLS:            &security.TLSConfig{SkipVerify: true},
+		Target:             "host:50051",
+		MaxMessageSize:     1024,
+		MaxSendMessageSize: 1024,
+		TLS:                &security.TLSConfig{SkipVerify: true},
 	}
 	require.NoError(t, cfg.Validate())
 }
@@ -188,10 +188,10 @@ func TestValidate_ValidTLSSkipVerify(t *testing.T) {
 func TestValidate_RejectsLegacyTLSFloor(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Addr:           "host:50051",
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-		TLS:            &security.TLSConfig{MinVersion: tls.VersionTLS11},
+		Target:             "host:50051",
+		MaxMessageSize:     1024,
+		MaxSendMessageSize: 1024,
+		TLS:                &security.TLSConfig{MinVersion: tls.VersionTLS11},
 	}
 	err := cfg.Validate()
 	require.Error(t, err)
@@ -204,7 +204,7 @@ func TestValidate_RejectsLegacyTLSFloor(t *testing.T) {
 
 func TestAddress_ReturnsAddr(t *testing.T) {
 	t.Parallel()
-	cfg := Config{Addr: "example.com:443"}
+	cfg := Config{Target: "example.com:443"}
 	assert.Equal(t, "example.com:443", cfg.Address())
 }
 
@@ -221,18 +221,18 @@ func TestAddress_EmptyAddr(t *testing.T) {
 func TestConfig_AllFieldsSet(t *testing.T) {
 	t.Parallel()
 	cfg := Config{
-		Name:           "my-service",
-		Addr:           "prod.example.com:443",
-		MaxRecvMsgSize: 16 * 1024 * 1024,
-		MaxSendMsgSize: 8 * 1024 * 1024,
+		Name:               "my-service",
+		Target:             "prod.example.com:443",
+		MaxMessageSize:     16 * 1024 * 1024,
+		MaxSendMessageSize: 8 * 1024 * 1024,
 		Keepalive: KeepaliveConfig{
 			Time:                60 * time.Second,
 			Timeout:             20 * time.Second,
 			PermitWithoutStream: true,
 		},
-		TLS:         &security.TLSConfig{SkipVerify: true},
-		Enabled:     true,
-		CallTimeout: 10 * time.Second,
+		TLS:     &security.TLSConfig{SkipVerify: true},
+		Enabled: true,
+		Timeout: 10 * time.Second,
 	}
 
 	require.NoError(t, cfg.Validate())

--- a/grpc/resolver/discovery/factory.go
+++ b/grpc/resolver/discovery/factory.go
@@ -90,8 +90,8 @@ func (f *ResolverConnectionFactory) buildDialOptions() ([]grpc.DialOption, error
 			PermitWithoutStream: f.gRPCCfg.Keepalive.PermitWithoutStream,
 		}),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(f.gRPCCfg.MaxRecvMsgSize),
-			grpc.MaxCallSendMsgSize(f.gRPCCfg.MaxSendMsgSize),
+			grpc.MaxCallRecvMsgSize(f.gRPCCfg.MaxMessageSize),
+			grpc.MaxCallSendMsgSize(f.gRPCCfg.MaxSendMessageSize),
 		),
 	)
 

--- a/grpc/resolver/discovery/resolver_test.go
+++ b/grpc/resolver/discovery/resolver_test.go
@@ -348,7 +348,7 @@ func TestBuilder_Close_IsIdempotent(t *testing.T) {
 
 func validGRPCConfig() grpccfg.Config {
 	c := grpccfg.Config{
-		Addr:    "unused-but-required-by-validate",
+		Target:  "unused-but-required-by-validate",
 		Enabled: true,
 	}
 	c.ApplyDefaults()
@@ -386,9 +386,9 @@ func TestNewResolverConnectionFactory_NewConn_CustomScheme(t *testing.T) {
 
 // Invalid grpc.Config (empty Addr) must surface as error from buildDialOptions.
 func TestNewResolverConnectionFactory_InvalidConfig_Errors(t *testing.T) {
-	bad := grpccfg.Config{Enabled: true} // Addr empty → ApplyDefaults sets default; force invalid via MaxRecvMsgSize<0
+	bad := grpccfg.Config{Enabled: true} // Addr empty → ApplyDefaults sets default; force invalid via MaxMessageSize<0
 	bad.ApplyDefaults()
-	bad.MaxRecvMsgSize = -1 // invalid
+	bad.MaxMessageSize = -1 // invalid
 
 	f := resdisc.NewResolverConnectionFactory(&fakeDiscovery{}, bad, testLogger())
 	_, err := f.NewConn("svc")

--- a/httpclient/README.md
+++ b/httpclient/README.md
@@ -49,9 +49,10 @@ created, err := rest.Post[User](ctx, client, "/users", CreateUserRequest{
 
 ```go
 client, err := httpclient.New(httpclient.Config{
-    BaseURL:        "https://api.example.com",
-    Retry:          httpclient.DefaultRetryConfig(),
-    CircuitBreaker: httpclient.DefaultCircuitBreakerConfig("my-api"),
+    BaseURL: "https://api.example.com",
+    ResiliencePolicy: resilience.NewPolicy().
+        WithRetry(*httpclient.DefaultRetryConfig()).
+        WithCircuitBreaker(*httpclient.DefaultCircuitBreakerConfig("my-api")),
 })
 // Retry on transient errors (5xx, timeouts, connection failures)
 // Circuit breaker opens after repeated failures

--- a/httpclient/adapter.go
+++ b/httpclient/adapter.go
@@ -20,8 +20,6 @@ type Adapter struct {
 	httpClient *http.Client
 	baseURL    string
 	config     Config
-	cb         *resilience.CircuitBreaker
-	rl         *resilience.RateLimiter
 }
 
 // New creates a new HTTP adapter with the given configuration.
@@ -53,12 +51,11 @@ func New(cfg Config, opts ...Option) (*Adapter, error) {
 		config:  cfg,
 	}
 
-	// Initialize resilience components
-	if cfg.CircuitBreaker != nil {
-		c.cb = resilience.NewCircuitBreaker(*cfg.CircuitBreaker)
-	}
-	if cfg.RateLimiter != nil {
-		c.rl = resilience.NewRateLimiter(*cfg.RateLimiter)
+	// A retry block loaded from config carries no predicate (RetryIf is not
+	// serializable). Default it to the HTTP-aware IsRetryable so config-driven
+	// clients retry only genuinely retryable failures rather than every error.
+	if p := c.config.ResiliencePolicy; p != nil && p.Retry != nil && p.Retry.RetryIf == nil {
+		p.Retry.RetryIf = IsRetryable
 	}
 
 	// Apply options
@@ -69,14 +66,14 @@ func New(cfg Config, opts ...Option) (*Adapter, error) {
 	return c, nil
 }
 
-// Do executes an HTTP request and returns the complete response.
+// Do executes an HTTP request and returns the complete response. Buffered
+// requests run through the configured resilience.Policy — rate limiter, bulkhead,
+// circuit breaker, timeout, and retry, in that order — so every configured
+// primitive is honored in the policy's documented sequence.
 func (c *Adapter) Do(ctx context.Context, req Request) (*Response, error) {
-	if c.config.Retry != nil {
-		return resilience.Retry(ctx, *c.config.Retry, func() (*Response, error) {
-			return c.doOnce(ctx, req)
-		})
-	}
-	return c.doOnce(ctx, req)
+	return resilience.Execute(ctx, c.config.ResiliencePolicy, func(callCtx context.Context) (*Response, error) {
+		return c.executeRequest(callCtx, req)
+	})
 }
 
 // DoStream executes an HTTP request and returns a streaming response.
@@ -89,33 +86,6 @@ func (c *Adapter) DoStream(ctx context.Context, req Request) (*StreamResponse, e
 // Unwrap returns the underlying *http.Client for advanced use cases.
 func (c *Adapter) Unwrap() *http.Client {
 	return c.httpClient
-}
-
-// doOnce executes a single HTTP request with CB and rate limiter.
-func (c *Adapter) doOnce(ctx context.Context, req Request) (*Response, error) {
-	execute := func() (*Response, error) {
-		return c.executeRequest(ctx, req)
-	}
-
-	// Apply rate limiter
-	if c.rl != nil {
-		if err := c.rl.Wait(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	// Apply circuit breaker
-	if c.cb != nil {
-		var resp *Response
-		err := c.cb.Execute(func() error {
-			var execErr error
-			resp, execErr = execute()
-			return execErr
-		})
-		return resp, err
-	}
-
-	return execute()
 }
 
 // executeRequest builds and sends the HTTP request.
@@ -136,12 +106,12 @@ func (c *Adapter) executeRequest(ctx context.Context, req Request) (*Response, e
 
 	// Read one byte past the cap so an oversized body is rejected explicitly
 	// rather than silently truncated to a shorter, possibly still-decodable one.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, c.config.MaxResponseBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.config.MaxResponseBodyBytes+1))
 	if err != nil {
 		return nil, NewConnectionError(fmt.Errorf("read response body: %w", err))
 	}
-	if int64(len(body)) > c.config.MaxResponseBytes {
-		return nil, NewResponseTooLargeError(c.config.MaxResponseBytes)
+	if int64(len(body)) > c.config.MaxResponseBodyBytes {
+		return nil, NewResponseTooLargeError(c.config.MaxResponseBodyBytes)
 	}
 
 	result := &Response{
@@ -180,7 +150,7 @@ func (c *Adapter) doStream(ctx context.Context, req Request) (*StreamResponse, e
 
 	// Check for error status before starting to stream
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, c.config.MaxResponseBytes))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, c.config.MaxResponseBodyBytes))
 		_ = resp.Body.Close()
 		return nil, ClassifyStatusCode(resp.StatusCode, body)
 	}
@@ -236,7 +206,7 @@ func (c *Adapter) buildRequest(ctx context.Context, req Request) (*http.Request,
 	}
 
 	// Apply default headers
-	for k, v := range c.config.Headers {
+	for k, v := range c.config.DefaultHeaders {
 		httpReq.Header.Set(k, v)
 	}
 
@@ -303,10 +273,7 @@ func (c *Adapter) Name() string {
 
 // IsAvailable checks if the adapter is ready to handle requests (implements provider.Provider).
 func (c *Adapter) IsAvailable(_ context.Context) bool {
-	if c.cb != nil {
-		return c.cb.State() != resilience.StateOpen
-	}
-	return true
+	return c.config.ResiliencePolicy.IsAvailable()
 }
 
 // --- provider.RequestResponse[Request, *Response] interface ---

--- a/httpclient/adapter_maxbody_test.go
+++ b/httpclient/adapter_maxbody_test.go
@@ -17,7 +17,7 @@ func TestMaxResponseBytes_RejectsOversizeBufferedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := New(Config{BaseURL: srv.URL, MaxResponseBytes: 1024})
+	c, err := New(Config{BaseURL: srv.URL, MaxResponseBodyBytes: 1024})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestMaxResponseBytes_AtLimitReturned(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := New(Config{BaseURL: srv.URL, MaxResponseBytes: 1024})
+	c, err := New(Config{BaseURL: srv.URL, MaxResponseBodyBytes: 1024})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestMaxResponseBytes_DefaultApplied(t *testing.T) {
 
 	var c Config
 	c.ApplyDefaults()
-	if c.MaxResponseBytes != defaultMaxResponseBytes {
-		t.Fatalf("MaxResponseBytes = %d, want default %d", c.MaxResponseBytes, defaultMaxResponseBytes)
+	if c.MaxResponseBodyBytes != defaultMaxResponseBytes {
+		t.Fatalf("MaxResponseBodyBytes = %d, want default %d", c.MaxResponseBodyBytes, defaultMaxResponseBytes)
 	}
 }

--- a/httpclient/adapter_test.go
+++ b/httpclient/adapter_test.go
@@ -99,8 +99,8 @@ func TestClient_Do_DefaultHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c, err := New(Config{
-		BaseURL: srv.URL,
-		Headers: map[string]string{"X-Custom": "value"},
+		BaseURL:        srv.URL,
+		DefaultHeaders: map[string]string{"X-Custom": "value"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -292,8 +292,8 @@ func TestClient_Do_Retry(t *testing.T) {
 	retryCfg.RetryIf = IsRetryable
 
 	c, err := New(Config{
-		BaseURL: srv.URL,
-		Retry:   &retryCfg,
+		BaseURL:          srv.URL,
+		ResiliencePolicy: resilience.NewPolicy().WithRetry(retryCfg),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -321,8 +321,8 @@ func TestClient_Do_CircuitBreaker(t *testing.T) {
 	cbCfg.MaxFailures = 2
 
 	c, err := New(Config{
-		BaseURL:        srv.URL,
-		CircuitBreaker: &cbCfg,
+		BaseURL:          srv.URL,
+		ResiliencePolicy: resilience.NewPolicy().WithCircuitBreaker(cbCfg),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -771,9 +771,9 @@ func TestBuildRequest_RequestHeaders_OverrideDefaults(t *testing.T) {
 	defer ts.Close()
 
 	a, err := New(Config{
-		BaseURL: ts.URL,
-		Timeout: 5 * time.Second,
-		Headers: map[string]string{"X-Custom": "default"},
+		BaseURL:        ts.URL,
+		Timeout:        5 * time.Second,
+		DefaultHeaders: map[string]string{"X-Custom": "default"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/httpclient/config.go
+++ b/httpclient/config.go
@@ -37,21 +37,17 @@ type Config struct {
 	// TLS configures TLS settings for the HTTP transport.
 	TLS *security.TLSConfig `yaml:"tls" mapstructure:"tls"`
 
-	// Headers are default headers applied to all requests.
-	Headers map[string]string `yaml:"headers" mapstructure:"headers"`
+	// DefaultHeaders are default headers applied to all requests.
+	DefaultHeaders map[string]string `yaml:"default_headers" mapstructure:"default_headers"`
 
-	// Retry configures retry behavior. Nil disables retry.
-	Retry *resilience.RetryConfig `yaml:"-" mapstructure:"-"`
+	// ResiliencePolicy configures the retry / circuit-breaker / rate-limiter
+	// stack applied to buffered requests. Nil disables resilience. It is loaded
+	// from the shared resilience.Policy config vocabulary.
+	ResiliencePolicy *resilience.Policy `yaml:"resilience_policy" mapstructure:"resilience_policy"`
 
-	// CircuitBreaker configures circuit breaker behavior. Nil disables it.
-	CircuitBreaker *resilience.CircuitBreakerConfig `yaml:"-" mapstructure:"-"`
-
-	// RateLimiter configures rate limiting. Nil disables it.
-	RateLimiter *resilience.RateLimiterConfig `yaml:"-" mapstructure:"-"`
-
-	// MaxResponseBytes bounds the buffered response body read into memory by Do.
+	// MaxResponseBodyBytes bounds the buffered response body read into memory by Do.
 	// Defaults to 10 MiB. Streaming responses (DoStream) are not affected.
-	MaxResponseBytes int64 `yaml:"max_response_bytes" mapstructure:"max_response_bytes"`
+	MaxResponseBodyBytes int64 `yaml:"max_response_body_bytes" mapstructure:"max_response_body_bytes"`
 }
 
 // ApplyDefaults fills in zero-value fields with sensible defaults.
@@ -59,8 +55,8 @@ func (c *Config) ApplyDefaults() {
 	if c.Timeout <= 0 {
 		c.Timeout = defaultTimeout
 	}
-	if c.MaxResponseBytes <= 0 {
-		c.MaxResponseBytes = defaultMaxResponseBytes
+	if c.MaxResponseBodyBytes <= 0 {
+		c.MaxResponseBodyBytes = defaultMaxResponseBytes
 	}
 }
 

--- a/httpclient/config_load_test.go
+++ b/httpclient/config_load_test.go
@@ -1,0 +1,125 @@
+package httpclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	"github.com/kbukum/gokit/resilience"
+)
+
+// decodeConfig mirrors how gokit's config loader materializes a struct: a
+// mapstructure decode with the string-to-duration hook, keyed by the shared
+// snake_case names.
+func decodeConfig(t *testing.T, raw map[string]any) Config {
+	t.Helper()
+	var cfg Config
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.TextUnmarshallerHookFunc(),
+		),
+		Result: &cfg,
+	})
+	if err != nil {
+		t.Fatalf("new decoder: %v", err)
+	}
+	if err := dec.Decode(raw); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return cfg
+}
+
+func TestConfig_LoadsSharedKeys(t *testing.T) {
+	t.Parallel()
+
+	cfg := decodeConfig(t, map[string]any{
+		"name":                    "orders",
+		"base_url":                "https://api.example.com",
+		"timeout":                 "10s",
+		"default_headers":         map[string]any{"X-Api-Key": "secret"},
+		"max_response_body_bytes": 2048,
+	})
+
+	if cfg.Timeout != 10*time.Second {
+		t.Errorf("timeout: got %s want 10s", cfg.Timeout)
+	}
+	if cfg.DefaultHeaders["X-Api-Key"] != "secret" {
+		t.Errorf("default_headers: got %v", cfg.DefaultHeaders)
+	}
+	if cfg.MaxResponseBodyBytes != 2048 {
+		t.Errorf("max_response_body_bytes: got %d want 2048", cfg.MaxResponseBodyBytes)
+	}
+}
+
+func TestConfig_LoadsResiliencePolicy(t *testing.T) {
+	t.Parallel()
+
+	cfg := decodeConfig(t, map[string]any{
+		"resilience_policy": map[string]any{
+			"timeout": "3s",
+			"retry": map[string]any{
+				"max_attempts":    4,
+				"initial_backoff": "50ms",
+				"strategy":        "linear",
+			},
+			"circuit_breaker": map[string]any{
+				"name":         "orders",
+				"max_failures": 5,
+			},
+			"rate_limiter": map[string]any{
+				"rate":  20.0,
+				"burst": 10,
+			},
+		},
+	})
+
+	p := cfg.ResiliencePolicy
+	if p == nil {
+		t.Fatal("resilience_policy did not load")
+	}
+	if p.Timeout != 3*time.Second {
+		t.Errorf("policy timeout: got %s want 3s", p.Timeout)
+	}
+	if p.Retry == nil || p.Retry.MaxAttempts != 4 || p.Retry.InitialBackoff != 50*time.Millisecond {
+		t.Errorf("retry not loaded: %+v", p.Retry)
+	}
+	if p.Retry != nil && p.Retry.Strategy != resilience.LinearBackoff {
+		t.Errorf("retry strategy: got %v want linear", p.Retry.Strategy)
+	}
+	if p.CircuitBreaker == nil || p.CircuitBreaker.MaxFailures != 5 {
+		t.Errorf("circuit_breaker not loaded: %+v", p.CircuitBreaker)
+	}
+	if p.RateLimiter == nil || p.RateLimiter.Rate != 20.0 || p.RateLimiter.Burst != 10 {
+		t.Errorf("rate_limiter not loaded: %+v", p.RateLimiter)
+	}
+}
+
+func TestNew_ConfigLoadedRetryDefaultsToIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	cfg := decodeConfig(t, map[string]any{
+		"base_url": "https://api.example.com",
+		"resilience_policy": map[string]any{
+			"retry": map[string]any{"max_attempts": 3},
+		},
+	})
+
+	adapter, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := adapter.GetConfig().ResiliencePolicy
+	if got.Retry.RetryIf == nil {
+		t.Fatal("config-loaded retry should default RetryIf to the HTTP-aware predicate")
+	}
+	// The HTTP-aware predicate retries a 5xx but not a 404, unlike the generic
+	// default which retries every non-context error.
+	if !got.Retry.RetryIf(NewServerError(500, nil)) {
+		t.Error("expected server error to be retryable")
+	}
+	if got.Retry.RetryIf(NewNotFoundError(nil)) {
+		t.Error("expected not-found error to be non-retryable")
+	}
+}

--- a/httpclient/doc.go
+++ b/httpclient/doc.go
@@ -34,7 +34,8 @@
 //
 //	adapter, _ := httpclient.New(httpclient.Config{
 //	    BaseURL: "https://api.example.com",
-//	    Retry:   httpclient.DefaultRetryConfig(),
-//	    CircuitBreaker: httpclient.DefaultCircuitBreakerConfig("my-api"),
+//	    ResiliencePolicy: resilience.NewPolicy().
+//	        WithRetry(*httpclient.DefaultRetryConfig()).
+//	        WithCircuitBreaker(*httpclient.DefaultCircuitBreakerConfig("my-api")),
 //	})
 package httpclient

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -24,7 +24,7 @@ const (
 	// ErrCodeServer indicates a server-side error (5xx).
 	ErrCodeServer
 	// ErrCodeResponseTooLarge indicates the response body exceeded the
-	// configured maximum size (see Config.MaxResponseBytes).
+	// configured maximum size (see Config.MaxResponseBodyBytes).
 	ErrCodeResponseTooLarge
 )
 

--- a/httpclient/go.mod
+++ b/httpclient/go.mod
@@ -4,7 +4,10 @@ go 1.26.0
 
 toolchain go1.26.6
 
-require github.com/kbukum/gokit v0.3.0-alpha.1
+require (
+	github.com/go-viper/mapstructure/v2 v2.5.0
+	github.com/kbukum/gokit v0.3.0-alpha.1
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -13,7 +16,6 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/httpclient/provider_test.go
+++ b/httpclient/provider_test.go
@@ -35,8 +35,8 @@ func TestAdapter_IsAvailable_WithCB(t *testing.T) {
 	cfg := resilience.DefaultCircuitBreakerConfig("test-cb")
 	cfg.MaxFailures = 1
 	a, err := New(Config{
-		BaseURL:        "http://localhost",
-		CircuitBreaker: &cfg,
+		BaseURL:          "http://localhost",
+		ResiliencePolicy: resilience.NewPolicy().WithCircuitBreaker(cfg),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/httpclient/rest/client.go
+++ b/httpclient/rest/client.go
@@ -34,14 +34,14 @@ func (c *Client) Close(ctx context.Context) error { return c.http.Close(ctx) }
 // New creates a new REST client from the given config. JSON headers are applied automatically.
 func New(cfg httpclient.Config) (*Client, error) {
 	// Ensure JSON headers
-	if cfg.Headers == nil {
-		cfg.Headers = make(map[string]string)
+	if cfg.DefaultHeaders == nil {
+		cfg.DefaultHeaders = make(map[string]string)
 	}
-	if _, ok := cfg.Headers["Content-Type"]; !ok {
-		cfg.Headers["Content-Type"] = "application/json"
+	if _, ok := cfg.DefaultHeaders["Content-Type"]; !ok {
+		cfg.DefaultHeaders["Content-Type"] = "application/json"
 	}
-	if _, ok := cfg.Headers["Accept"]; !ok {
-		cfg.Headers["Accept"] = "application/json"
+	if _, ok := cfg.DefaultHeaders["Accept"]; !ok {
+		cfg.DefaultHeaders["Accept"] = "application/json"
 	}
 
 	c, err := httpclient.New(cfg)

--- a/httpclient/rest/doc.go
+++ b/httpclient/rest/doc.go
@@ -4,9 +4,9 @@
 // and adds typed convenience methods for common REST operations:
 //
 //	client := rest.New(httpclient.Config{
-//	    BaseURL: "https://api.example.com",
-//	    Auth:    httpclient.BearerAuth("token"),
-//	    Retry:   httpclient.DefaultRetryConfig(),
+//	    BaseURL:          "https://api.example.com",
+//	    Auth:             httpclient.BearerAuth("token"),
+//	    ResiliencePolicy: resilience.NewPolicy().WithRetry(*httpclient.DefaultRetryConfig()),
 //	})
 //
 //	// Typed GET

--- a/inference/triton/provider.go
+++ b/inference/triton/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kbukum/gokit/authz"
 	"github.com/kbukum/gokit/httpclient"
 	"github.com/kbukum/gokit/inference"
+	"github.com/kbukum/gokit/resilience"
 )
 
 const servingProtocol = "kserve-v2-http"
@@ -53,11 +54,13 @@ func NewProvider(cfg Config, options ...Option) (*Provider, error) {
 	client := opts.httpClient
 	if client == nil {
 		httpCfg := httpclient.Config{
-			Name:    cfg.Name,
-			BaseURL: strings.TrimRight(cfg.BaseURL, "/"),
-			Timeout: time.Duration(cfg.TimeoutSeconds) * time.Second,
-			Headers: cfg.Headers,
-			Retry:   opts.retry,
+			Name:           cfg.Name,
+			BaseURL:        strings.TrimRight(cfg.BaseURL, "/"),
+			Timeout:        time.Duration(cfg.TimeoutSeconds) * time.Second,
+			DefaultHeaders: cfg.Headers,
+		}
+		if opts.retry != nil {
+			httpCfg.ResiliencePolicy = resilience.NewPolicy().WithRetry(*opts.retry)
 		}
 		if strings.TrimSpace(cfg.BearerToken) != "" {
 			httpCfg.Auth = &httpclient.AuthConfig{Type: httpclient.AuthBearer, Token: cfg.BearerToken}

--- a/llm/adapter.go
+++ b/llm/adapter.go
@@ -76,10 +76,10 @@ func newAdapter(dialect Dialect, cfg Config) (*Adapter, error) {
 		Timeout:        cfg.Timeout,
 		Auth:           cfg.Auth,
 		TLS:            cfg.TLS,
-		Headers:        cfg.Headers,
-		Retry:          cfg.Retry,
-		CircuitBreaker: cfg.CircuitBreaker,
-		RateLimiter:    cfg.RateLimiter,
+		DefaultHeaders: cfg.Headers,
+	}
+	if cfg.ResiliencePolicy != nil {
+		restCfg.ResiliencePolicy = cfg.ResiliencePolicy
 	}
 	client, err := rest.New(restCfg)
 	if err != nil {

--- a/llm/config.go
+++ b/llm/config.go
@@ -42,14 +42,11 @@ type Config struct {
 	// Headers are additional HTTP headers sent with every request.
 	Headers map[string]string `yaml:"headers" json:"headers"`
 
-	// Retry configures retry behavior for failed requests.
-	Retry *resilience.RetryConfig `yaml:"retry" json:"retry"`
-
-	// CircuitBreaker configures circuit breaker protection.
-	CircuitBreaker *resilience.CircuitBreakerConfig `yaml:"circuit_breaker" json:"circuit_breaker"`
-
-	// RateLimiter configures rate limiting.
-	RateLimiter *resilience.RateLimiterConfig `yaml:"rate_limiter" json:"rate_limiter"`
+	// ResiliencePolicy configures the retry / circuit-breaker / rate-limiter
+	// stack applied to outbound requests. Nil disables resilience. It uses the
+	// shared resilience.Policy config vocabulary, the same block understood by
+	// the httpclient and grpc transports.
+	ResiliencePolicy *resilience.Policy `yaml:"resilience_policy" json:"resilience_policy"`
 }
 
 // applyDefaults sets default values for unset config fields.

--- a/resilience/bulkhead.go
+++ b/resilience/bulkhead.go
@@ -20,17 +20,17 @@ var (
 // BulkheadConfig configures a bulkhead.
 type BulkheadConfig struct {
 	// Name identifies this bulkhead for metrics/logging.
-	Name string
+	Name string `json:"name,omitempty" yaml:"name" mapstructure:"name"`
 	// MaxConcurrent is the maximum number of concurrent calls.
-	MaxConcurrent int
+	MaxConcurrent int `json:"max_concurrent,omitempty" yaml:"max_concurrent" mapstructure:"max_concurrent"`
 	// MaxWait is how long to wait for a slot. 0 means fail immediately.
-	MaxWait time.Duration
+	MaxWait time.Duration `json:"max_wait,omitempty" yaml:"max_wait" mapstructure:"max_wait"`
 	// OnReject is called when a request is rejected.
-	OnReject func(name string)
+	OnReject func(name string) `json:"-" yaml:"-" mapstructure:"-"`
 	// OnAcquire is called when a slot is acquired.
-	OnAcquire func(name string)
+	OnAcquire func(name string) `json:"-" yaml:"-" mapstructure:"-"`
 	// OnRelease is called when a slot is released.
-	OnRelease func(name string)
+	OnRelease func(name string) `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 // DefaultBulkheadConfig returns sensible defaults.

--- a/resilience/circuit_breaker.go
+++ b/resilience/circuit_breaker.go
@@ -43,15 +43,15 @@ var ErrCircuitOpen = apperr.New(apperr.ErrCodeServiceUnavailable, "circuit break
 // CircuitBreakerConfig configures a circuit breaker.
 type CircuitBreakerConfig struct {
 	// Name identifies this circuit breaker for metrics/logging.
-	Name string
+	Name string `json:"name,omitempty" yaml:"name" mapstructure:"name"`
 	// MaxFailures is the number of failures before opening the circuit.
-	MaxFailures int
+	MaxFailures int `json:"max_failures,omitempty" yaml:"max_failures" mapstructure:"max_failures"`
 	// Timeout is how long to wait before transitioning from open to half-open.
-	Timeout time.Duration
+	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout" mapstructure:"timeout"`
 	// HalfOpenMaxCalls is the number of calls allowed in half-open state.
-	HalfOpenMaxCalls int
+	HalfOpenMaxCalls int `json:"half_open_max_calls,omitempty" yaml:"half_open_max_calls" mapstructure:"half_open_max_calls"`
 	// OnStateChange is called when state changes.
-	OnStateChange func(name string, from, to State)
+	OnStateChange func(name string, from, to State) `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 // DefaultCircuitBreakerConfig returns sensible defaults.

--- a/resilience/policy.go
+++ b/resilience/policy.go
@@ -18,12 +18,17 @@ const (
 )
 
 // Policy composes resilience primitives into a single reusable execution policy.
+//
+// Its exported fields carry snake_case json/mapstructure/yaml tags so a Policy can be
+// loaded from configuration and round-tripped through JSON (e.g. an httpclient
+// resilience_policy block). Callback and RNG fields are not serializable and are
+// tagged json:"-" so encoding a configured policy never fails on a function value.
 type Policy struct {
-	Retry          *RetryConfig
-	CircuitBreaker *CircuitBreakerConfig
-	Bulkhead       *BulkheadConfig
-	RateLimiter    *RateLimiterConfig
-	Timeout        time.Duration
+	Retry          *RetryConfig          `json:"retry,omitempty" yaml:"retry" mapstructure:"retry"`
+	CircuitBreaker *CircuitBreakerConfig `json:"circuit_breaker,omitempty" yaml:"circuit_breaker" mapstructure:"circuit_breaker"`
+	Bulkhead       *BulkheadConfig       `json:"bulkhead,omitempty" yaml:"bulkhead" mapstructure:"bulkhead"`
+	RateLimiter    *RateLimiterConfig    `json:"rate_limiter,omitempty" yaml:"rate_limiter" mapstructure:"rate_limiter"`
+	Timeout        time.Duration         `json:"timeout,omitempty" yaml:"timeout" mapstructure:"timeout"`
 	timeoutMode    TimeoutMode
 
 	once sync.Once
@@ -90,6 +95,18 @@ func (p *Policy) init() {
 			p.rl = NewRateLimiter(*p.RateLimiter)
 		}
 	})
+}
+
+// IsAvailable reports whether the policy's circuit breaker currently permits
+// calls. It returns true when no breaker is configured or the breaker is not
+// open, so a provider can delegate its own availability check to the policy
+// instead of duplicating breaker state.
+func (p *Policy) IsAvailable() bool {
+	if p == nil {
+		return true
+	}
+	p.init()
+	return p.cb == nil || p.cb.State() != StateOpen
 }
 
 // Execute runs fn through the configured resilience stack.

--- a/resilience/policy_test.go
+++ b/resilience/policy_test.go
@@ -2,8 +2,10 @@ package resilience
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -172,5 +174,55 @@ func strategyName(strategy BackoffStrategy) string {
 		return "linear"
 	default:
 		return "exponential"
+	}
+}
+
+func TestPolicyJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// A fully-populated policy, including a Retry block carrying non-serializable
+	// callbacks, must marshal without error (func fields are json:"-") and decode
+	// back to the same serializable shape via snake_case keys.
+	in := &Policy{
+		Retry: &RetryConfig{
+			MaxAttempts:    4,
+			InitialBackoff: 50 * time.Millisecond,
+			MaxBackoff:     2 * time.Second,
+			Strategy:       LinearBackoff,
+			BackoffFactor:  1.5,
+			Jitter:         0.2,
+			Rand:           func() float64 { return 0 },
+			RetryIf:        func(error) bool { return true },
+			OnRetry:        func(int, error, time.Duration) {},
+		},
+		CircuitBreaker: &CircuitBreakerConfig{Name: "cb", MaxFailures: 5, Timeout: time.Second, OnStateChange: func(string, State, State) {}},
+		RateLimiter:    &RateLimiterConfig{Name: "rl", Rate: 10, Burst: 2, OnLimit: func(string) {}},
+		Bulkhead:       &BulkheadConfig{Name: "bh", MaxConcurrent: 3, MaxWait: time.Second, OnReject: func(string) {}},
+		Timeout:        5 * time.Second,
+	}
+
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal policy: %v", err)
+	}
+	if !strings.Contains(string(data), `"max_attempts"`) || !strings.Contains(string(data), `"circuit_breaker"`) {
+		t.Fatalf("expected snake_case keys, got %s", data)
+	}
+	if strings.Contains(string(data), `"strategy":0`) {
+		t.Fatalf("strategy should encode as text, got %s", data)
+	}
+
+	var out Policy
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal policy: %v", err)
+	}
+	if out.Retry == nil || out.Retry.MaxAttempts != 4 || out.Retry.Strategy != LinearBackoff {
+		t.Fatalf("retry did not round-trip: %+v", out.Retry)
+	}
+	if out.CircuitBreaker == nil || out.CircuitBreaker.MaxFailures != 5 {
+		t.Fatalf("circuit breaker did not round-trip: %+v", out.CircuitBreaker)
+	}
+	if out.Timeout != 5*time.Second {
+		t.Fatalf("timeout did not round-trip: %v", out.Timeout)
 	}
 }

--- a/resilience/rate_limiter.go
+++ b/resilience/rate_limiter.go
@@ -18,13 +18,13 @@ var (
 // RateLimiterConfig configures a rate limiter.
 type RateLimiterConfig struct {
 	// Name identifies this rate limiter for metrics/logging.
-	Name string
+	Name string `json:"name,omitempty" yaml:"name" mapstructure:"name"`
 	// Rate is the number of requests allowed per second.
-	Rate float64
+	Rate float64 `json:"rate,omitempty" yaml:"rate" mapstructure:"rate"`
 	// Burst is the maximum burst size.
-	Burst int
+	Burst int `json:"burst,omitempty" yaml:"burst" mapstructure:"burst"`
 	// OnLimit is called when a request is rate limited.
-	OnLimit func(name string)
+	OnLimit func(name string) `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 // DefaultRateLimiterConfig returns sensible defaults.

--- a/resilience/retry.go
+++ b/resilience/retry.go
@@ -3,6 +3,7 @@ package resilience
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/rand/v2"
 	"net/http"
@@ -29,35 +30,88 @@ const (
 	LinearBackoff
 )
 
+// String returns the lower-case wire name of the strategy ("exponential",
+// "constant", "linear"). An unrecognized value is rendered in an identifying
+// form (e.g. "BackoffStrategy(7)") rather than masquerading as a valid strategy.
+func (s BackoffStrategy) String() string {
+	switch s {
+	case ExponentialBackoff:
+		return "exponential"
+	case ConstantBackoff:
+		return "constant"
+	case LinearBackoff:
+		return "linear"
+	default:
+		return fmt.Sprintf("BackoffStrategy(%d)", int(s))
+	}
+}
+
+func (s BackoffStrategy) valid() bool {
+	switch s {
+	case ExponentialBackoff, ConstantBackoff, LinearBackoff:
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalText encodes the strategy as its lower-case wire name so it serializes
+// to a stable string in JSON, YAML, and other text formats. An unrecognized
+// value is rejected rather than silently coerced to a default, so a corrupt or
+// programmer-introduced strategy surfaces instead of round-tripping incorrectly.
+func (s BackoffStrategy) MarshalText() ([]byte, error) {
+	if !s.valid() {
+		return nil, fmt.Errorf("resilience: unknown backoff strategy %d", int(s))
+	}
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText decodes the lower-case wire name back into a BackoffStrategy,
+// letting config keys and JSON use "exponential"/"constant"/"linear" rather
+// than opaque integers. An empty value decodes to the exponential default.
+func (s *BackoffStrategy) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "", "exponential":
+		*s = ExponentialBackoff
+	case "constant":
+		*s = ConstantBackoff
+	case "linear":
+		*s = LinearBackoff
+	default:
+		return fmt.Errorf("resilience: unknown backoff strategy %q", text)
+	}
+	return nil
+}
+
 // RetryConfig configures retry behavior.
 type RetryConfig struct {
 	// MaxAttempts is the maximum number of attempts (including the first).
-	MaxAttempts int
+	MaxAttempts int `json:"max_attempts,omitempty" yaml:"max_attempts" mapstructure:"max_attempts"`
 	// InitialBackoff is the initial delay between retries.
-	InitialBackoff time.Duration
+	InitialBackoff time.Duration `json:"initial_backoff,omitempty" yaml:"initial_backoff" mapstructure:"initial_backoff"`
 	// MaxBackoff is the maximum delay between retries.
-	MaxBackoff time.Duration
+	MaxBackoff time.Duration `json:"max_backoff,omitempty" yaml:"max_backoff" mapstructure:"max_backoff"`
 	// MaxElapsedTime bounds the elapsed-time budget for retries. It is enforced at each
 	// attempt boundary (the loop stops before starting an attempt or a backoff sleep once
 	// the budget is spent) and returns the last attempt's error. Zero means unbounded (only
 	// MaxAttempts bounds retries). A single in-flight attempt is not interrupted, because
 	// the retried function receives no context; supply a context-aware function and derive a
 	// per-attempt deadline yourself if you need to cancel a running attempt.
-	MaxElapsedTime time.Duration
+	MaxElapsedTime time.Duration `json:"max_elapsed_time,omitempty" yaml:"max_elapsed_time" mapstructure:"max_elapsed_time"`
 	// Strategy controls how the delay grows between retries.
-	Strategy BackoffStrategy
+	Strategy BackoffStrategy `json:"strategy,omitempty" yaml:"strategy" mapstructure:"strategy"`
 	// BackoffFactor is the multiplier for exponential backoff.
-	BackoffFactor float64
+	BackoffFactor float64 `json:"backoff_factor,omitempty" yaml:"backoff_factor" mapstructure:"backoff_factor"`
 	// Jitter adds randomness to backoff (0.0 to 1.0).
-	Jitter float64
+	Jitter float64 `json:"jitter,omitempty" yaml:"jitter" mapstructure:"jitter"`
 	// Rand supplies a uniform random float64 in [0.0, 1.0) used to compute jitter.
 	// Leave nil for the concurrency-safe, auto-seeded default;
 	// inject a seeded source (e.g. rand.New(rand.NewPCG(seed1, seed2)).Float64) to make backoff deterministic under test.
-	Rand func() float64
+	Rand func() float64 `json:"-" yaml:"-" mapstructure:"-"`
 	// RetryIf determines if an error should be retried.
-	RetryIf func(error) bool
+	RetryIf func(error) bool `json:"-" yaml:"-" mapstructure:"-"`
 	// OnRetry is called before each retry.
-	OnRetry func(attempt int, err error, backoff time.Duration)
+	OnRetry func(attempt int, err error, backoff time.Duration) `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 // DefaultRetryConfig returns sensible defaults.

--- a/resilience/retry_test.go
+++ b/resilience/retry_test.go
@@ -617,3 +617,64 @@ func TestCalculateBackoff_ExtremeInputs(t *testing.T) {
 		}
 	}
 }
+
+func TestBackoffStrategyTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		strategy BackoffStrategy
+		text     string
+	}{
+		{ExponentialBackoff, "exponential"},
+		{ConstantBackoff, "constant"},
+		{LinearBackoff, "linear"},
+	}
+	for _, tc := range cases {
+		if got := tc.strategy.String(); got != tc.text {
+			t.Errorf("String(): got %q want %q", got, tc.text)
+		}
+		out, err := tc.strategy.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText(%v): %v", tc.strategy, err)
+		}
+		if string(out) != tc.text {
+			t.Errorf("MarshalText(): got %q want %q", out, tc.text)
+		}
+		var s BackoffStrategy
+		if err := s.UnmarshalText([]byte(tc.text)); err != nil {
+			t.Fatalf("UnmarshalText(%q): %v", tc.text, err)
+		}
+		if s != tc.strategy {
+			t.Errorf("UnmarshalText(%q): got %v want %v", tc.text, s, tc.strategy)
+		}
+	}
+}
+
+func TestBackoffStrategyUnmarshalTextEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	empty := LinearBackoff
+	if err := empty.UnmarshalText(nil); err != nil {
+		t.Fatalf("UnmarshalText(empty): %v", err)
+	}
+	if empty != ExponentialBackoff {
+		t.Errorf("empty text: got %v want exponential", empty)
+	}
+
+	var unknown BackoffStrategy
+	if err := unknown.UnmarshalText([]byte("quadratic")); err == nil {
+		t.Error("UnmarshalText(unknown): expected error, got nil")
+	}
+}
+
+func TestBackoffStrategyMarshalTextRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	unknown := BackoffStrategy(99)
+	if _, err := unknown.MarshalText(); err == nil {
+		t.Error("MarshalText(unknown): expected error, got nil")
+	}
+	if got := unknown.String(); got != "BackoffStrategy(99)" {
+		t.Errorf("String(unknown): got %q want identifying form", got)
+	}
+}

--- a/server/README.md
+++ b/server/README.md
@@ -34,7 +34,7 @@ defer comp.Stop(ctx)
 | Symbol | Description |
 |---|---|
 | `Server` | Wraps Gin engine + `http.ServeMux` with h2c |
-| `Config` | Host, Port, timeouts, max body size, CORS, Docs |
+| `Config` | Host, Port, timeouts, max body bytes, h2c toggle, CORS, Docs |
 | `DocsConfig` | Controls API documentation serving (`docs.enabled`) |
 | `Component` | Managed lifecycle — `Start`, `Stop`, `Health` |
 | `New(cfg, log)` | Create a server instance |

--- a/server/config.go
+++ b/server/config.go
@@ -9,14 +9,17 @@ import (
 
 // Config holds HTTP server configuration.
 type Config struct {
-	Host         string                `yaml:"host" mapstructure:"host"`
-	Port         int                   `yaml:"port" mapstructure:"port"`
-	ReadTimeout  int                   `yaml:"read_timeout" mapstructure:"read_timeout"`   // seconds
-	WriteTimeout int                   `yaml:"write_timeout" mapstructure:"write_timeout"` // seconds
-	IdleTimeout  int                   `yaml:"idle_timeout" mapstructure:"idle_timeout"`   // seconds
-	MaxBodySize  string                `yaml:"max_body_size" mapstructure:"max_body_size"` // e.g. "10MB"
-	TLS          *security.TLSConfig   `yaml:"tls" mapstructure:"tls"`
-	CORS         middleware.CORSConfig `yaml:"cors" mapstructure:"cors"`
+	Host            string                `yaml:"host" mapstructure:"host"`
+	Port            int                   `yaml:"port" mapstructure:"port"`
+	ReadTimeout     int                   `yaml:"read_timeout" mapstructure:"read_timeout"`         // seconds
+	WriteTimeout    int                   `yaml:"write_timeout" mapstructure:"write_timeout"`       // seconds
+	IdleTimeout     int                   `yaml:"idle_timeout" mapstructure:"idle_timeout"`         // seconds
+	RequestTimeout  int                   `yaml:"request_timeout" mapstructure:"request_timeout"`   // seconds; 0 disables the per-request timeout. Applies to REST routes only, not RPC/streaming mounts; keep it off in front of SSE/streaming handlers.
+	ShutdownTimeout int                   `yaml:"shutdown_timeout" mapstructure:"shutdown_timeout"` // seconds
+	MaxBodyBytes    int64                 `yaml:"max_body_bytes" mapstructure:"max_body_bytes"`     // request body cap in bytes
+	EnableH2C       *bool                 `yaml:"enable_h2c" mapstructure:"enable_h2c"`             // serve HTTP/2 cleartext when TLS is off (default true)
+	TLS             *security.TLSConfig   `yaml:"tls" mapstructure:"tls"`
+	CORS            middleware.CORSConfig `yaml:"cors" mapstructure:"cors"`
 	// SecurityHeaders configures the secure-by-default response headers applied to every route.
 	// Zero value yields secure defaults; set Disabled to opt out.
 	SecurityHeaders security.HeadersConfig `yaml:"security_headers" mapstructure:"security_headers"`
@@ -53,8 +56,15 @@ func (c *Config) ApplyDefaults() {
 	if c.IdleTimeout == 0 {
 		c.IdleTimeout = 60
 	}
-	if c.MaxBodySize == "" {
-		c.MaxBodySize = "10MB"
+	if c.ShutdownTimeout == 0 {
+		c.ShutdownTimeout = 5
+	}
+	if c.MaxBodyBytes == 0 {
+		c.MaxBodyBytes = 10 * 1024 * 1024
+	}
+	if c.EnableH2C == nil {
+		enabled := true
+		c.EnableH2C = &enabled
 	}
 	if len(c.CORS.AllowedOrigins) == 0 {
 		c.CORS.AllowedOrigins = []string{"*"}
@@ -65,6 +75,12 @@ func (c *Config) ApplyDefaults() {
 	if len(c.CORS.AllowedHeaders) == 0 {
 		c.CORS.AllowedHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization"}
 	}
+}
+
+// H2CEnabled reports whether HTTP/2 cleartext should be served when TLS is off.
+// It defaults to true when unset.
+func (c *Config) H2CEnabled() bool {
+	return c.EnableH2C == nil || *c.EnableH2C
 }
 
 // Validate checks the configuration for invalid values.
@@ -80,6 +96,15 @@ func (c *Config) Validate() error {
 	}
 	if c.IdleTimeout < 0 {
 		return fmt.Errorf("server.idle_timeout must be non-negative (got: %d)", c.IdleTimeout)
+	}
+	if c.RequestTimeout < 0 {
+		return fmt.Errorf("server.request_timeout must be non-negative (got: %d)", c.RequestTimeout)
+	}
+	if c.ShutdownTimeout < 0 {
+		return fmt.Errorf("server.shutdown_timeout must be non-negative (got: %d)", c.ShutdownTimeout)
+	}
+	if c.MaxBodyBytes < 0 {
+		return fmt.Errorf("server.max_body_bytes must be non-negative (got: %d)", c.MaxBodyBytes)
 	}
 	if _, err := c.SecurityHeaders.HeaderMap(); err != nil {
 		return err

--- a/server/endpoint/golden_test.go
+++ b/server/endpoint/golden_test.go
@@ -1,0 +1,143 @@
+package endpoint_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kbukum/gokit/component"
+	"github.com/kbukum/gokit/contracttest/golden"
+	"github.com/kbukum/gokit/server/endpoint"
+)
+
+// These goldens pin the transport-layer wire shapes shared with rskit. Dynamic
+// fields (timestamp, uptime, runtime metrics, build info) are set to fixed
+// values so the fixtures assert the field set, key names, and status vocabulary
+// deterministically. The health document reuses the healthy/degraded/unhealthy
+// vocabulary owned by component.HealthStatus.
+
+func TestHealthResponseGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	resp := endpoint.HealthResponse{
+		Status:    string(component.StatusDegraded),
+		Service:   "orders",
+		Timestamp: "2026-03-05T10:00:00Z",
+		Components: []component.Health{
+			{Name: "db", Status: component.StatusHealthy},
+			{Name: "cache", Status: component.StatusDegraded, Message: "slow"},
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal HealthResponse: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"status": "degraded",
+		"service": "orders",
+		"timestamp": "2026-03-05T10:00:00Z",
+		"components": [
+			{"name": "db", "status": "healthy"},
+			{"name": "cache", "status": "degraded", "message": "slow"}
+		]
+	}`)
+}
+
+func TestReadinessResponseGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	resp := endpoint.ReadinessResponse{
+		Status:    "ready",
+		Service:   "orders",
+		Timestamp: "2026-03-05T10:00:00Z",
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal ReadinessResponse: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"status": "ready",
+		"service": "orders",
+		"timestamp": "2026-03-05T10:00:00Z"
+	}`)
+}
+
+func TestLivenessResponseGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	resp := endpoint.LivenessResponse{
+		Status:    "alive",
+		Service:   "orders",
+		Timestamp: "2026-03-05T10:00:00Z",
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal LivenessResponse: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"status": "alive",
+		"service": "orders",
+		"timestamp": "2026-03-05T10:00:00Z"
+	}`)
+}
+
+func TestInfoResponseGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	resp := endpoint.InfoResponse{
+		Service:   "orders",
+		Version:   "v0.1.0",
+		GitCommit: "abc1234",
+		GitBranch: "main",
+		BuildTime: "2026-03-05T10:00:00Z",
+		GoVersion: "go1.25",
+		IsRelease: false,
+		IsDirty:   false,
+		Uptime:    "2h30m15s",
+		Timestamp: "2026-03-05T10:00:00Z",
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal InfoResponse: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"service": "orders",
+		"version": "v0.1.0",
+		"git_commit": "abc1234",
+		"git_branch": "main",
+		"build_time": "2026-03-05T10:00:00Z",
+		"go_version": "go1.25",
+		"is_release": false,
+		"is_dirty": false,
+		"uptime": "2h30m15s",
+		"timestamp": "2026-03-05T10:00:00Z"
+	}`)
+}
+
+func TestMetricsResponseGoldenJSON(t *testing.T) {
+	t.Parallel()
+
+	resp := endpoint.MetricsResponse{
+		Timestamp:  "2026-03-05T10:00:00Z",
+		Goroutines: 42,
+		Memory: endpoint.MemoryMetrics{
+			AllocMB:      24,
+			TotalAllocMB: 128,
+			SysMB:        64,
+			GCRuns:       15,
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal MetricsResponse: %v", err)
+	}
+	golden.AssertJSON(t, data, `{
+		"timestamp": "2026-03-05T10:00:00Z",
+		"goroutines": 42,
+		"memory": {
+			"alloc_mb": 24,
+			"total_alloc_mb": 128,
+			"sys_mb": 64,
+			"gc_runs": 15
+		}
+	}`)
+}

--- a/server/endpoint/health.go
+++ b/server/endpoint/health.go
@@ -16,32 +16,32 @@ type HealthChecker func(ctx context.Context) []component.Health
 // Health returns a handler that reports service health including component statuses.
 func Health(serviceName string, checker HealthChecker) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		status := "healthy"
+		status := string(component.StatusHealthy)
 		var components []component.Health
 
 		if checker != nil {
 			components = checker(c.Request.Context())
 			for _, ch := range components {
 				if ch.Status == component.StatusUnhealthy {
-					status = "unhealthy"
+					status = string(component.StatusUnhealthy)
 					break
 				}
-				if ch.Status == component.StatusDegraded && status != "unhealthy" {
-					status = "degraded"
+				if ch.Status == component.StatusDegraded && status != string(component.StatusUnhealthy) {
+					status = string(component.StatusDegraded)
 				}
 			}
 		}
 
 		httpStatus := http.StatusOK
-		if status == "unhealthy" {
+		if status == string(component.StatusUnhealthy) {
 			httpStatus = http.StatusServiceUnavailable
 		}
 
-		c.JSON(httpStatus, gin.H{
-			"status":     status,
-			"service":    serviceName,
-			"timestamp":  time.Now().UTC().Format(time.RFC3339),
-			"components": components,
+		c.JSON(httpStatus, HealthResponse{
+			Status:     status,
+			Service:    serviceName,
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+			Components: components,
 		})
 	}
 }

--- a/server/endpoint/info.go
+++ b/server/endpoint/info.go
@@ -16,17 +16,17 @@ var startTime = time.Now()
 func Info(serviceName string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		v := version.GetVersionInfo()
-		c.JSON(http.StatusOK, gin.H{
-			"service":    serviceName,
-			"version":    v.Version,
-			"git_commit": v.GitCommit,
-			"git_branch": v.GitBranch,
-			"build_time": v.BuildTime,
-			"go_version": v.GoVersion,
-			"is_release": v.IsRelease,
-			"is_dirty":   v.IsDirty,
-			"uptime":     time.Since(startTime).String(),
-			"timestamp":  time.Now().UTC().Format(time.RFC3339),
+		c.JSON(http.StatusOK, InfoResponse{
+			Service:   serviceName,
+			Version:   v.Version,
+			GitCommit: v.GitCommit,
+			GitBranch: v.GitBranch,
+			BuildTime: v.BuildTime,
+			GoVersion: v.GoVersion,
+			IsRelease: v.IsRelease,
+			IsDirty:   v.IsDirty,
+			Uptime:    time.Since(startTime).String(),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		})
 	}
 }

--- a/server/endpoint/liveness.go
+++ b/server/endpoint/liveness.go
@@ -11,10 +11,10 @@ import (
 // and able to serve HTTP.
 func Liveness(serviceName string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{
-			"status":    "alive",
-			"service":   serviceName,
-			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		c.JSON(http.StatusOK, LivenessResponse{
+			Status:    "alive",
+			Service:   serviceName,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		})
 	}
 }

--- a/server/endpoint/metrics.go
+++ b/server/endpoint/metrics.go
@@ -14,14 +14,14 @@ func Metrics() gin.HandlerFunc {
 		var m runtime.MemStats
 		runtime.ReadMemStats(&m)
 
-		c.JSON(http.StatusOK, gin.H{
-			"timestamp":  time.Now().UTC().Format(time.RFC3339),
-			"goroutines": runtime.NumGoroutine(),
-			"memory": gin.H{
-				"alloc_mb":       m.Alloc / 1024 / 1024,
-				"total_alloc_mb": m.TotalAlloc / 1024 / 1024,
-				"sys_mb":         m.Sys / 1024 / 1024,
-				"gc_runs":        m.NumGC,
+		c.JSON(http.StatusOK, MetricsResponse{
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+			Goroutines: runtime.NumGoroutine(),
+			Memory: MemoryMetrics{
+				AllocMB:      m.Alloc / 1024 / 1024,
+				TotalAllocMB: m.TotalAlloc / 1024 / 1024,
+				SysMB:        m.Sys / 1024 / 1024,
+				GCRuns:       m.NumGC,
 			},
 		})
 	}

--- a/server/endpoint/readiness.go
+++ b/server/endpoint/readiness.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/kbukum/gokit/component"
 )
 
 // Readiness returns a handler for K8s readiness probes.
@@ -16,7 +18,7 @@ func Readiness(serviceName string, checker HealthChecker) gin.HandlerFunc {
 
 		if checker != nil {
 			for _, ch := range checker(c.Request.Context()) {
-				if ch.Status == "unhealthy" {
+				if ch.Status == component.StatusUnhealthy {
 					status = "not_ready"
 					httpStatus = http.StatusServiceUnavailable
 					break
@@ -24,10 +26,10 @@ func Readiness(serviceName string, checker HealthChecker) gin.HandlerFunc {
 			}
 		}
 
-		c.JSON(httpStatus, gin.H{
-			"status":    status,
-			"service":   serviceName,
-			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		c.JSON(httpStatus, ReadinessResponse{
+			Status:    status,
+			Service:   serviceName,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		})
 	}
 }

--- a/server/endpoint/types.go
+++ b/server/endpoint/types.go
@@ -15,6 +15,20 @@ type HealthResponse struct {
 	Components []component.Health `json:"components"`
 }
 
+// ReadinessResponse is the response from GET /readyz.
+type ReadinessResponse struct {
+	Status    string `json:"status" example:"ready"`
+	Service   string `json:"service" example:"my-service"`
+	Timestamp string `json:"timestamp" example:"2026-03-05T10:00:00Z"`
+}
+
+// LivenessResponse is the response from GET /livez.
+type LivenessResponse struct {
+	Status    string `json:"status" example:"alive"`
+	Service   string `json:"service" example:"my-service"`
+	Timestamp string `json:"timestamp" example:"2026-03-05T10:00:00Z"`
+}
+
 // InfoResponse is the response from GET /info.
 type InfoResponse struct {
 	Service   string `json:"service" example:"my-service"`

--- a/server/go.mod
+++ b/server/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
-	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.21.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -106,12 +106,6 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
-github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
-github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
-github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
-github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
-github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
-github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/server/middleware/bodysize.go
+++ b/server/middleware/bodysize.go
@@ -4,18 +4,19 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/kbukum/gokit/util"
 )
 
-const defaultMaxBodySize = 10 * 1024 * 1024 // 10MB
+const defaultMaxBodySize int64 = 10 * 1024 * 1024 // 10MB
 
-// BodySizeLimit returns middleware that restricts the request body to the given size string (e.g. "10MB", "512KB", "1GB").
-func BodySizeLimit(maxSize string) Middleware {
-	size := util.ParseSize(maxSize, defaultMaxBodySize)
+// BodySizeLimit returns middleware that restricts the request body to maxBytes.
+// A non-positive maxBytes falls back to the 10MB default.
+func BodySizeLimit(maxBytes int64) Middleware {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBodySize
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r.Body = http.MaxBytesReader(w, r.Body, size)
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -24,6 +25,6 @@ func BodySizeLimit(maxSize string) Middleware {
 // GinBodySizeLimit returns a Gin middleware for body size limiting.
 // Prefer using BodySizeLimit() at the server level via ApplyMiddleware() which covers all routes.
 // Use this only when you need it on the Gin engine directly.
-func GinBodySizeLimit(maxSize string) gin.HandlerFunc {
-	return GinWrap(BodySizeLimit(maxSize))
+func GinBodySizeLimit(maxBytes int64) gin.HandlerFunc {
+	return GinWrap(BodySizeLimit(maxBytes))
 }

--- a/server/middleware/bodysize_test.go
+++ b/server/middleware/bodysize_test.go
@@ -12,7 +12,7 @@ import (
 func TestGinBodySizeLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(GinBodySizeLimit("10MB"))
+	r.Use(GinBodySizeLimit(10 * 1024 * 1024))
 	r.POST("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))

--- a/server/middleware/http_test.go
+++ b/server/middleware/http_test.go
@@ -221,7 +221,7 @@ func TestRequestLogger_SkipsHealth(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBodySizeLimit_AppliesLimit(t *testing.T) {
-	handler := middleware.BodySizeLimit("1KB")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := middleware.BodySizeLimit(1024)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/server/middleware/timeout.go
+++ b/server/middleware/timeout.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	apperrors "github.com/kbukum/gokit/errors"
+)
+
+// Timeout returns middleware that bounds each request to d. When the deadline
+// elapses the request context is canceled — so downstream calls that honor the
+// context stop — and the client receives a 503 with a Problem Details
+// (application/problem+json) body, so JSON clients can parse the response even
+// under a nosniff policy.
+//
+// A non-positive d disables the middleware (returns the handler unchanged).
+// The timeout applies to every wrapped route, so do not enable it in front of
+// long-lived streaming handlers (e.g. SSE); mount those without it.
+func Timeout(d time.Duration) Middleware {
+	return func(next http.Handler) http.Handler {
+		if d <= 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cancel := context.WithTimeout(r.Context(), d)
+			defer cancel()
+
+			buf := &bufferedResponseWriter{header: make(http.Header), status: http.StatusOK}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				next.ServeHTTP(buf, r.WithContext(ctx))
+			}()
+
+			select {
+			case <-done:
+				buf.flushTo(w)
+			case <-ctx.Done():
+				writeTimeout(w, r)
+			}
+		})
+	}
+}
+
+// writeTimeout emits the 503 Problem Details response for an elapsed deadline.
+func writeTimeout(w http.ResponseWriter, r *http.Request) {
+	pd := apperrors.New(apperrors.ErrCodeServiceUnavailable, "request timeout", http.StatusServiceUnavailable).ToProblemDetail()
+	pd.Instance = r.URL.Path
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	body, _ := json.Marshal(pd)
+	_, _ = w.Write(body)
+}
+
+// bufferedResponseWriter records a handler's response so the timeout middleware
+// can either replay it once the handler finishes or discard it if the deadline
+// fires first. Discarding avoids a partially written response racing with the
+// timeout body on the real writer.
+type bufferedResponseWriter struct {
+	mu          sync.Mutex
+	header      http.Header
+	body        bytes.Buffer
+	status      int
+	wroteHeader bool
+}
+
+func (b *bufferedResponseWriter) Header() http.Header { return b.header }
+
+func (b *bufferedResponseWriter) WriteHeader(status int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.wroteHeader {
+		return
+	}
+	b.status = status
+	b.wroteHeader = true
+}
+
+func (b *bufferedResponseWriter) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.wroteHeader = true
+	return b.body.Write(p)
+}
+
+// flushTo replays the recorded response onto the real writer.
+func (b *bufferedResponseWriter) flushTo(w http.ResponseWriter) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	dst := w.Header()
+	for k, vv := range b.header {
+		dst[k] = vv
+	}
+	w.WriteHeader(b.status)
+	_, _ = w.Write(b.body.Bytes())
+}

--- a/server/middleware/timeout_test.go
+++ b/server/middleware/timeout_test.go
@@ -1,0 +1,77 @@
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kbukum/gokit/server/middleware"
+)
+
+func TestTimeout_ExceededReturns503(t *testing.T) {
+	t.Parallel()
+
+	h := middleware.Timeout(10 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/slow", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("content-type: got %q want application/problem+json", ct)
+	}
+	if !json.Valid(rr.Body.Bytes()) {
+		t.Fatalf("timeout body is not valid JSON: %q", rr.Body.String())
+	}
+}
+
+func TestTimeout_WithinDeadlinePasses(t *testing.T) {
+	t.Parallel()
+
+	h := middleware.Timeout(time.Second)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fast", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type passthrough: got %q want application/json", ct)
+	}
+	if rr.Body.String() != `{"ok":true}` {
+		t.Fatalf("body passthrough: got %q", rr.Body.String())
+	}
+}
+
+func TestTimeout_NonPositiveDisables(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := middleware.Timeout(0)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if !called || rr.Code != http.StatusTeapot {
+		t.Fatalf("disabled timeout must pass through unchanged; called=%v code=%d", called, rr.Code)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -20,14 +20,15 @@ import (
 
 // Server is a unified HTTP server backed by Gin with optional support for additional http.Handler mounts (e.g. Connect-Go / gRPC) on the same port.
 type Server struct {
-	httpServer *http.Server
-	engine     *gin.Engine
-	mux        *http.ServeMux
-	config     Config
-	log        *logging.Logger
-	mounts     []MountedHandler      // tracked for summary display
-	listener   net.Listener          // set by Start(); used by ListenAddr()
-	secHeaders middleware.Middleware // built once from config; no-op when disabled
+	httpServer  *http.Server
+	engine      *gin.Engine
+	mux         *http.ServeMux
+	restHandler http.Handler // Gin engine, optionally wrapped with the per-request timeout
+	config      Config
+	log         *logging.Logger
+	mounts      []MountedHandler      // tracked for summary display
+	listener    net.Listener          // set by Start(); used by ListenAddr()
+	secHeaders  middleware.Middleware // built once from config; no-op when disabled
 }
 
 // MountedHandler records a handler mounted on the ServeMux.
@@ -56,9 +57,6 @@ func New(cfg *Config, log *logging.Logger) *Server {
 	engine := gin.New()
 	mux := http.NewServeMux()
 
-	// Mount Gin as the fallback handler on the root mux.
-	mux.Handle("/", engine)
-
 	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
 
 	// Configure HTTP/2 protocol support based on TLS setting.
@@ -76,7 +74,7 @@ func New(cfg *Config, log *logging.Logger) *Server {
 			// We don't panic in constructors.
 			tlsConfig = nil
 		}
-	} else {
+	} else if cfg.H2CEnabled() {
 		// No TLS: enable unencrypted HTTP/2 (h2c) for gRPC without TLS.
 		protocols.SetUnencryptedHTTP2(true)
 	}
@@ -109,7 +107,7 @@ func New(cfg *Config, log *logging.Logger) *Server {
 		}
 	}
 
-	return &Server{
+	srv := &Server{
 		httpServer: httpServer,
 		engine:     engine,
 		mux:        mux,
@@ -117,6 +115,14 @@ func New(cfg *Config, log *logging.Logger) *Server {
 		log:        log,
 		secHeaders: secHeaders,
 	}
+	// Default the REST handler to the bare Gin engine; ApplyMiddleware may wrap
+	// it with the per-request timeout. Mount an indirection at "/" so that later
+	// wrapping is visible without re-registering the (single-use) mux pattern.
+	srv.restHandler = engine
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.restHandler.ServeHTTP(w, r)
+	}))
+	return srv
 }
 
 // GinEngine returns the underlying Gin engine for route registration.
@@ -187,11 +193,16 @@ func (s *Server) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the server with a 5-second deadline.
+// Stop gracefully shuts down the server, waiting up to the configured
+// shutdown_timeout for in-flight requests to drain.
 func (s *Server) Stop(ctx context.Context) error {
 	s.log.DebugCtx(ctx, "Shutting down HTTP server")
 
-	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeout := time.Duration(s.config.ShutdownTimeout) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	shutdownCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
@@ -232,7 +243,19 @@ func readSpecFile(path string) ([]byte, error) {
 
 // ApplyMiddleware applies the standard middleware stack at the handler level
 // so it covers ALL routes — both Gin REST endpoints and ConnectRPC services mounted via Handle().
+//
+// The optional per-request timeout is the exception: it wraps only the Gin
+// (REST) engine, not the RPC/streaming handlers mounted via Handle(), because
+// http.TimeoutHandler buffers the response and cannot flush or hijack — which
+// would break streaming RPCs and h2c.
 func (s *Server) ApplyMiddleware() {
+	// Wrap the REST engine (and only the REST engine) with the per-request
+	// timeout. RPC/streaming mounts keep serving through the bare mux.
+	s.restHandler = s.engine
+	if s.config.RequestTimeout > 0 {
+		s.restHandler = middleware.Timeout(time.Duration(s.config.RequestTimeout) * time.Second)(s.engine)
+	}
+
 	stack := []middleware.Middleware{
 		middleware.InjectLogger(s.log),
 		middleware.Recovery(s.log),
@@ -245,8 +268,8 @@ func (s *Server) ApplyMiddleware() {
 		middleware.CORS(&s.config.CORS),
 		middleware.RequestLogger(s.log),
 	)
-	if s.config.MaxBodySize != "" {
-		stack = append(stack, middleware.BodySizeLimit(s.config.MaxBodySize))
+	if s.config.MaxBodyBytes > 0 {
+		stack = append(stack, middleware.BodySizeLimit(s.config.MaxBodyBytes))
 	}
 
 	s.httpServer.Handler = middleware.Chain(stack...)(s.mux)

--- a/server/server_lifecycle_test.go
+++ b/server/server_lifecycle_test.go
@@ -110,8 +110,14 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 	if cfg.IdleTimeout != 60 {
 		t.Errorf("idle_timeout: want 60, got %d", cfg.IdleTimeout)
 	}
-	if cfg.MaxBodySize != "10MB" {
-		t.Errorf("max_body_size: want 10MB, got %s", cfg.MaxBodySize)
+	if cfg.MaxBodyBytes != 10*1024*1024 {
+		t.Errorf("max_body_bytes: want %d, got %d", 10*1024*1024, cfg.MaxBodyBytes)
+	}
+	if cfg.ShutdownTimeout != 5 {
+		t.Errorf("shutdown_timeout: want 5, got %d", cfg.ShutdownTimeout)
+	}
+	if !cfg.H2CEnabled() {
+		t.Error("enable_h2c: want true by default")
 	}
 }
 
@@ -159,13 +165,25 @@ func TestConfig_Validate_NegativeTimeouts(t *testing.T) {
 		{"read", server.Config{ReadTimeout: -1}},
 		{"write", server.Config{WriteTimeout: -1}},
 		{"idle", server.Config{IdleTimeout: -1}},
+		{"request", server.Config{RequestTimeout: -1}},
+		{"shutdown", server.Config{ShutdownTimeout: -1}},
+		{"max_body_bytes", server.Config{MaxBodyBytes: -1}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.cfg.Validate(); err == nil {
-				t.Error("expected validation error for negative timeout")
+				t.Error("expected validation error for negative value")
 			}
 		})
+	}
+}
+
+func TestConfig_H2CExplicitFalse(t *testing.T) {
+	disabled := false
+	cfg := &server.Config{EnableH2C: &disabled}
+	cfg.ApplyDefaults()
+	if cfg.H2CEnabled() {
+		t.Error("enable_h2c: explicit false must stay disabled after ApplyDefaults")
 	}
 }
 
@@ -633,6 +651,66 @@ func TestHandle_SequentialMultipleRegistration(t *testing.T) {
 
 	if got := len(s.Mounts()); got != 10 {
 		t.Errorf("mounts after registration: want 10, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Request timeout scoping
+// ---------------------------------------------------------------------------
+
+// The per-request timeout must wrap REST routes only. RPC/streaming handlers
+// mounted via Handle() must keep a flushable writer, because http.TimeoutHandler
+// buffers the response and cannot flush or hijack.
+
+func TestApplyMiddleware_RequestTimeout_SkipsMountedHandlers(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.RequestTimeout = 1
+	s := server.New(cfg, logging.NewDefault("test"))
+
+	var mountFlushable bool
+	s.Handle("/svc.S/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, mountFlushable = w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.ApplyMiddleware()
+
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/svc.S/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	if !mountFlushable {
+		t.Error("mounted RPC handler must receive a flushable writer (not wrapped by the request timeout)")
+	}
+}
+
+func TestApplyMiddleware_RequestTimeout_AppliesToREST(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.RequestTimeout = 1
+	s := server.New(cfg, logging.NewDefault("test"))
+
+	s.GinEngine().GET("/slow", func(c *gin.Context) {
+		<-c.Request.Context().Done()
+		c.String(http.StatusOK, "done")
+	})
+	s.ApplyMiddleware()
+
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/slow")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("REST slow handler: want 503 from request timeout, got %d", resp.StatusCode)
 	}
 }
 

--- a/server/testutil/go.mod
+++ b/server/testutil/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
-	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect

--- a/server/testutil/go.sum
+++ b/server/testutil/go.sum
@@ -106,12 +106,6 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
-github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
-github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
-github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
-github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
-github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
-github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/util/README.md
+++ b/util/README.md
@@ -55,7 +55,7 @@ func main() {
 | `SecretString` / `SecretKeyMatcher` / `MaskSecret()` | In-memory secret redaction (crypto lives in `encryption`) |
 | `GetEnv()` / `GetEnvOr()` / `GetEnvBool()` / `GetEnvParsed[T]()` | Environment variable access |
 | `ContentHasher` / `Sha256Hex()` / `HashHex()` / `Sha256Reader()` | Content hashing |
-| `FormatBytes()` / `ParseBytes()` / `ParseSize()` | Human-readable byte sizes |
+| `FormatBytes()` / `ParseBytes()` | Human-readable byte sizes |
 | `FormatDuration()` / `ParseDuration()` / `TimeIt[T]()` | Duration formatting and timing |
 | `Clock` / `NewFakeClock()` | Injectable clock for deterministic tests |
 | `GlobMatch()` / `NewGlob()` / `HasWildcard()` | Glob pattern matching |

--- a/util/parse.go
+++ b/util/parse.go
@@ -1,38 +1,5 @@
 package util
 
-import (
-	"fmt"
-	"strings"
-)
-
-// ParseSize parses a human-readable size string (e.g. "10MB", "512KB", "2GB") into bytes.
-// Returns defaultBytes if the string cannot be parsed.
-func ParseSize(s string, defaultBytes int64) int64 {
-	s = strings.ToUpper(strings.TrimSpace(s))
-	if s == "" {
-		return defaultBytes
-	}
-
-	var multiplier int64 = 1
-	switch {
-	case strings.HasSuffix(s, "GB"):
-		multiplier = 1024 * 1024 * 1024
-		s = s[:len(s)-2]
-	case strings.HasSuffix(s, "MB"):
-		multiplier = 1024 * 1024
-		s = s[:len(s)-2]
-	case strings.HasSuffix(s, "KB"):
-		multiplier = 1024
-		s = s[:len(s)-2]
-	}
-
-	var val int64
-	if _, err := fmt.Sscanf(s, "%d", &val); err == nil {
-		return val * multiplier
-	}
-	return defaultBytes
-}
-
 // MaskSecret hides sensitive parts of a string for safe display in logs.
 // If the string is shorter than visiblePrefix, it is fully masked.
 func MaskSecret(s string, visiblePrefix int) string {

--- a/util/parse_test.go
+++ b/util/parse_test.go
@@ -2,44 +2,13 @@ package util
 
 import "testing"
 
-func TestParseSize(t *testing.T) {
-	tests := []struct {
-		input string
-		want  int64
-	}{
-		{"10MB", 10 * 1024 * 1024},
-		{"512KB", 512 * 1024},
-		{"2GB", 2 * 1024 * 1024 * 1024},
-		{"1024", 1024},
-		{"  10MB  ", 10 * 1024 * 1024},
-		{"10mb", 10 * 1024 * 1024},
-	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			if got := ParseSize(tc.input, 0); got != tc.want {
-				t.Errorf("ParseSize(%q) = %d, want %d", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseSize_Default(t *testing.T) {
-	defaultVal := int64(5 * 1024 * 1024)
-	if got := ParseSize("", defaultVal); got != defaultVal {
-		t.Errorf("expected default %d, got %d", defaultVal, got)
-	}
-	if got := ParseSize("invalid", defaultVal); got != defaultVal {
-		t.Errorf("expected default %d for invalid input, got %d", defaultVal, got)
-	}
-}
-
 func TestMaskSecret(t *testing.T) {
 	tests := []struct {
 		input  string
 		prefix int
 		want   string
 	}{
-		{"host=localhost user=admin password=secret", 10, "host=local***"},
+		{"host=localhost user=admin ******", 10, "host=local***"},
 		{"short", 10, "***"},
 		{"exactly10!", 10, "***"},
 		{"", 5, "***"},
@@ -53,111 +22,6 @@ func TestMaskSecret(t *testing.T) {
 		})
 	}
 }
-
-// ── ParseSize extended ──────────────────────────────────────────────────
-
-func TestParseSize_ZeroValues(t *testing.T) {
-	tests := []struct {
-		input string
-		want  int64
-	}{
-		{"0MB", 0},
-		{"0KB", 0},
-		{"0GB", 0},
-		{"0", 0},
-	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			if got := ParseSize(tc.input, -1); got != tc.want {
-				t.Errorf("ParseSize(%q) = %d, want %d", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseSize_LargeValues(t *testing.T) {
-	// 100GB
-	got := ParseSize("100GB", 0)
-	want := int64(100) * 1024 * 1024 * 1024
-	if got != want {
-		t.Errorf("ParseSize(100GB) = %d, want %d", got, want)
-	}
-}
-
-func TestParseSize_OnlySuffix(t *testing.T) {
-	// "MB" with no number should return default
-	got := ParseSize("MB", 42)
-	if got != 42 {
-		t.Errorf("ParseSize(MB) = %d, want default 42", got)
-	}
-}
-
-func TestParseSize_WhitespaceOnly(t *testing.T) {
-	got := ParseSize("   ", 99)
-	if got != 99 {
-		t.Errorf("ParseSize(whitespace) = %d, want default 99", got)
-	}
-}
-
-func TestParseSize_MixedCase(t *testing.T) {
-	tests := []struct {
-		input string
-		want  int64
-	}{
-		{"10Mb", 10 * 1024 * 1024},
-		{"10mB", 10 * 1024 * 1024},
-		{"10Kb", 10 * 1024},
-		{"10kB", 10 * 1024},
-		{"10Gb", 10 * 1024 * 1024 * 1024},
-		{"10gB", 10 * 1024 * 1024 * 1024},
-	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			if got := ParseSize(tc.input, 0); got != tc.want {
-				t.Errorf("ParseSize(%q) = %d, want %d", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseSize_NegativeNumber(t *testing.T) {
-	// Sscanf(%d) parses negative integers, so -10MB yields -10 * MB
-	got := ParseSize("-10MB", 777)
-	want := int64(-10) * 1024 * 1024
-	if got != want {
-		t.Errorf("ParseSize(-10MB) = %d, want %d", got, want)
-	}
-}
-
-func TestParseSize_FloatingPoint(t *testing.T) {
-	// Sscanf(%d) reads integer prefix of "1.5", i.e. 1
-	got := ParseSize("1.5MB", 777)
-	want := int64(1) * 1024 * 1024
-	if got != want {
-		t.Errorf("ParseSize(1.5MB) = %d, want %d", got, want)
-	}
-}
-
-func TestParseSize_AlphaAndSpecial(t *testing.T) {
-	defaultVal := int64(777)
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"alpha", "abc"},
-		{"special chars", "!@#$"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := ParseSize(tc.input, defaultVal)
-			if got != defaultVal {
-				t.Errorf("ParseSize(%q) = %d, want default %d", tc.input, got, defaultVal)
-			}
-		})
-	}
-}
-
-// ── MaskSecret extended ────────────────────────────────────────────────
 
 func TestMaskSecret_ZeroPrefix(t *testing.T) {
 	got := MaskSecret("secret", 0)


### PR DESCRIPTION
## Description

Aligns the transport and resilience configuration surface with the shared cross-kit wire vocabulary and gives the JSON contracts a single stable shape. Config field names, resilience policy blocks, and discovery/backoff JSON encodings now match the naming used across the transports (and the sibling kit), so a service can be configured with one consistent set of keys regardless of which transport it wires up.

## Motivation

The transports and resilience layer had drifted into per-module naming (`addr`, `max_recv_msg_size`, `call_timeout`, `headers`, separate `retry`/`circuit_breaker`/`rate_limiter` blocks) and untagged structs that serialized inconsistently. This unifies the vocabulary so config and JSON contracts are predictable and match rskit where they cross a wire.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Module(s) Affected

- grpc, httpclient, server, discovery, resilience, config, llm, inference/triton, util

## Changes Made

- Rename gRPC config to the canonical `target` / `max_message_size` / `max_send_message_size` / `timeout` keys.
- Replace httpclient's split `headers` + `retry`/`circuit_breaker`/`rate_limiter` with `default_headers` and a single `resilience_policy` block using the shared `resilience.Policy` vocabulary; bound buffered responses via `max_response_body_bytes`.
- Give `discovery.ServiceInstance` a snake_case JSON contract: tri-state `Health` (zero → `unknown`) and omitted `Weight` defaulting to 1.
- Add text (un)marshaling for `resilience.BackoffStrategy` so config/JSON use `exponential`/`constant`/`linear`, and tag the retry config for `yaml`/`mapstructure` loading.
- Add a server request-timeout middleware; register the `TextUnmarshallerHookFunc` in the config loader so typed text values decode from config.
- Cover the new wire shapes with golden/round-trip tests; drop the now-unused `util.ParseSize` in favor of the typed byte field.

## Testing

- [x] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
- [ ] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [ ] Manual testing performed (describe below if applicable)

### Test Evidence

```
$ make test-affected
✓ All modules completed successfully.  (config, discovery, grpc, httpclient,
  resilience, server, llm, inference/triton, util, ... — green under -race -shuffle=on)
```

## Breaking Changes

Pre-stable rename with no compat shims: existing config keys (`addr`, `max_recv_msg_size`, `max_send_msg_size`, `call_timeout`, `headers`, and the separate resilience blocks) are replaced by the canonical names above. Callers referencing the old struct fields must move to the new ones. `util.ParseSize` is removed.

## Sibling Parity

- [x] Sibling-parity tracked: the transport config keys and discovery/backoff JSON contracts mirror the shared cross-kit wire shapes.

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [x] Suite is green under `-race -shuffle=on`
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated
