### PR TITLE
refactor(wire)!: align auth and data wire contracts across kits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,8 @@
 # gokit
 
-Multi-module Go library providing foundational infrastructure for service development.
-A sibling kit to rskit (Rust): the same capabilities and the same
-engineering baseline, idiomatic per language. Parity is tracked against rskit — for each
-capability, whichever kit has the stronger implementation is the one the other mirrors, so
-parity levels the kits up (never down) and stays scoped rather than symbol-for-symbol.
+Multi-module Go library providing foundational infrastructure for service development. A sibling kit to rskit (Rust): the same capabilities and the same engineering baseline, idiomatic per language. Parity is tracked against rskit — for each capability, whichever kit has the stronger implementation is the one the other mirrors, so parity levels the kits up (never down) and stays scoped rather than symbol-for-symbol.
+
+**Priority order:** up-to-date, idiomatic Go best practices outrank parity. Parity is a nice-to-have — pursue it only when it doesn't compromise practices, development ergonomics, or the tech stack; when the idiomatic Go approach is more efficient or correct, take it and let parity stay scoped to wire/contract compatibility, not internal types. Above both, **consistency across the project wins**: apply the same choice everywhere so the codebase reads as one coherent whole rather than a patchwork of locally-optimal decisions.
 
 ## Engineering principles
 

--- a/.github/skills/parity/SKILL.md
+++ b/.github/skills/parity/SKILL.md
@@ -29,6 +29,15 @@ When in doubt about a heavy capability, prefer the light-gokit / strong-elsewher
 
 Parity is about **capability and behavior**, not identical names or directory layouts. Where a language's current idioms, conventions, or best practices differ, follow Go's convention rather than force structural sameness — naming conventions, file/folder organization, error/option ergonomics, and module layout should read as native Go. Match the *concept and behavior* so users get intuition transfer; do not transliterate Rust. Call out any deliberate rename or reshaping in the rskit tracking issue so the mapping stays discoverable.
 
+## Priority order: consistency > best practices > parity
+
+Parity is a **nice-to-have**, not a mandate. When it conflicts with anything more important, parity yields:
+
+1. **Up-to-date, idiomatic Go best practices win over parity.** If the idiomatic Go approach is more efficient, safer, or more maintainable — considering current conventions, development ergonomics, and the tech stack — take it, even when it diverges from the sibling's shape. Never force a non-idiomatic type or structure (e.g. `any` in a public API, a hand-rolled sum type, a foreign directory layout) purely to match rskit. Parity legitimately binds only **wire/contract compatibility** (serialized shapes, event-type strings, protocol semantics), not internal representations.
+2. **Consistency across the project outranks both.** This is the load-bearing rule: once a pattern is chosen for a concern, apply it *everywhere* so gokit reads as one coherent whole rather than a patchwork of locally-optimal choices. A slightly-less-ideal choice applied consistently beats a marginally-better choice applied in one place and not another. Before diverging for idiom, check how the rest of gokit already handles the concern and match it.
+
+When a parity gap is intentionally left unclosed because Go's idiom or project consistency wins, record the decision (rskit tracking issue and/or a stored memory) so it is not re-flagged as a gap in later reviews.
+
 ## Workflow
 
 1. **Find the strongest existing implementation.** Locate the counterpart in the sibling kit (rskit crate in the [rskit repo](https://github.com/kbukum/rskit)) and study the public API, invariants, and error model — not just the surface — then decide which side currently has the better implementation for this scope.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -97,7 +97,7 @@ func TestConfig_ApplyDefaultsValidateDescribe(t *testing.T) {
 			Enabled:     true,
 			Issuer:      "https://issuer.example.com",
 			ClientID:    "client-id",
-			RedirectURL: "https://app.example.com/callback",
+			RedirectURI: "https://app.example.com/callback",
 		},
 	}
 	cfg.ApplyDefaults()

--- a/auth/oidc/config.go
+++ b/auth/oidc/config.go
@@ -22,8 +22,8 @@ type Config struct {
 	// ClientSecret is the OAuth2 client secret (for confidential clients).
 	ClientSecret string `mapstructure:"client_secret"`
 
-	// RedirectURL is the OAuth2 callback URL.
-	RedirectURL string `mapstructure:"redirect_url"`
+	// RedirectURI is the OAuth2 callback URL.
+	RedirectURI string `mapstructure:"redirect_uri"`
 
 	// PublicClient enables OAuth 2.1 public-client validation rules.
 	PublicClient bool `mapstructure:"public_client"`
@@ -77,10 +77,10 @@ func (c *Config) Validate() error {
 	if c.ClientID == "" {
 		return fmt.Errorf("client_id is required")
 	}
-	if c.RedirectURL != "" {
-		parsed, err := url.Parse(c.RedirectURL)
-		if err != nil || !parsed.IsAbs() || parsed.Fragment != "" || strings.Contains(c.RedirectURL, "*") {
-			return fmt.Errorf("redirect_url must be an exact absolute URI without fragments or wildcards")
+	if c.RedirectURI != "" {
+		parsed, err := url.Parse(c.RedirectURI)
+		if err != nil || !parsed.IsAbs() || parsed.Fragment != "" || strings.Contains(c.RedirectURI, "*") {
+			return fmt.Errorf("redirect_uri must be an exact absolute URI without fragments or wildcards")
 		}
 	}
 	if c.PublicClient && c.ClientSecret != "" {

--- a/auth/oidc/providers/apple_test.go
+++ b/auth/oidc/providers/apple_test.go
@@ -28,7 +28,7 @@ func TestAppleAuthURL(t *testing.T) {
 	a := NewApple(AppleConfig{
 		ProviderConfig: ProviderConfig{
 			ClientID:    "apple-id",
-			RedirectURL: "http://localhost/callback",
+			RedirectURI: "http://localhost/callback",
 		},
 	})
 	u := a.AuthURL("apple-state")
@@ -53,7 +53,7 @@ func TestNewApple_WithPrivateKeySetsSecretFunc(t *testing.T) {
 	pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
 
 	p := NewApple(AppleConfig{
-		ProviderConfig: ProviderConfig{ClientID: "cid", RedirectURL: "http://x"},
+		ProviderConfig: ProviderConfig{ClientID: "cid", RedirectURI: "http://x"},
 		TeamID:         "team",
 		KeyID:          "kid",
 		PrivateKey:     pemKey,

--- a/auth/oidc/providers/authurl.go
+++ b/auth/oidc/providers/authurl.go
@@ -21,7 +21,7 @@ func BuildAuthURL(req AuthURLRequest) string {
 	if len(opts.Scopes) > 0 {
 		scopes = opts.Scopes
 	}
-	redirectURI := req.Config.RedirectURL
+	redirectURI := req.Config.RedirectURI
 	if opts.RedirectURI != "" {
 		redirectURI = opts.RedirectURI
 	}

--- a/auth/oidc/providers/authurl_test.go
+++ b/auth/oidc/providers/authurl_test.go
@@ -13,7 +13,7 @@ func TestAuthURLWithPKCE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURL: "http://test"})
+	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURI: "http://test"})
 	u := g.AuthURL("state", oidc.WithPKCE(pkce))
 
 	if !strings.Contains(u, "code_challenge=") {
@@ -27,7 +27,7 @@ func TestAuthURLWithPKCE(t *testing.T) {
 func TestAuthURLWithOverrides(t *testing.T) {
 	g := NewGoogle(ProviderConfig{
 		ClientID:    "id",
-		RedirectURL: "http://original",
+		RedirectURI: "http://original",
 		Scopes:      []string{"openid"},
 	})
 
@@ -46,7 +46,7 @@ func TestAuthURLWithOverrides(t *testing.T) {
 }
 
 func TestAuthURLWithNonce(t *testing.T) {
-	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURL: "http://test"})
+	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURI: "http://test"})
 	u := g.AuthURL("state", oidc.WithNonce("my-nonce"))
 
 	if !strings.Contains(u, "nonce=my-nonce") {
@@ -56,7 +56,7 @@ func TestAuthURLWithNonce(t *testing.T) {
 
 func TestAuthURLCustomClientIDParam(t *testing.T) {
 	p := NewGeneric(GenericConfig{
-		ProviderConfig: ProviderConfig{ClientID: "tk-key", RedirectURL: "http://test"},
+		ProviderConfig: ProviderConfig{ClientID: "tk-key", RedirectURI: "http://test"},
 		ProviderName:   "tiktok-like",
 		AuthEndpoint:   "https://example.com/auth",
 		ClientIDParam:  "client_key",
@@ -75,7 +75,7 @@ func TestAuthURLCustomScopeSeparator(t *testing.T) {
 	p := NewGeneric(GenericConfig{
 		ProviderConfig: ProviderConfig{
 			ClientID:    "id",
-			RedirectURL: "http://test",
+			RedirectURI: "http://test",
 			Scopes:      []string{"user.info.basic", "video.list"},
 		},
 		ProviderName:   "tiktok-like",

--- a/auth/oidc/providers/config.go
+++ b/auth/oidc/providers/config.go
@@ -13,7 +13,7 @@
 //	google := providers.NewGoogle(providers.ProviderConfig{
 //	    ClientID:     "your-client-id",
 //	    ClientSecret: "your-client-secret",
-//	    RedirectURL:  "http://localhost:8381/api/v1/auth/oauth/google/callback",
+//	    RedirectURI:  "http://localhost:8381/api/v1/auth/oauth/google/callback",
 //	})
 //	authURL := google.AuthURL(state)
 //	tokens, err := google.Exchange(ctx, code)
@@ -35,7 +35,7 @@ var DefaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
 type ProviderConfig struct {
 	ClientID     string
 	ClientSecret string
-	RedirectURL  string
+	RedirectURI  string
 	Scopes       []string
 }
 

--- a/auth/oidc/providers/exchange.go
+++ b/auth/oidc/providers/exchange.go
@@ -40,7 +40,7 @@ type tokenResponse struct {
 func ExchangeCode(ctx context.Context, req ExchangeRequest) (*tokenResponse, error) {
 	redirectURI := req.Options.RedirectURI
 	if redirectURI == "" {
-		redirectURI = req.Config.RedirectURL
+		redirectURI = req.Config.RedirectURI
 	}
 
 	data := url.Values{
@@ -90,7 +90,7 @@ func ExchangeCode(ctx context.Context, req ExchangeRequest) (*tokenResponse, err
 func ExchangeJSON(ctx context.Context, req ExchangeRequest) (*tokenResponse, error) {
 	redirectURI := req.Options.RedirectURI
 	if redirectURI == "" {
-		redirectURI = req.Config.RedirectURL
+		redirectURI = req.Config.RedirectURI
 	}
 
 	clientIDKey := "client_id"

--- a/auth/oidc/providers/exchange_test.go
+++ b/auth/oidc/providers/exchange_test.go
@@ -114,7 +114,7 @@ func TestExchangeWithExtraHeaders(t *testing.T) {
 	defer server.Close()
 
 	p := NewGeneric(GenericConfig{
-		ProviderConfig: ProviderConfig{ClientID: "id", ClientSecret: "s", RedirectURL: "http://test"},
+		ProviderConfig: ProviderConfig{ClientID: "id", ClientSecret: "s", RedirectURI: "http://test"},
 		ProviderName:   "header-test",
 		TokenEndpoint:  server.URL + "/token",
 		TokenExtraHeaders: map[string]string{

--- a/auth/oidc/providers/github_test.go
+++ b/auth/oidc/providers/github_test.go
@@ -29,7 +29,7 @@ func TestGitHubConstructor(t *testing.T) {
 func TestGitHubAuthURL(t *testing.T) {
 	g := NewGitHub(ProviderConfig{
 		ClientID:    "gh-id",
-		RedirectURL: "http://localhost/callback",
+		RedirectURI: "http://localhost/callback",
 		Scopes:      []string{"read:user", "user:email"},
 	})
 	u := g.AuthURL("my-state")
@@ -70,7 +70,7 @@ func TestGitHubEmailFallback(t *testing.T) {
 	defer server.Close()
 
 	p := NewGeneric(GenericConfig{
-		ProviderConfig:   ProviderConfig{ClientID: "id", ClientSecret: "s", RedirectURL: "http://test"},
+		ProviderConfig:   ProviderConfig{ClientID: "id", ClientSecret: "s", RedirectURI: "http://test"},
 		ProviderName:     "github-mock",
 		TokenEndpoint:    server.URL + "/token",
 		UserInfoEndpoint: server.URL + "/user",

--- a/auth/oidc/providers/google_test.go
+++ b/auth/oidc/providers/google_test.go
@@ -22,7 +22,7 @@ func TestGoogleConstructor(t *testing.T) {
 func TestGoogleAuthURL(t *testing.T) {
 	g := NewGoogle(ProviderConfig{
 		ClientID:    "my-id",
-		RedirectURL: "http://localhost/callback",
+		RedirectURI: "http://localhost/callback",
 	})
 	u := g.AuthURL("test-state")
 

--- a/auth/oidc/providers/manager_test.go
+++ b/auth/oidc/providers/manager_test.go
@@ -77,7 +77,7 @@ func TestManagerListProvidersWithSocial(t *testing.T) {
 }
 
 func TestManagerAuthURL(t *testing.T) {
-	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURL: "http://test"})
+	g := NewGoogle(ProviderConfig{ClientID: "id", RedirectURI: "http://test"})
 	m := NewManager(g)
 
 	u, err := m.AuthURL("google", "state123")

--- a/auth/oidc/providers/mock_test.go
+++ b/auth/oidc/providers/mock_test.go
@@ -29,7 +29,7 @@ func mockProviderConfig() ProviderConfig {
 	return ProviderConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		RedirectURL:  "http://localhost/callback",
+		RedirectURI:  "http://localhost/callback",
 	}
 }
 
@@ -110,7 +110,7 @@ func TestFullFlowTikTokLike(t *testing.T) {
 		ProviderConfig: ProviderConfig{
 			ClientID:     "tk-key",
 			ClientSecret: "tk-secret",
-			RedirectURL:  "http://test/callback",
+			RedirectURI:  "http://test/callback",
 			Scopes:       []string{"user.info.basic", "video.list"},
 		},
 		ProviderName:       "tiktok-mock",

--- a/auth/oidc/providers/provider_test.go
+++ b/auth/oidc/providers/provider_test.go
@@ -40,7 +40,7 @@ func TestClientSecretFunc(t *testing.T) {
 		ProviderConfig: ProviderConfig{
 			ClientID:     "apple-client",
 			ClientSecret: "static-secret-should-be-overridden",
-			RedirectURL:  "http://test",
+			RedirectURI:  "http://test",
 		},
 		ProviderName:  "apple-like",
 		TokenEndpoint: srv.TokenURL(),

--- a/auth/oidc/providers/userinfo_test.go
+++ b/auth/oidc/providers/userinfo_test.go
@@ -100,7 +100,7 @@ func TestUserInfoNeverSendsTokenInQueryString(t *testing.T) {
 	defer server.Close()
 
 	p := NewGeneric(GenericConfig{
-		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURL: "http://test"},
+		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURI: "http://test"},
 		ProviderName:     "placeholder-test",
 		UserInfoEndpoint: server.URL + "/me?access_token={access_token}",
 		UserInfo:         UserInfoMapper{SubjectKey: "id"},
@@ -250,7 +250,7 @@ func TestResponsePath(t *testing.T) {
 	defer server.Close()
 
 	p := NewGeneric(GenericConfig{
-		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURL: "http://test"},
+		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURI: "http://test"},
 		ProviderName:     "nested-test",
 		UserInfoEndpoint: server.URL + "/userinfo",
 		UserInfo: UserInfoMapper{
@@ -284,7 +284,7 @@ func TestNumericSubjectFallback(t *testing.T) {
 	defer server.Close()
 
 	p := NewGeneric(GenericConfig{
-		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURL: "http://test"},
+		ProviderConfig:   ProviderConfig{ClientID: "id", RedirectURI: "http://test"},
 		ProviderName:     "num-id",
 		UserInfoEndpoint: server.URL + "/user",
 		UserInfo:         UserInfoMapper{SubjectKey: "id", NameKey: "name"},

--- a/auth/oidc/security_policy_test.go
+++ b/auth/oidc/security_policy_test.go
@@ -80,7 +80,7 @@ func TestConfig_Validate_PublicClientRequiresNoSecret(t *testing.T) {
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		PublicClient: true,
-		RedirectURL:  "https://app.example.com/callback",
+		RedirectURI:  "https://app.example.com/callback",
 	}
 	cfg.ApplyDefaults()
 	if err := cfg.Validate(); err == nil {
@@ -148,7 +148,7 @@ func TestConfig_Validate_RejectsWildcardRedirectURI(t *testing.T) {
 		Enabled:     true,
 		Issuer:      "https://issuer.example.com",
 		ClientID:    "client-id",
-		RedirectURL: "https://*.example.com/callback",
+		RedirectURI: "https://*.example.com/callback",
 	}
 	cfg.ApplyDefaults()
 	err := cfg.Validate()

--- a/auth/oidc/testutil/doc.go
+++ b/auth/oidc/testutil/doc.go
@@ -13,7 +13,7 @@
 //	        ProviderConfig: providers.ProviderConfig{
 //	            ClientID:     "test-client",
 //	            ClientSecret: "test-secret",
-//	            RedirectURL:  "http://localhost/callback",
+//	            RedirectURI:  "http://localhost/callback",
 //	        },
 //	        ProviderName:     "test",
 //	        AuthEndpoint:     srv.AuthURL(),

--- a/authz/boundary.go
+++ b/authz/boundary.go
@@ -1,0 +1,147 @@
+package authz
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecisionKind enumerates the transport-agnostic authorization outcomes exchanged
+// across service boundaries.
+type DecisionKind uint8
+
+const (
+	// DecisionInvalid is the zero value and never permits a request, so an
+	// uninitialized BoundaryDecision fails closed.
+	DecisionInvalid DecisionKind = iota
+	// DecisionAllow permits the request.
+	DecisionAllow
+	// DecisionDeny refuses the request with a reason.
+	DecisionDeny
+	// DecisionRequiresHumanApproval defers the request to a human approver with a reason.
+	DecisionRequiresHumanApproval
+)
+
+// String implements fmt.Stringer.
+func (k DecisionKind) String() string {
+	switch k {
+	case DecisionAllow:
+		return "Allow"
+	case DecisionDeny:
+		return "Deny"
+	case DecisionRequiresHumanApproval:
+		return "RequiresHumanApproval"
+	default:
+		return "Invalid"
+	}
+}
+
+// BoundaryDecision is a transport-agnostic authorization decision exchanged across
+// service boundaries. It serializes as a tagged union: Allow encodes as the string
+// "Allow"; Deny and RequiresHumanApproval encode as a single-key object carrying the
+// reason, e.g. {"Deny":"not an owner"}.
+type BoundaryDecision struct {
+	kind   DecisionKind
+	reason string
+}
+
+// Allow returns an allow decision.
+func Allow() BoundaryDecision { return BoundaryDecision{kind: DecisionAllow} }
+
+// Deny returns a deny decision carrying the given reason.
+func Deny(reason string) BoundaryDecision {
+	return BoundaryDecision{kind: DecisionDeny, reason: reason}
+}
+
+// RequiresHumanApproval returns a decision that defers to a human approver with the given reason.
+func RequiresHumanApproval(reason string) BoundaryDecision {
+	return BoundaryDecision{kind: DecisionRequiresHumanApproval, reason: reason}
+}
+
+// Kind reports which outcome this decision carries.
+func (d BoundaryDecision) Kind() DecisionKind { return d.kind }
+
+// Allowed reports whether the decision permits the request.
+func (d BoundaryDecision) Allowed() bool { return d.kind == DecisionAllow }
+
+// Reason returns the explanation for a Deny or RequiresHumanApproval decision, or "" for Allow.
+func (d BoundaryDecision) Reason() string { return d.reason }
+
+// MarshalJSON implements the tagged-union wire shape.
+func (d BoundaryDecision) MarshalJSON() ([]byte, error) {
+	switch d.kind {
+	case DecisionAllow:
+		return []byte(`"Allow"`), nil
+	case DecisionDeny:
+		return json.Marshal(map[string]string{"Deny": d.reason})
+	case DecisionRequiresHumanApproval:
+		return json.Marshal(map[string]string{"RequiresHumanApproval": d.reason})
+	default:
+		return nil, fmt.Errorf("authz: invalid boundary decision kind %d", d.kind)
+	}
+}
+
+// UnmarshalJSON decodes the tagged-union wire shape.
+func (d *BoundaryDecision) UnmarshalJSON(data []byte) error {
+	var unit string
+	if err := json.Unmarshal(data, &unit); err == nil {
+		if unit != "Allow" {
+			return fmt.Errorf("authz: unknown boundary decision %q", unit)
+		}
+		*d = Allow()
+		return nil
+	}
+
+	var obj map[string]string
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("authz: decode boundary decision: %w", err)
+	}
+	if len(obj) != 1 {
+		return fmt.Errorf("authz: boundary decision must carry exactly one variant, got %d", len(obj))
+	}
+	for variant, reason := range obj {
+		switch variant {
+		case "Deny":
+			*d = Deny(reason)
+		case "RequiresHumanApproval":
+			*d = RequiresHumanApproval(reason)
+		default:
+			return fmt.Errorf("authz: unknown boundary decision variant %q", variant)
+		}
+	}
+	return nil
+}
+
+// Boundary converts an engine Decision into its transport-agnostic form. An allowed
+// decision maps to Allow; otherwise it maps to Deny carrying the decision reason.
+func (d Decision) Boundary() BoundaryDecision {
+	if d.Allowed {
+		return Allow()
+	}
+	return Deny(d.Reason)
+}
+
+// BoundaryRequest is the transport-agnostic authorization request exchanged across
+// service boundaries. Attributes is an opaque JSON document (the documented opaque
+// exception) carrying structured request context.
+type BoundaryRequest struct {
+	// Principal identifies the caller being authorized.
+	Principal string `json:"principal"`
+	// Action is the operation being attempted.
+	Action string `json:"action"`
+	// Resource identifies the target being accessed.
+	Resource string `json:"resource"`
+	// Scopes are the scopes relevant to the request. It always serializes as an array.
+	Scopes []string `json:"scopes"`
+	// Attributes carries additional structured attributes. It serializes as null when absent.
+	Attributes json.RawMessage `json:"attributes"`
+}
+
+// MarshalJSON normalizes an absent Scopes slice to an empty array for a stable wire shape.
+func (r BoundaryRequest) MarshalJSON() ([]byte, error) {
+	type wire BoundaryRequest
+	w := wire(r)
+	if w.Scopes == nil {
+		w.Scopes = []string{}
+	}
+	return json.Marshal(w)
+}

--- a/authz/boundary_test.go
+++ b/authz/boundary_test.go
@@ -1,0 +1,131 @@
+package authz
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBoundaryDecisionMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		decision BoundaryDecision
+		want     string
+	}{
+		"allow":                   {Allow(), `"Allow"`},
+		"deny":                    {Deny("not an owner"), `{"Deny":"not an owner"}`},
+		"requires_human_approval": {RequiresHumanApproval("destructive action"), `{"RequiresHumanApproval":"destructive action"}`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			data, err := json.Marshal(tc.decision)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if got := string(data); got != tc.want {
+				t.Fatalf("JSON = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBoundaryDecisionUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		wire       string
+		wantKind   DecisionKind
+		wantReason string
+	}{
+		"allow":                   {`"Allow"`, DecisionAllow, ""},
+		"deny":                    {`{"Deny":"nope"}`, DecisionDeny, "nope"},
+		"requires_human_approval": {`{"RequiresHumanApproval":"review"}`, DecisionRequiresHumanApproval, "review"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var d BoundaryDecision
+			if err := json.Unmarshal([]byte(tc.wire), &d); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if d.Kind() != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", d.Kind(), tc.wantKind)
+			}
+			if d.Reason() != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", d.Reason(), tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestBoundaryDecisionUnmarshalRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, wire := range []string{`"Nope"`, `{"Deny":"a","Extra":"b"}`, `{"Bogus":"x"}`, `{}`, `42`} {
+		var d BoundaryDecision
+		if err := json.Unmarshal([]byte(wire), &d); err == nil {
+			t.Errorf("expected error decoding %s", wire)
+		}
+	}
+}
+
+func TestDecisionToBoundary(t *testing.T) {
+	t.Parallel()
+
+	if got := (Decision{Allowed: true, Reason: "ok"}).Boundary(); got.Kind() != DecisionAllow {
+		t.Errorf("allowed decision -> %v, want DecisionAllow", got.Kind())
+	}
+	denied := (Decision{Allowed: false, Reason: "default deny"}).Boundary()
+	if denied.Kind() != DecisionDeny || denied.Reason() != "default deny" {
+		t.Errorf("denied decision -> %v/%q, want DecisionDeny/default deny", denied.Kind(), denied.Reason())
+	}
+}
+
+func TestBoundaryDecisionZeroValueFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var d BoundaryDecision
+	if d.Kind() != DecisionInvalid {
+		t.Errorf("zero-value Kind = %v, want DecisionInvalid", d.Kind())
+	}
+	if d.Allowed() {
+		t.Error("zero-value BoundaryDecision must not be Allowed")
+	}
+	if _, err := json.Marshal(d); err == nil {
+		t.Error("marshaling an invalid BoundaryDecision must error, not emit a permissive shape")
+	}
+}
+
+func TestBoundaryRequestJSONShape(t *testing.T) {
+	t.Parallel()
+
+	req := BoundaryRequest{
+		Principal:  "user:1",
+		Action:     ActionToolInvoke,
+		Resource:   "tool:deploy",
+		Scopes:     []string{"read", "write"},
+		Attributes: json.RawMessage(`{"env":"prod"}`),
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"principal":"user:1","action":"tool:invoke","resource":"tool:deploy","scopes":["read","write"],"attributes":{"env":"prod"}}`
+	if got := string(data); got != want {
+		t.Fatalf("JSON = %s, want %s", got, want)
+	}
+}
+
+func TestBoundaryRequestEmptyEncodesStableShape(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(BoundaryRequest{Principal: "p", Action: "a", Resource: "r"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"principal":"p","action":"a","resource":"r","scopes":[],"attributes":null}`
+	if got := string(data); got != want {
+		t.Fatalf("JSON = %s, want %s", got, want)
+	}
+}

--- a/authz/engine.go
+++ b/authz/engine.go
@@ -10,30 +10,30 @@ type Attributes map[string]string
 
 // Subject is the caller being authorized.
 type Subject struct {
-	ID         string
-	Roles      []string
-	Attributes Attributes
+	ID         string     `json:"id"`
+	Roles      []string   `json:"roles"`
+	Attributes Attributes `json:"attributes"`
 }
 
 // Resource is the target being accessed.
 type Resource struct {
-	Type       string
-	ID         string
-	Attributes Attributes
+	Type       string     `json:"resource_type"`
+	ID         string     `json:"id"`
+	Attributes Attributes `json:"attributes"`
 }
 
 // Request is the canonical authorization input.
 type Request struct {
-	Subject  Subject
-	Resource Resource
-	Action   string
-	Context  Attributes
+	Subject  Subject    `json:"subject"`
+	Resource Resource   `json:"resource"`
+	Action   string     `json:"action"`
+	Context  Attributes `json:"context"`
 }
 
 // Permission is an RBAC grant with wildcard-capable resource/action matching.
 type Permission struct {
-	Resource string
-	Action   string
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
 }
 
 // Matches reports whether the permission covers the requested resource/action.
@@ -43,9 +43,9 @@ func (p Permission) Matches(resource, action string) bool {
 
 // Role defines an RBAC role and any inherited parent roles.
 type Role struct {
-	Name        string
-	Inherits    []string
-	Permissions []Permission
+	Name        string       `json:"name"`
+	Inherits    []string     `json:"inherits"`
+	Permissions []Permission `json:"permissions"`
 }
 
 // Effect determines the result of a policy match.
@@ -76,27 +76,27 @@ const (
 
 // Condition compares a source attribute against literal values or another attribute.
 type Condition struct {
-	Source        AttributeSource
-	Key           string
-	Operator      Operator
-	Values        []string
-	CompareSource AttributeSource
-	CompareKey    string
+	Source        AttributeSource `json:"source"`
+	Key           string          `json:"key"`
+	Operator      Operator        `json:"operator"`
+	Values        []string        `json:"values"`
+	CompareSource AttributeSource `json:"compare_source,omitempty"`
+	CompareKey    string          `json:"compare_key,omitempty"`
 }
 
 // Policy is an ABAC rule evaluated alongside RBAC grants.
 type Policy struct {
-	Name       string
-	Effect     Effect
-	Actions    []string
-	Resources  []string
-	Conditions []Condition
+	Name       string      `json:"name"`
+	Effect     Effect      `json:"effect"`
+	Actions    []string    `json:"actions"`
+	Resources  []string    `json:"resources"`
+	Conditions []Condition `json:"conditions"`
 }
 
 // Decision is the authorization result.
 type Decision struct {
-	Allowed bool
-	Reason  string
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason"`
 }
 
 // Engine evaluates RBAC role grants and ABAC policies with explicit default-deny semantics.

--- a/bench/storage/provider_test.go
+++ b/bench/storage/provider_test.go
@@ -68,6 +68,33 @@ func (f *fakeStorage) URL(_ context.Context, path string) (string, error) {
 	return "mem://" + path, nil
 }
 
+func (f *fakeStorage) Head(_ context.Context, path string) (gostorage.FileInfo, error) {
+	data, ok := f.objects[path]
+	if !ok {
+		return gostorage.FileInfo{}, errors.New("not found: " + path)
+	}
+	return gostorage.FileInfo{Path: path, Size: int64(len(data))}, nil
+}
+
+func (f *fakeStorage) Copy(_ context.Context, srcPath, dstPath string) error {
+	data, ok := f.objects[srcPath]
+	if !ok {
+		return errors.New("not found: " + srcPath)
+	}
+	f.objects[dstPath] = bytes.Clone(data)
+	return nil
+}
+
+func (f *fakeStorage) Rename(_ context.Context, srcPath, dstPath string) error {
+	data, ok := f.objects[srcPath]
+	if !ok {
+		return errors.New("not found: " + srcPath)
+	}
+	f.objects[dstPath] = data
+	delete(f.objects, srcPath)
+	return nil
+}
+
 func (f *fakeStorage) List(_ context.Context, prefix string) ([]gostorage.FileInfo, error) {
 	if f.failList {
 		return nil, errors.New("list failed")

--- a/cache/bytes_test.go
+++ b/cache/bytes_test.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+// nonUTF8Payload is deliberately invalid UTF-8 and includes NUL and high bytes to
+// prove the cache stores raw bytes rather than text.
+var nonUTF8Payload = []byte{0x00, 0xff, 0xfe, 0x80, 0x01, 'g', 'o', 0xc0, 0xc1}
+
+func TestMemoryStoreRoundTripsNonUTF8Bytes(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(MemoryConfig{})
+	ctx := context.Background()
+
+	if err := store.Set(ctx, "raw", nonUTF8Payload, 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "raw")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: entry missing")
+	}
+	if !bytes.Equal(got, nonUTF8Payload) {
+		t.Fatalf("Get = %v, want %v", got, nonUTF8Payload)
+	}
+}
+
+func TestFileStoreRoundTripsNonUTF8Bytes(t *testing.T) {
+	t.Parallel()
+
+	store := newTestFileStore(t, FileConfig{}, time.Unix(100, 0))
+	ctx := context.Background()
+
+	if err := store.Set(ctx, "raw", nonUTF8Payload, 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "raw")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: entry missing")
+	}
+	if !bytes.Equal(got, nonUTF8Payload) {
+		t.Fatalf("Get = %v, want %v", got, nonUTF8Payload)
+	}
+}

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -45,7 +45,7 @@ func main() {
 
 	// Consume messages
 	go consumer.Consume(ctx, func(ctx context.Context, msg messaging.Message) error {
-		fmt.Printf("Received: %s\n", msg.Value)
+		fmt.Printf("Received: %s\n", msg.Payload)
 		return nil
 	})
 }
@@ -57,7 +57,7 @@ func main() {
 
 | Type | Description |
 |------|-------------|
-| `Message` | Low-level broker message with key, value, topic, partition, offset, headers |
+| `Message` | Low-level broker message with key, payload, topic, partition, offset, headers |
 | `NewMessage` | Broker-neutral constructor for low-level messages with non-nil headers |
 | `Event` | Structured domain event with ID, type, source, timestamp, and JSON data |
 | `Producer` | Interface with `Publish`, `PublishJSON`, and `PublishBinary` methods |
@@ -176,7 +176,7 @@ consumer := broker.Consumer("my-topic")
 // Publish and assert
 _ = producer.PublishBinary(ctx, "my-topic", "key", []byte("hello"))
 memory.AssertPublished(t, broker, "my-topic", func(msg messaging.Message) bool {
-	return string(msg.Value) == "hello"
+	return string(msg.Payload) == "hello"
 })
 ```
 

--- a/messaging/batch.go
+++ b/messaging/batch.go
@@ -61,7 +61,7 @@ func (b *BatchProducer) Send(ctx context.Context, msg Message) error {
 	}
 
 	b.buf = append(b.buf, msg)
-	b.bufBytes += int64(len(msg.Value))
+	b.bufBytes += int64(len(msg.Payload))
 
 	needsFlush := len(b.buf) >= b.cfg.MaxSize ||
 		(b.cfg.MaxBytes > 0 && b.bufBytes >= b.cfg.MaxBytes)
@@ -129,7 +129,7 @@ func (b *BatchProducer) timerFlush() {
 // publishBatch sends each message in the batch via the underlying Producer.
 func (b *BatchProducer) publishBatch(ctx context.Context, batch []Message) error {
 	for _, msg := range batch {
-		if err := b.producer.PublishBinary(ctx, b.topic, msg.Key, msg.Value); err != nil {
+		if err := b.producer.PublishBinary(ctx, b.topic, msg.Key, msg.Payload); err != nil {
 			return err
 		}
 	}

--- a/messaging/batch_test.go
+++ b/messaging/batch_test.go
@@ -30,12 +30,12 @@ func (p *stubProducer) PublishBinary(_ context.Context, topic, key string, data 
 	if p.err != nil {
 		return p.err
 	}
-	p.messages = append(p.messages, Message{Topic: topic, Key: key, Value: data})
+	p.messages = append(p.messages, Message{Topic: topic, Key: key, Payload: data})
 	return nil
 }
 
 func (p *stubProducer) Send(ctx context.Context, msg Message) error {
-	return p.PublishBinary(ctx, msg.Topic, msg.Key, msg.Value)
+	return p.PublishBinary(ctx, msg.Topic, msg.Key, msg.Payload)
 }
 
 func (p *stubProducer) SendBatch(ctx context.Context, messages []Message) error {
@@ -66,7 +66,7 @@ func TestBatchProducer_SizeTriggeredFlush(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < 3; i++ {
-		if err := bp.Send(ctx, Message{Key: "k", Value: []byte("v")}); err != nil {
+		if err := bp.Send(ctx, Message{Key: "k", Payload: []byte("v")}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -87,7 +87,7 @@ func TestBatchProducer_TimeTriggeredFlush(t *testing.T) {
 	defer bp.Close(context.Background())
 
 	ctx := context.Background()
-	if err := bp.Send(ctx, Message{Key: "k", Value: []byte("v")}); err != nil {
+	if err := bp.Send(ctx, Message{Key: "k", Payload: []byte("v")}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -113,7 +113,7 @@ func TestBatchProducer_ByteTriggeredFlush(t *testing.T) {
 	ctx := context.Background()
 	// 6 bytes each → second message should trigger flush at 12 bytes ≥ 10.
 	for i := 0; i < 2; i++ {
-		if err := bp.Send(ctx, Message{Key: "k", Value: []byte("123456")}); err != nil {
+		if err := bp.Send(ctx, Message{Key: "k", Payload: []byte("123456")}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -134,7 +134,7 @@ func TestBatchProducer_CloseFlushesRemaining(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
-		if err := bp.Send(ctx, Message{Key: "k", Value: []byte("v")}); err != nil {
+		if err := bp.Send(ctx, Message{Key: "k", Payload: []byte("v")}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -163,7 +163,7 @@ func TestBatchProducer_FlushExplicit(t *testing.T) {
 	defer bp.Close(context.Background())
 
 	ctx := context.Background()
-	_ = bp.Send(ctx, Message{Key: "k", Value: []byte("v")})
+	_ = bp.Send(ctx, Message{Key: "k", Payload: []byte("v")})
 
 	if err := bp.Flush(ctx); err != nil {
 		t.Fatal(err)
@@ -189,7 +189,7 @@ func TestBatchProducer_ConcurrentSend(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			if err := bp.Send(context.Background(), Message{Key: "k", Value: []byte("v")}); err != nil {
+			if err := bp.Send(context.Background(), Message{Key: "k", Payload: []byte("v")}); err != nil {
 				sendErr.Store(err)
 			}
 		}()
@@ -215,7 +215,7 @@ func TestBatchProducer_SendAfterCloseReturnsError(t *testing.T) {
 	bp := NewBatchProducer(sp, "topic", BatchConfig{MaxSize: 10, MaxWait: time.Hour})
 	_ = bp.Close(context.Background())
 
-	err := bp.Send(context.Background(), Message{Key: "k", Value: []byte("v")})
+	err := bp.Send(context.Background(), Message{Key: "k", Payload: []byte("v")})
 	if err == nil {
 		t.Error("expected error after Close, got nil")
 	}
@@ -229,7 +229,7 @@ func TestBatchProducer_ProducerErrorPropagated(t *testing.T) {
 	bp := NewBatchProducer(sp, "topic", BatchConfig{MaxSize: 1, MaxWait: time.Hour})
 	defer bp.Close(context.Background())
 
-	err := bp.Send(context.Background(), Message{Key: "k", Value: []byte("v")})
+	err := bp.Send(context.Background(), Message{Key: "k", Payload: []byte("v")})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("error = %v, want %v", err, sentinel)
 	}

--- a/messaging/bridge/provider_test.go
+++ b/messaging/bridge/provider_test.go
@@ -23,16 +23,16 @@ func TestProducerAsSink(t *testing.T) {
 			name:  "simple message",
 			topic: "orders",
 			msg: messaging.Message{
-				Key:   "k1",
-				Value: []byte("hello"),
+				Key:     "k1",
+				Payload: []byte("hello"),
 			},
 		},
 		{
 			name:  "empty value",
 			topic: "events",
 			msg: messaging.Message{
-				Key:   "k2",
-				Value: nil,
+				Key:     "k2",
+				Payload: nil,
 			},
 		},
 	}
@@ -62,8 +62,8 @@ func TestProducerAsSink(t *testing.T) {
 			if len(msgs) != 1 {
 				t.Fatalf("expected 1 message on topic %q, got %d", tt.topic, len(msgs))
 			}
-			if !bytes.Equal(msgs[0].Value, tt.msg.Value) {
-				t.Errorf("value = %q, want %q", msgs[0].Value, tt.msg.Value)
+			if !bytes.Equal(msgs[0].Payload, tt.msg.Payload) {
+				t.Errorf("value = %q, want %q", msgs[0].Payload, tt.msg.Payload)
 			}
 		})
 	}
@@ -139,8 +139,8 @@ func TestConsumerAsStream(t *testing.T) {
 		if !ok {
 			t.Fatal("Next() returned ok=false, want true")
 		}
-		if len(msg.Value) != 1 || msg.Value[0] != byte(i) {
-			t.Errorf("message %d value = %v, want [%d]", i, msg.Value, i)
+		if len(msg.Payload) != 1 || msg.Payload[0] != byte(i) {
+			t.Errorf("message %d value = %v, want [%d]", i, msg.Payload, i)
 		}
 	}
 }

--- a/messaging/kafka/consumer/consumer_test.go
+++ b/messaging/kafka/consumer/consumer_test.go
@@ -86,8 +86,8 @@ func TestConsumerDeliversMessageAndLogsRecovery(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Consume = %v, want context.Canceled", err)
 	}
-	if string(got.Value) != "payload" {
-		t.Fatalf("delivered value = %q", got.Value)
+	if string(got.Payload) != "payload" {
+		t.Fatalf("delivered value = %q", got.Payload)
 	}
 	if c.errCount.Load() != 0 {
 		t.Fatalf("errCount = %d, want reset to 0 after recovery", c.errCount.Load())

--- a/messaging/kafka/consumer/start.go
+++ b/messaging/kafka/consumer/start.go
@@ -41,7 +41,7 @@ func StartConsumer(ctx context.Context, cfg StartConsumerConfig) (*ManagedConsum
 		Config: cfg.Config,
 		Topic:  cfg.Topic,
 		Handler: func(ctx context.Context, msg messaging.Message) error {
-			return cfg.Handler(ctx, msg.Value)
+			return cfg.Handler(ctx, msg.Payload)
 		},
 		Log: cfg.Log,
 	})

--- a/messaging/kafka/convert.go
+++ b/messaging/kafka/convert.go
@@ -14,7 +14,7 @@ func FromKafkaMessage(msg kafkago.Message) messaging.Message {
 	}
 	return messaging.Message{
 		Key:       string(msg.Key),
-		Value:     msg.Value,
+		Payload:   msg.Value,
 		Topic:     msg.Topic,
 		Partition: msg.Partition,
 		Offset:    msg.Offset,
@@ -31,7 +31,7 @@ func ToKafkaMessage(m messaging.Message) kafkago.Message {
 	}
 	return kafkago.Message{
 		Key:       []byte(m.Key),
-		Value:     m.Value,
+		Value:     m.Payload,
 		Topic:     m.Topic,
 		Partition: m.Partition,
 		Offset:    m.Offset,

--- a/messaging/kafka/convert_test.go
+++ b/messaging/kafka/convert_test.go
@@ -28,8 +28,8 @@ func TestFromKafkaMessage(t *testing.T) {
 	if msg.Key != "key1" {
 		t.Errorf("Key = %q, want key1", msg.Key)
 	}
-	if string(msg.Value) != `{"hello":"world"}` {
-		t.Errorf("Value = %q", string(msg.Value))
+	if string(msg.Payload) != `{"hello":"world"}` {
+		t.Errorf("Payload = %q", string(msg.Payload))
 	}
 	if msg.Topic != "test-topic" {
 		t.Errorf("Topic = %q", msg.Topic)

--- a/messaging/kafka/producer/producer_test.go
+++ b/messaging/kafka/producer/producer_test.go
@@ -120,10 +120,10 @@ func TestProducerConvenienceMethodsRouteThroughWriter(t *testing.T) {
 	p := newTestProducer(w, 1, 0)
 	ctx := context.Background()
 
-	if err := p.Send(ctx, messaging.Message{Topic: "orders", Key: "k", Value: []byte("send")}); err != nil {
+	if err := p.Send(ctx, messaging.Message{Topic: "orders", Key: "k", Payload: []byte("send")}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	if err := p.SendBatch(ctx, []messaging.Message{{Topic: "orders", Value: []byte("a")}, {Topic: "orders", Value: []byte("b")}}); err != nil {
+	if err := p.SendBatch(ctx, []messaging.Message{{Topic: "orders", Payload: []byte("a")}, {Topic: "orders", Payload: []byte("b")}}); err != nil {
 		t.Fatalf("SendBatch: %v", err)
 	}
 	if err := p.PublishJSON(ctx, "orders", "jk", map[string]string{"id": "1"}); err != nil {

--- a/messaging/kafka/testutil/component_test.go
+++ b/messaging/kafka/testutil/component_test.go
@@ -49,7 +49,7 @@ func TestMockProducer_WriteAndRead(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("Messages() = %d, want 2", len(msgs))
 	}
-	if msgs[0].Topic != "topic-1" || string(msgs[0].Value) != "value" {
+	if msgs[0].Topic != "topic-1" || string(msgs[0].Payload) != "value" {
 		t.Errorf("msg[0] = %+v, unexpected", msgs[0])
 	}
 
@@ -135,7 +135,7 @@ func TestMockProducer_Publish_WithExplicitKey(t *testing.T) {
 
 func TestMockProducer_Send(t *testing.T) {
 	p := &MockProducer{}
-	msg := messaging.Message{Topic: "send-topic", Key: "k1", Value: []byte("v1")}
+	msg := messaging.Message{Topic: "send-topic", Key: "k1", Payload: []byte("v1")}
 	if err := p.Send(context.Background(), msg); err != nil {
 		t.Fatalf("Send() error: %v", err)
 	}
@@ -205,8 +205,8 @@ func TestMockConsumer_FeedAndProcess(t *testing.T) {
 		close(done)
 	}()
 
-	mc.Feed(Message{Topic: "events", Value: []byte("hello")})
-	mc.Feed(Message{Topic: "events", Value: []byte("world")})
+	mc.Feed(Message{Topic: "events", Payload: []byte("hello")})
+	mc.Feed(Message{Topic: "events", Payload: []byte("world")})
 
 	// Give consumer time to process
 	cancel()

--- a/messaging/kafka/testutil/doc.go
+++ b/messaging/kafka/testutil/doc.go
@@ -12,5 +12,5 @@
 //	kfk.MockProducerClient().Messages() // returns all produced messages
 //
 //	// Access mock consumer that can be fed messages
-//	kfk.MockConsumerClient("my-topic").Feed(Message{Value: []byte("hello")})
+//	kfk.MockConsumerClient("my-topic").Feed(Message{Payload: []byte("hello")})
 package testutil

--- a/messaging/managed_producer_test.go
+++ b/messaging/managed_producer_test.go
@@ -157,7 +157,7 @@ func TestManagedProducer_SendBeforeStartErrors(t *testing.T) {
 
 	p := &recordingProducer{}
 	mp := newTestManagedProducer(p, nil)
-	err := mp.Send(context.Background(), Message{Topic: "t", Value: []byte("v")})
+	err := mp.Send(context.Background(), Message{Topic: "t", Payload: []byte("v")})
 	if err == nil {
 		t.Fatal("Send before Start did not error")
 	}
@@ -176,7 +176,7 @@ func TestManagedProducer_SendAfterStartDelegatesAndRecordsMetrics(t *testing.T) 
 	if err := mp.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	if err := mp.Send(ctx, Message{Topic: "t", Value: []byte("v")}); err != nil {
+	if err := mp.Send(ctx, Message{Topic: "t", Payload: []byte("v")}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if p.sentCount() != 1 {

--- a/messaging/memory/broker_test.go
+++ b/messaging/memory/broker_test.go
@@ -55,8 +55,8 @@ func TestBroker_ProduceConsume(t *testing.T) {
 	if len(received) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(received))
 	}
-	if string(received[0].Value) != "hello" {
-		t.Errorf("msg[0].Value = %q, want hello", string(received[0].Value))
+	if string(received[0].Payload) != "hello" {
+		t.Errorf("msg[0].Payload = %q, want hello", string(received[0].Payload))
 	}
 	if received[0].Key != "k1" {
 		t.Errorf("msg[0].Key = %q, want k1", received[0].Key)
@@ -102,7 +102,7 @@ func TestBroker_PublishJSON(t *testing.T) {
 		t.Errorf("content-type = %q", received.Headers["content-type"])
 	}
 	var parsed map[string]string
-	if err := json.Unmarshal(received.Value, &parsed); err != nil {
+	if err := json.Unmarshal(received.Payload, &parsed); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if parsed["name"] != "Alice" {
@@ -255,8 +255,8 @@ func TestBroker_Messages(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("Messages(t1) = %d, want 2", len(msgs))
 	}
-	if string(msgs[0].Value) != "a" || string(msgs[1].Value) != "b" {
-		t.Errorf("unexpected values: %q, %q", msgs[0].Value, msgs[1].Value)
+	if string(msgs[0].Payload) != "a" || string(msgs[1].Payload) != "b" {
+		t.Errorf("unexpected values: %q, %q", msgs[0].Payload, msgs[1].Payload)
 	}
 
 	all := broker.AllMessages()
@@ -333,7 +333,7 @@ func TestAssertPublished(t *testing.T) {
 	_ = producer.PublishBinary(context.Background(), "t1", "k2", []byte("world"))
 
 	AssertPublished(t, broker, "t1", func(m messaging.Message) bool {
-		return string(m.Value) == "world"
+		return string(m.Payload) == "world"
 	})
 }
 
@@ -365,8 +365,8 @@ func TestWaitForMessage(t *testing.T) {
 	}()
 
 	msg := WaitForMessage(t, broker, "t1", 2*time.Second)
-	if string(msg.Value) != "delayed" {
-		t.Errorf("WaitForMessage value = %q, want delayed", msg.Value)
+	if string(msg.Payload) != "delayed" {
+		t.Errorf("WaitForMessage value = %q, want delayed", msg.Payload)
 	}
 }
 
@@ -456,8 +456,8 @@ func TestBroker_SendBatch(t *testing.T) {
 
 	producer := broker.Producer()
 	msgs := []messaging.Message{
-		{Topic: "batch", Key: "k1", Value: []byte("a")},
-		{Topic: "batch", Key: "k2", Value: []byte("b")},
+		{Topic: "batch", Key: "k1", Payload: []byte("a")},
+		{Topic: "batch", Key: "k2", Payload: []byte("b")},
 	}
 	if err := producer.SendBatch(context.Background(), msgs); err != nil {
 		t.Fatalf("SendBatch() error: %v", err)

--- a/messaging/memory/producer.go
+++ b/messaging/memory/producer.go
@@ -65,7 +65,7 @@ func (p *InMemoryProducer) Publish(_ context.Context, topic string, event messag
 	}
 	msg := messaging.Message{
 		Key:       partitionKey,
-		Value:     data,
+		Payload:   data,
 		Topic:     topic,
 		Timestamp: event.Timestamp,
 		Headers: map[string]string{
@@ -93,7 +93,7 @@ func (p *InMemoryProducer) PublishJSON(_ context.Context, topic, key string, val
 	}
 	msg := messaging.Message{
 		Key:       key,
-		Value:     data,
+		Payload:   data,
 		Topic:     topic,
 		Timestamp: time.Now().UTC(),
 		Headers:   map[string]string{"content-type": "application/json"},
@@ -112,7 +112,7 @@ func (p *InMemoryProducer) PublishBinary(_ context.Context, topic, key string, d
 
 	msg := messaging.Message{
 		Key:       key,
-		Value:     data,
+		Payload:   data,
 		Topic:     topic,
 		Timestamp: time.Now().UTC(),
 		Headers:   map[string]string{"content-type": "application/octet-stream"},

--- a/messaging/middleware/deadletter.go
+++ b/messaging/middleware/deadletter.go
@@ -68,7 +68,7 @@ func (d *DeadLetterProducer) Send(ctx context.Context, msg messaging.Message, or
 		RetryCount:    retryCount,
 		Timestamp:     time.Now().UTC(),
 		Headers:       redactHeaders(msg.Headers),
-		Payload:       summarizePayloadBytes(msg.Value),
+		Payload:       summarizePayloadBytes(msg.Payload),
 	}
 
 	dlqTopic := msg.Topic + d.suffix

--- a/messaging/middleware/deadletter_test.go
+++ b/messaging/middleware/deadletter_test.go
@@ -34,7 +34,7 @@ func (m *mockPublisher) PublishBinary(_ context.Context, _, _ string, _ []byte) 
 }
 
 func (m *mockPublisher) Send(ctx context.Context, msg messaging.Message) error {
-	return m.PublishBinary(ctx, msg.Topic, msg.Key, msg.Value)
+	return m.PublishBinary(ctx, msg.Topic, msg.Key, msg.Payload)
 }
 
 func (m *mockPublisher) SendBatch(ctx context.Context, messages []messaging.Message) error {
@@ -69,7 +69,7 @@ func TestDeadLetterProducer_Send(t *testing.T) {
 	msg := messaging.Message{
 		Topic:   "orders",
 		Key:     "order-123",
-		Value:   []byte(`{"id":"order-123"}`),
+		Payload: []byte(`{"id":"order-123"}`),
 		Headers: map[string]string{"x-retry-count": "3", "content-type": "application/json"},
 	}
 
@@ -118,7 +118,7 @@ func TestDeadLetterProducer_Send_EmptyKey(t *testing.T) {
 	msg := messaging.Message{
 		Topic:   "events",
 		Key:     "",
-		Value:   []byte("data"),
+		Payload: []byte("data"),
 		Headers: map[string]string{},
 	}
 
@@ -134,7 +134,7 @@ func TestDeadLetterProducer_Send_NoRetryCountHeader(t *testing.T) {
 
 	msg := messaging.Message{
 		Topic:   "events",
-		Value:   []byte("data"),
+		Payload: []byte("data"),
 		Headers: map[string]string{},
 	}
 
@@ -178,8 +178,8 @@ func TestDeadLetterProducer_Send_RedactsSensitiveFields(t *testing.T) {
 	d := NewDeadLetterProducer(pub)
 
 	msg := messaging.Message{
-		Topic: "orders",
-		Value: []byte("password=secret"),
+		Topic:   "orders",
+		Payload: []byte("password=secret"),
 		Headers: map[string]string{
 			"authorization": "Bearer secret",
 			"trace-id":      "abc",
@@ -220,7 +220,7 @@ func TestDeadLetterProducer_Send_TruncatesPayload(t *testing.T) {
 	pub := &mockPublisher{}
 	d := NewDeadLetterProducer(pub)
 
-	msg := messaging.Message{Topic: "events", Value: []byte(strings.Repeat("x", maxDLQPayloadBytes+10))}
+	msg := messaging.Message{Topic: "events", Payload: []byte(strings.Repeat("x", maxDLQPayloadBytes+10))}
 	if err := d.Send(context.Background(), msg, errors.New("err")); err != nil {
 		t.Fatalf("Send() error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestDeadLetterProducer_Send_RedactsSensitiveLargePayloadBeyondTruncationLim
 	pub := &mockPublisher{}
 	d := NewDeadLetterProducer(pub)
 
-	msg := messaging.Message{Topic: "events", Value: []byte(strings.Repeat("x", maxDLQPayloadBytes+10) + "token")}
+	msg := messaging.Message{Topic: "events", Payload: []byte(strings.Repeat("x", maxDLQPayloadBytes+10) + "token")}
 	if err := d.Send(context.Background(), msg, errors.New("err")); err != nil {
 		t.Fatalf("Send() error: %v", err)
 	}

--- a/messaging/middleware/metrics_test.go
+++ b/messaging/middleware/metrics_test.go
@@ -149,10 +149,10 @@ func TestInstrumentHandler_PassesThrough(t *testing.T) {
 	}
 
 	wrapped := InstrumentHandler("t", "g", handler)
-	msg := messaging.Message{Topic: "t", Key: "k1", Value: []byte("v"), Headers: map[string]string{}}
+	msg := messaging.Message{Topic: "t", Key: "k1", Payload: []byte("v"), Headers: map[string]string{}}
 	_ = wrapped(context.Background(), msg)
 
-	if received.Key != "k1" || string(received.Value) != "v" {
+	if received.Key != "k1" || string(received.Payload) != "v" {
 		t.Errorf("handler received wrong message: %+v", received)
 	}
 }

--- a/messaging/nats/consumer.go
+++ b/messaging/nats/consumer.go
@@ -96,7 +96,7 @@ func (c *Consumer) Consume(ctx context.Context, handler messaging.MessageHandler
 		}
 		domain := messaging.Message{
 			Key:       headers["message-key"],
-			Value:     msg.Data,
+			Payload:   msg.Data,
 			Topic:     c.topic,
 			Timestamp: time.Now().UTC(),
 			Headers:   headers,

--- a/messaging/nats/consumer_test.go
+++ b/messaging/nats/consumer_test.go
@@ -48,7 +48,7 @@ func TestConsumerConsumeDeliversHeadersAndStopsOnContext(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Consume = %v, want context.Canceled", err)
 	}
-	if got.Topic != "orders" || got.Key != "k" || string(got.Value) != "payload" || got.Headers["x"] != "y" {
+	if got.Topic != "orders" || got.Key != "k" || string(got.Payload) != "payload" || got.Headers["x"] != "y" {
 		t.Fatalf("delivered message = %#v", got)
 	}
 }

--- a/messaging/nats/producer.go
+++ b/messaging/nats/producer.go
@@ -66,7 +66,7 @@ func (p *Producer) ensureConnLocked() (natsConn, error) {
 
 // Send writes a pre-built transport-agnostic message.
 func (p *Producer) Send(ctx context.Context, msg messaging.Message) error {
-	return p.publish(ctx, msg.Topic, msg.Value, headersWithMessageKey(msg.Headers, msg.Key))
+	return p.publish(ctx, msg.Topic, msg.Payload, headersWithMessageKey(msg.Headers, msg.Key))
 }
 
 // SendBatch writes pre-built messages in order.

--- a/messaging/nats/producer_test.go
+++ b/messaging/nats/producer_test.go
@@ -52,7 +52,7 @@ func TestProducerPublishMethodsUseSubjectHeadersAndPayloads(t *testing.T) {
 	if err := p.Publish(ctx, "events", event); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if err := p.Send(ctx, messaging.Message{Topic: "raw", Key: "msg-key", Value: []byte("body"), Headers: map[string]string{"x": "y"}}); err != nil {
+	if err := p.Send(ctx, messaging.Message{Topic: "raw", Key: "msg-key", Payload: []byte("body"), Headers: map[string]string{"x": "y"}}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 
@@ -83,7 +83,7 @@ func TestProducerPublishMethodsUseSubjectHeadersAndPayloads(t *testing.T) {
 func TestProducerSendBatchStopsOnErrorAndCloseDrains(t *testing.T) {
 	conn := &fakeNATSConn{}
 	p := &Producer{cfg: Config{PublishTimeout: "1s"}, conn: conn, retryAttempts: 1}
-	err := p.SendBatch(context.Background(), []messaging.Message{{Topic: "a", Value: []byte("1")}, {Topic: "bad topic"}})
+	err := p.SendBatch(context.Background(), []messaging.Message{{Topic: "a", Payload: []byte("1")}, {Topic: "bad topic"}})
 	if err == nil {
 		t.Fatal("expected invalid topic error")
 	}

--- a/messaging/rabbitmq/consumer.go
+++ b/messaging/rabbitmq/consumer.go
@@ -101,7 +101,7 @@ func (c *Consumer) Consume(ctx context.Context, handler messaging.MessageHandler
 		}
 		domain := messaging.Message{
 			Key:       headers["message-key"],
-			Value:     delivery.Body,
+			Payload:   delivery.Body,
 			Topic:     c.topic,
 			Timestamp: delivery.Timestamp,
 			Headers:   headers,

--- a/messaging/rabbitmq/consumer_test.go
+++ b/messaging/rabbitmq/consumer_test.go
@@ -98,7 +98,7 @@ func TestConsumerConsumeAcksSuccessfulMessages(t *testing.T) {
 	if acks.acked != 1 || acks.nacked != 0 {
 		t.Fatalf("acks=%d nacks=%d", acks.acked, acks.nacked)
 	}
-	if got.Topic != "orders" || got.Key != "k" || string(got.Value) != "payload" || got.Headers["x"] != "y" {
+	if got.Topic != "orders" || got.Key != "k" || string(got.Payload) != "payload" || got.Headers["x"] != "y" {
 		t.Fatalf("message = %#v", got)
 	}
 }

--- a/messaging/rabbitmq/producer.go
+++ b/messaging/rabbitmq/producer.go
@@ -73,7 +73,7 @@ func (p *Producer) ensureChannelLocked() (rabbitChannel, error) {
 
 // Send writes a pre-built transport-agnostic message.
 func (p *Producer) Send(ctx context.Context, msg messaging.Message) error {
-	return p.publish(ctx, msg.Topic, msg.Value, headersWithMessageKey(msg.Headers, msg.Key))
+	return p.publish(ctx, msg.Topic, msg.Payload, headersWithMessageKey(msg.Headers, msg.Key))
 }
 
 // SendBatch writes pre-built messages in order.

--- a/messaging/rabbitmq/producer_test.go
+++ b/messaging/rabbitmq/producer_test.go
@@ -176,7 +176,7 @@ func TestProducerPublishMethodsDeclareQueueAndPublish(t *testing.T) {
 	if err := p.Publish(ctx, "events", event); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if err := p.Send(ctx, messaging.Message{Topic: "raw", Key: "msg-key", Value: []byte("body"), Headers: map[string]string{"x": "y"}}); err != nil {
+	if err := p.Send(ctx, messaging.Message{Topic: "raw", Key: "msg-key", Payload: []byte("body"), Headers: map[string]string{"x": "y"}}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if len(ch.published) != 4 {
@@ -231,7 +231,7 @@ func TestProducerErrorsFlushAndClose(t *testing.T) {
 func TestProducerSendBatchStopsOnError(t *testing.T) {
 	ch := &fakeRabbitChannel{}
 	p := &Producer{cfg: Config{PublishTimeout: "1s"}, ch: ch, retryAttempts: 1, declared: map[string]struct{}{}}
-	err := p.SendBatch(context.Background(), []messaging.Message{{Topic: "a", Value: []byte("1")}, {Topic: "bad topic"}})
+	err := p.SendBatch(context.Background(), []messaging.Message{{Topic: "a", Payload: []byte("1")}, {Topic: "bad topic"}})
 	if err == nil {
 		t.Fatal("expected invalid topic error")
 	}

--- a/messaging/testutil/assertions_test.go
+++ b/messaging/testutil/assertions_test.go
@@ -36,8 +36,8 @@ func TestAssertConsumed(t *testing.T) {
 	t.Parallel()
 
 	received := []messaging.Message{
-		{Key: "k1", Value: []byte("v1")},
-		{Key: "k2", Value: []byte("v2")},
+		{Key: "k1", Payload: []byte("v1")},
+		{Key: "k2", Payload: []byte("v2")},
 	}
 	AssertConsumed(t, received, 2)
 	AssertConsumed(t, nil, 0)

--- a/messaging/testutil/component.go
+++ b/messaging/testutil/component.go
@@ -15,7 +15,7 @@ import (
 type Message struct {
 	Topic   string
 	Key     []byte
-	Value   []byte
+	Payload []byte
 	Headers map[string]string
 }
 
@@ -38,7 +38,7 @@ var (
 func (p *MockProducer) WriteMessage(topic string, key, value []byte) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.messages = append(p.messages, Message{Topic: topic, Key: key, Value: value})
+	p.messages = append(p.messages, Message{Topic: topic, Key: key, Payload: value})
 }
 
 // Publish sends a structured gokit Event to the in-memory store.
@@ -63,9 +63,9 @@ func (p *MockProducer) Publish(_ context.Context, topic string, event messaging.
 		partitionKey = event.ID
 	}
 	p.messages = append(p.messages, Message{
-		Topic: topic,
-		Key:   []byte(partitionKey),
-		Value: data,
+		Topic:   topic,
+		Key:     []byte(partitionKey),
+		Payload: data,
 		Headers: map[string]string{
 			"event-id":     event.ID,
 			"event-type":   event.Type,
@@ -93,7 +93,7 @@ func (p *MockProducer) PublishJSON(_ context.Context, topic, key string, value a
 	p.messages = append(p.messages, Message{
 		Topic:   topic,
 		Key:     []byte(key),
-		Value:   data,
+		Payload: data,
 		Headers: map[string]string{"content-type": "application/json"},
 	})
 	return nil
@@ -112,7 +112,7 @@ func (p *MockProducer) PublishBinary(_ context.Context, topic, key string, data 
 	p.messages = append(p.messages, Message{
 		Topic:   topic,
 		Key:     []byte(key),
-		Value:   data,
+		Payload: data,
 		Headers: map[string]string{"content-type": "application/octet-stream"},
 	})
 	return nil
@@ -131,7 +131,7 @@ func (p *MockProducer) Send(_ context.Context, msg messaging.Message) error {
 	p.messages = append(p.messages, Message{
 		Topic:   msg.Topic,
 		Key:     []byte(msg.Key),
-		Value:   msg.Value,
+		Payload: msg.Payload,
 		Headers: msg.Headers,
 	})
 	return nil

--- a/messaging/testutil/mock_consumer_test.go
+++ b/messaging/testutil/mock_consumer_test.go
@@ -34,8 +34,8 @@ func TestChannelConsumer_FeedAndConsume(t *testing.T) {
 	}()
 
 	c.Feed(
-		messaging.Message{Topic: "events", Key: "k1", Value: []byte("hello")},
-		messaging.Message{Topic: "events", Key: "k2", Value: []byte("world")},
+		messaging.Message{Topic: "events", Key: "k1", Payload: []byte("hello")},
+		messaging.Message{Topic: "events", Key: "k2", Payload: []byte("world")},
 	)
 
 	// Give the consumer time to process
@@ -46,11 +46,11 @@ func TestChannelConsumer_FeedAndConsume(t *testing.T) {
 	if len(received) != 2 {
 		t.Fatalf("received %d messages, want 2", len(received))
 	}
-	if string(received[0].Value) != "hello" {
-		t.Errorf("received[0].Value = %q, want hello", string(received[0].Value))
+	if string(received[0].Payload) != "hello" {
+		t.Errorf("received[0].Payload = %q, want hello", string(received[0].Payload))
 	}
-	if string(received[1].Value) != "world" {
-		t.Errorf("received[1].Value = %q, want world", string(received[1].Value))
+	if string(received[1].Payload) != "world" {
+		t.Errorf("received[1].Payload = %q, want world", string(received[1].Payload))
 	}
 }
 

--- a/messaging/testutil/mock_producer_test.go
+++ b/messaging/testutil/mock_producer_test.go
@@ -75,7 +75,7 @@ func TestMockProducer_LastMessage(t *testing.T) {
 	p.WriteMessage("t2", nil, []byte("second"))
 
 	last := p.LastMessage()
-	if last.Topic != "t2" || string(last.Value) != "second" {
+	if last.Topic != "t2" || string(last.Payload) != "second" {
 		t.Errorf("LastMessage() = %+v, want topic=t2 value=second", last)
 	}
 }

--- a/messaging/types.go
+++ b/messaging/types.go
@@ -12,7 +12,7 @@ import (
 // Message represents a broker message with both binary and JSON support.
 type Message struct {
 	Key       string            `json:"key"`
-	Value     []byte            `json:"value"`
+	Payload   []byte            `json:"payload"`
 	Topic     string            `json:"topic"`
 	Partition int               `json:"partition"`
 	Offset    int64             `json:"offset"`
@@ -20,14 +20,14 @@ type Message struct {
 	Headers   map[string]string `json:"headers,omitempty"`
 }
 
-// NewMessage creates a broker-neutral Message with topic, key, value, and headers.
-func NewMessage(topic, key string, value []byte, headers map[string]string) Message {
+// NewMessage creates a broker-neutral Message with topic, key, payload, and headers.
+func NewMessage(topic, key string, payload []byte, headers map[string]string) Message {
 	if headers == nil {
 		headers = make(map[string]string)
 	}
 	return Message{
 		Key:     key,
-		Value:   value,
+		Payload: payload,
 		Topic:   topic,
 		Headers: headers,
 	}
@@ -97,22 +97,22 @@ func (m Message) IsJSON() bool {
 	if ct, ok := m.Headers["content-type"]; ok && ct == "application/json" {
 		return true
 	}
-	if len(m.Value) > 0 {
-		return m.Value[0] == '{' || m.Value[0] == '['
+	if len(m.Payload) > 0 {
+		return m.Payload[0] == '{' || m.Payload[0] == '['
 	}
 	return false
 }
 
-// UnmarshalValueJSON unmarshals the message value as JSON into v.
+// UnmarshalPayloadJSON unmarshals the message payload as JSON into v.
 // v is intentionally opaque because encoding/json requires a caller-owned destination.
-func (m Message) UnmarshalValueJSON(v any) error {
-	return json.Unmarshal(m.Value, v)
+func (m Message) UnmarshalPayloadJSON(v any) error {
+	return json.Unmarshal(m.Payload, v)
 }
 
-// UnmarshalMessageJSON unmarshals the message value into a typed value.
+// UnmarshalMessageJSON unmarshals the message payload into a typed value.
 func UnmarshalMessageJSON[T any](m Message) (T, error) {
 	var out T
-	err := json.Unmarshal(m.Value, &out)
+	err := json.Unmarshal(m.Payload, &out)
 	return out, err
 }
 
@@ -122,6 +122,6 @@ func (m Message) RoutingKey() string { return m.Key }
 // ToEvent converts the message to an Event (assumes JSON content).
 func (m Message) ToEvent() (Event, error) {
 	var event Event
-	err := json.Unmarshal(m.Value, &event)
+	err := json.Unmarshal(m.Payload, &event)
 	return event, err
 }

--- a/messaging/types_test.go
+++ b/messaging/types_test.go
@@ -88,7 +88,7 @@ func TestParseData_Invalid(t *testing.T) {
 func TestMessage_IsJSON_ByHeader(t *testing.T) {
 	msg := Message{
 		Headers: map[string]string{"content-type": "application/json"},
-		Value:   []byte("not json at all"),
+		Payload: []byte("not json at all"),
 	}
 	if !msg.IsJSON() {
 		t.Error("expected IsJSON=true when content-type header is application/json")
@@ -107,28 +107,28 @@ func TestMessage_IsJSON_ByContent(t *testing.T) {
 		{nil, false},
 	}
 	for _, tt := range tests {
-		msg := Message{Value: tt.value, Headers: map[string]string{}}
+		msg := Message{Payload: tt.value, Headers: map[string]string{}}
 		if got := msg.IsJSON(); got != tt.want {
 			t.Errorf("IsJSON(%q) = %v, want %v", string(tt.value), got, tt.want)
 		}
 	}
 }
 
-func TestMessage_UnmarshalValueJSON(t *testing.T) {
-	msg := Message{Value: []byte(`{"name":"Bob"}`)}
+func TestMessage_UnmarshalPayloadJSON(t *testing.T) {
+	msg := Message{Payload: []byte(`{"name":"Bob"}`)}
 	var result map[string]string
-	if err := msg.UnmarshalValueJSON(&result); err != nil {
-		t.Fatalf("UnmarshalValueJSON() error: %v", err)
+	if err := msg.UnmarshalPayloadJSON(&result); err != nil {
+		t.Fatalf("UnmarshalPayloadJSON() error: %v", err)
 	}
 	if result["name"] != "Bob" {
 		t.Errorf("name = %q, want Bob", result["name"])
 	}
 }
 
-func TestMessage_UnmarshalValueJSON_Invalid(t *testing.T) {
-	msg := Message{Value: []byte("not json")}
+func TestMessage_UnmarshalPayloadJSON_Invalid(t *testing.T) {
+	msg := Message{Payload: []byte("not json")}
 	var result map[string]string
-	if err := msg.UnmarshalValueJSON(&result); err == nil {
+	if err := msg.UnmarshalPayloadJSON(&result); err == nil {
 		t.Error("expected error for invalid JSON")
 	}
 }
@@ -140,7 +140,7 @@ func TestMessage_ToEvent(t *testing.T) {
 		Source: "unit-test",
 	}
 	data, _ := json.Marshal(e)
-	msg := Message{Value: data}
+	msg := Message{Payload: data}
 	parsed, err := msg.ToEvent()
 	if err != nil {
 		t.Fatalf("ToEvent() error: %v", err)
@@ -151,7 +151,7 @@ func TestMessage_ToEvent(t *testing.T) {
 }
 
 func TestMessage_ToEvent_Invalid(t *testing.T) {
-	msg := Message{Value: []byte("not json")}
+	msg := Message{Payload: []byte("not json")}
 	_, err := msg.ToEvent()
 	if err == nil {
 		t.Error("expected error for invalid JSON")
@@ -176,8 +176,8 @@ func TestNewMessage(t *testing.T) {
 	if msg.Key != "key" {
 		t.Errorf("Key = %q", msg.Key)
 	}
-	if string(msg.Value) != "val" {
-		t.Errorf("Value = %q", string(msg.Value))
+	if string(msg.Payload) != "val" {
+		t.Errorf("Payload = %q", string(msg.Payload))
 	}
 	if msg.Headers == nil {
 		t.Error("expected non-nil Headers")
@@ -195,7 +195,7 @@ func TestNewMessagePreservesHeaders(t *testing.T) {
 
 func TestUnmarshalMessageJSON(t *testing.T) {
 	t.Parallel()
-	msg := Message{Value: []byte(`{"name":"Alice","age":30}`)}
+	msg := Message{Payload: []byte(`{"name":"Alice","age":30}`)}
 	out, err := UnmarshalMessageJSON[struct {
 		Name string `json:"name"`
 		Age  int    `json:"age"`
@@ -207,7 +207,7 @@ func TestUnmarshalMessageJSON(t *testing.T) {
 		t.Fatalf("decoded = %+v", out)
 	}
 
-	if _, err := UnmarshalMessageJSON[map[string]string](Message{Value: []byte("not json")}); err == nil {
+	if _, err := UnmarshalMessageJSON[map[string]string](Message{Payload: []byte("not json")}); err == nil {
 		t.Fatal("expected unmarshal error for invalid JSON")
 	}
 }
@@ -230,4 +230,81 @@ func FuzzParseData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		_, _ = ParseData[payload](Event{Data: data})
 	})
+}
+
+func TestMessage_JSONWireShape(t *testing.T) {
+	t.Parallel()
+
+	msg := Message{
+		Key:       "k1",
+		Payload:   []byte(`{"hello":"world"}`),
+		Topic:     "orders",
+		Partition: 2,
+		Offset:    42,
+		Timestamp: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	wantKeys := map[string]bool{
+		"key": true, "payload": true, "topic": true, "partition": true,
+		"offset": true, "timestamp": true, "headers": true,
+	}
+	for k := range wire {
+		if !wantKeys[k] {
+			t.Errorf("unexpected wire key %q", k)
+		}
+	}
+	for k := range wantKeys {
+		if _, ok := wire[k]; !ok {
+			t.Errorf("missing wire key %q", k)
+		}
+	}
+	if _, ok := wire["value"]; ok {
+		t.Error("wire shape must not contain legacy key \"value\"")
+	}
+
+	var payload string
+	if err := json.Unmarshal(wire["payload"], &payload); err != nil {
+		t.Fatalf("payload not base64 string: %v", err)
+	}
+	if payload == "" {
+		t.Error("payload key must carry the message body")
+	}
+
+	var back Message
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("round-trip Unmarshal() error: %v", err)
+	}
+	if string(back.Payload) != `{"hello":"world"}` {
+		t.Errorf("round-trip Payload = %q", string(back.Payload))
+	}
+	if back.Key != "k1" || back.Topic != "orders" || back.Partition != 2 || back.Offset != 42 {
+		t.Errorf("round-trip envelope = %+v", back)
+	}
+}
+
+func TestMessage_JSONHeadersOmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(Message{Key: "k", Payload: []byte("x"), Topic: "t"})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if _, ok := wire["headers"]; ok {
+		t.Error("headers must be omitted when empty")
+	}
 }

--- a/storage/component_test.go
+++ b/storage/component_test.go
@@ -26,6 +26,9 @@ func (s *stubStorage) URL(context.Context, string) (string, error) {
 	return "https://stub/x", s.urlErr
 }
 func (s *stubStorage) List(context.Context, string) ([]FileInfo, error) { return nil, nil }
+func (s *stubStorage) Head(context.Context, string) (FileInfo, error)   { return FileInfo{}, nil }
+func (s *stubStorage) Copy(context.Context, string, string) error       { return nil }
+func (s *stubStorage) Rename(context.Context, string, string) error     { return nil }
 
 func stubRegistry(t *testing.T, s Storage) *FactoryRegistry {
 	t.Helper()

--- a/storage/doc.go
+++ b/storage/doc.go
@@ -4,6 +4,14 @@
 // It defines interfaces for common storage operations (upload, download, delete, list)
 // and follows gokit's component pattern with lifecycle management.
 //
+// # Optional capabilities
+//
+// Single-object metadata, copy, move, and signed URLs are opt-in capability
+// interfaces ([HeadProvider], [CopyProvider], [RenameProvider], and
+// [SignedURLProvider]) rather than required methods. Call the package-level
+// [Head], [Copy], and [Rename] helpers to use a backend's native operation when
+// it has one and a portable fallback when it does not.
+//
 // # Backends
 //
 //   - storage/s3: Amazon S3 and S3-compatible storage

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,0 +1,33 @@
+// Portable error identities shared across storage backends.
+package storage
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is the portable identity for a missing object. Every backend wraps
+// it (via [NotFoundError]) so callers can test for a missing object with
+// errors.Is regardless of the underlying store.
+var ErrNotFound = errors.New("storage: object not found")
+
+// ErrSameObject reports a Copy or Rename whose source and destination keys are
+// identical. Such a request cannot duplicate or move an object and, for backends
+// that copy in place or copy-then-delete, would destroy it, so the package-level
+// helpers and every adapter reject it before touching the store.
+var ErrSameObject = errors.New("storage: source and destination path are the same")
+
+// NotFoundError wraps [ErrNotFound] with the missing object's path.
+func NotFoundError(path string) error {
+	return fmt.Errorf("%w: %s", ErrNotFound, path)
+}
+
+// CheckDistinctPaths returns an [ErrSameObject] error when srcPath equals
+// dstPath. Copy and Rename implementations call it at entry so a same-key request
+// can never reach a destructive backend operation.
+func CheckDistinctPaths(op, srcPath, dstPath string) error {
+	if srcPath == dstPath {
+		return fmt.Errorf("storage: %s source and destination path %q are the same: %w", op, srcPath, ErrSameObject)
+	}
+	return nil
+}

--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNotFoundErrorIsErrNotFound(t *testing.T) {
+	t.Parallel()
+
+	err := NotFoundError("dir/a.txt")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("NotFoundError should wrap ErrNotFound, got %v", err)
+	}
+	if got := err.Error(); got == "" || got == ErrNotFound.Error() {
+		t.Errorf("NotFoundError should include the path, got %q", got)
+	}
+}
+
+func TestCheckDistinctPaths(t *testing.T) {
+	t.Parallel()
+
+	if err := CheckDistinctPaths("Copy", "a.txt", "a.txt"); !errors.Is(err, ErrSameObject) {
+		t.Fatalf("equal paths should yield ErrSameObject, got %v", err)
+	}
+	if err := CheckDistinctPaths("Copy", "a.txt", "b.txt"); err != nil {
+		t.Fatalf("distinct paths should be accepted, got %v", err)
+	}
+}

--- a/storage/fileinfo.go
+++ b/storage/fileinfo.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"time"
+)
+
+// FileInfo contains metadata about a stored object.
+type FileInfo struct {
+	// Path is the object's key within the store.
+	Path string `json:"path"`
+	// Size is the object's size in bytes.
+	Size int64 `json:"size"`
+	// LastModified is the time the object was last written.
+	LastModified time.Time `json:"last_modified"`
+	// ContentType is the object's MIME type.
+	ContentType string `json:"content_type"`
+	// Metadata holds backend-provided user metadata for the object.
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// Checksum is the backend-provided content checksum, when available.
+	Checksum string `json:"checksum,omitempty"`
+}

--- a/storage/fileinfo_test.go
+++ b/storage/fileinfo_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestFileInfo_MarshalsToSnakeCaseJSON(t *testing.T) {
+	t.Parallel()
+
+	fi := FileInfo{
+		Path:         "dir/a.txt",
+		Size:         5,
+		LastModified: time.Date(2023, time.January, 2, 3, 4, 5, 0, time.UTC),
+		ContentType:  "text/plain",
+		Metadata:     map[string]string{"owner": "team"},
+		Checksum:     "abc123",
+	}
+
+	data, err := json.Marshal(fi)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for _, key := range []string{"path", "size", "last_modified", "content_type", "metadata", "checksum"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing key %q in %s", key, data)
+		}
+	}
+}
+
+func TestFileInfo_OmitsEmptyMetadataAndChecksum(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(FileInfo{Path: "a.txt", Size: 1})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := raw["metadata"]; ok {
+		t.Errorf("metadata should be omitted: %s", data)
+	}
+	if _, ok := raw["checksum"]; ok {
+		t.Errorf("checksum should be omitted: %s", data)
+	}
+}

--- a/storage/gcs/gcs.go
+++ b/storage/gcs/gcs.go
@@ -42,6 +42,8 @@ type objectClient interface {
 	Delete(ctx context.Context, path string) error
 	Exists(ctx context.Context, path string) (bool, error)
 	List(ctx context.Context, prefix string) ([]storage.FileInfo, error)
+	Head(ctx context.Context, path string) (storage.FileInfo, error)
+	Copy(ctx context.Context, srcPath, dstPath string) error
 	SignedURL(ctx context.Context, path string, expiry time.Duration) (string, error)
 }
 
@@ -78,6 +80,9 @@ func (s *Storage) Upload(ctx context.Context, path string, reader io.Reader) err
 func (s *Storage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
 	body, err := s.client.Get(ctx, path)
 	if err != nil {
+		if errors.Is(err, gcstorage.ErrObjectNotExist) {
+			return nil, storage.NotFoundError(path)
+		}
 		return nil, fmt.Errorf("storage: gcs download: %w", err)
 	}
 	return body, nil

--- a/storage/gcs/gcs_test.go
+++ b/storage/gcs/gcs_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	gcstorage "cloud.google.com/go/storage"
+
 	"github.com/kbukum/gokit/storage"
 )
 
@@ -39,7 +41,7 @@ func (f *fakeObjectClient) Get(_ context.Context, path string) (io.ReadCloser, e
 	}
 	v, ok := f.objects[path]
 	if !ok {
-		return nil, errors.New("missing")
+		return nil, gcstorage.ErrObjectNotExist
 	}
 	return io.NopCloser(strings.NewReader(v)), nil
 }
@@ -72,6 +74,29 @@ func (f *fakeObjectClient) List(_ context.Context, prefix string) ([]storage.Fil
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 	return files, nil
+}
+
+func (f *fakeObjectClient) Head(_ context.Context, path string) (storage.FileInfo, error) {
+	if f.fail != nil {
+		return storage.FileInfo{}, f.fail
+	}
+	body, ok := f.objects[path]
+	if !ok {
+		return storage.FileInfo{}, storage.NotFoundError(path)
+	}
+	return storage.FileInfo{Path: path, Size: int64(len(body)), Checksum: "deadbeef"}, nil
+}
+
+func (f *fakeObjectClient) Copy(_ context.Context, srcPath, dstPath string) error {
+	if f.fail != nil {
+		return f.fail
+	}
+	body, ok := f.objects[srcPath]
+	if !ok {
+		return storage.NotFoundError(srcPath)
+	}
+	f.objects[dstPath] = body
+	return nil
 }
 
 func (f *fakeObjectClient) SignedURL(_ context.Context, path string, _ time.Duration) (string, error) {
@@ -118,6 +143,15 @@ func TestStorageOperationsUseInjectedClient(t *testing.T) {
 	}
 	if err := s.Delete(ctx, "dir/a.txt"); err != nil {
 		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDownload_MissingReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	s := NewStorageWithClient("bucket", "", newFakeClient())
+	_, err := s.Download(context.Background(), "absent")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Download of a missing object = %v, want storage.ErrNotFound", err)
 	}
 }
 

--- a/storage/gcs/objectops.go
+++ b/storage/gcs/objectops.go
@@ -1,0 +1,95 @@
+package gcs
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	gcstorage "cloud.google.com/go/storage"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+// Head returns metadata for a single GCS object, including its metadata map and
+// a content checksum derived from the object's MD5 or CRC32C attribute.
+func (s *Storage) Head(ctx context.Context, path string) (storage.FileInfo, error) {
+	fi, err := s.client.Head(ctx, path)
+	if err != nil {
+		return storage.FileInfo{}, fmt.Errorf("storage: gcs head: %w", err)
+	}
+	return fi, nil
+}
+
+// Copy duplicates an object within the bucket, leaving the source in place.
+func (s *Storage) Copy(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Copy", srcPath, dstPath); err != nil {
+		return err
+	}
+	if err := s.client.Copy(ctx, srcPath, dstPath); err != nil {
+		return fmt.Errorf("storage: gcs copy: %w", err)
+	}
+	return nil
+}
+
+// Rename moves an object within the bucket by copying then deleting the source.
+func (s *Storage) Rename(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Rename", srcPath, dstPath); err != nil {
+		return err
+	}
+	if err := s.client.Copy(ctx, srcPath, dstPath); err != nil {
+		return fmt.Errorf("storage: gcs rename copy: %w", err)
+	}
+	if err := s.client.Delete(ctx, srcPath); err != nil {
+		return fmt.Errorf("storage: gcs rename delete: %w", err)
+	}
+	return nil
+}
+
+func (c *googleClient) Head(ctx context.Context, path string) (storage.FileInfo, error) {
+	attrs, err := c.object(path).Attrs(ctx)
+	if err != nil {
+		if errors.Is(err, gcstorage.ErrObjectNotExist) {
+			return storage.FileInfo{}, storage.NotFoundError(path)
+		}
+		return storage.FileInfo{}, err
+	}
+	fi := storage.FileInfo{
+		Path:         path,
+		Size:         attrs.Size,
+		LastModified: attrs.Updated,
+		ContentType:  attrs.ContentType,
+		Checksum:     checksum(attrs),
+	}
+	if len(attrs.Metadata) > 0 {
+		fi.Metadata = make(map[string]string, len(attrs.Metadata))
+		for k, v := range attrs.Metadata {
+			fi.Metadata[k] = v
+		}
+	}
+	return fi, nil
+}
+
+func (c *googleClient) Copy(ctx context.Context, srcPath, dstPath string) error {
+	src := c.object(srcPath)
+	dst := c.object(dstPath)
+	if _, err := dst.CopierFrom(src).Run(ctx); err != nil {
+		if errors.Is(err, gcstorage.ErrObjectNotExist) {
+			return storage.NotFoundError(srcPath)
+		}
+		return err
+	}
+	return nil
+}
+
+// checksum renders a GCS object's content hash as a hex string, preferring the
+// MD5 digest and falling back to the CRC32C checksum.
+func checksum(attrs *gcstorage.ObjectAttrs) string {
+	if len(attrs.MD5) > 0 {
+		return hex.EncodeToString(attrs.MD5)
+	}
+	if attrs.CRC32C != 0 {
+		return fmt.Sprintf("%08x", attrs.CRC32C)
+	}
+	return ""
+}

--- a/storage/gcs/objectops_test.go
+++ b/storage/gcs/objectops_test.go
@@ -1,0 +1,93 @@
+package gcs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+func TestHeadUsesInjectedClient(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client := newFakeClient()
+	s := NewStorageWithClient("bucket", "https://cdn.example", client)
+	if err := s.Upload(ctx, "dir/a.txt", strings.NewReader("hello")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	info, err := s.Head(ctx, "dir/a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Size != 5 || info.Checksum == "" {
+		t.Fatalf("info = %#v", info)
+	}
+}
+
+func TestHeadMissingErrors(t *testing.T) {
+	t.Parallel()
+	s := NewStorageWithClient("bucket", "", newFakeClient())
+	_, err := s.Head(context.Background(), "absent")
+	if err == nil {
+		t.Fatal("Head for a missing object did not error")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Head error is not storage.ErrNotFound: %v", err)
+	}
+}
+
+func TestCopyRenameRejectSamePath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client := newFakeClient()
+	s := NewStorageWithClient("bucket", "", client)
+	if err := s.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Copy(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Copy same path = %v, want storage.ErrSameObject", err)
+	}
+	if err := s.Rename(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Rename same path = %v, want storage.ErrSameObject", err)
+	}
+	if client.objects["a.txt"] != "payload" {
+		t.Errorf("object mutated by rejected same-path op: %q", client.objects["a.txt"])
+	}
+}
+
+func TestCopyDuplicatesObject(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client := newFakeClient()
+	s := NewStorageWithClient("bucket", "", client)
+	if err := s.Upload(ctx, "src.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Copy(ctx, "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if client.objects["dst.txt"] != "payload" || client.objects["src.txt"] != "payload" {
+		t.Fatalf("objects = %#v", client.objects)
+	}
+}
+
+func TestRenameMovesObject(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client := newFakeClient()
+	s := NewStorageWithClient("bucket", "", client)
+	if err := s.Upload(ctx, "src.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Rename(ctx, "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if client.objects["dst.txt"] != "payload" {
+		t.Fatalf("dst = %q", client.objects["dst.txt"])
+	}
+	if _, ok := client.objects["src.txt"]; ok {
+		t.Fatal("source still present after rename")
+	}
+}

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -18,11 +18,13 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
+	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.21.0 // indirect

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -23,6 +23,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -37,6 +39,12 @@ github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.45.0 h1:pdrWmLHofpubmArBv1LgFSv1Z0Ie/ppdZzu+kUN5EeU=

--- a/storage/local/local.go
+++ b/storage/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -10,9 +11,12 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
+	"github.com/kbukum/gokit/fs"
 	"github.com/kbukum/gokit/logging"
 	"github.com/kbukum/gokit/storage"
+	"github.com/kbukum/gokit/util"
 )
 
 // safePath resolves path within basePath and ensures it cannot escape via traversal.
@@ -50,6 +54,9 @@ func Register(reg *storage.FactoryRegistry, configs ...Config) error {
 // Storage implements storage.Storage using the local filesystem.
 type Storage struct {
 	basePath string
+	// renameFile performs the atomic move; it is a field so tests can exercise
+	// the copy-then-delete fallback taken when a rename crosses a mount point.
+	renameFile func(oldpath, newpath string) error
 }
 
 // NewStorage creates a new local filesystem storage.
@@ -61,7 +68,7 @@ func NewStorage(basePath string) (*Storage, error) {
 	if err := os.MkdirAll(abs, 0o750); err != nil {
 		return nil, fmt.Errorf("storage: create base directory: %w", err)
 	}
-	return &Storage{basePath: abs}, nil
+	return &Storage{basePath: abs, renameFile: os.Rename}, nil
 }
 
 // Upload writes data from reader to a local file.
@@ -95,7 +102,7 @@ func (s *Storage) Download(_ context.Context, path string) (io.ReadCloser, error
 	f, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("storage: file not found: %s", path)
+			return nil, storage.NotFoundError(path)
 		}
 		return nil, fmt.Errorf("storage: open file: %w", err)
 	}
@@ -140,8 +147,8 @@ func (s *Storage) URL(_ context.Context, path string) (string, error) {
 	return u.String(), nil
 }
 
-// Stat returns metadata for a single local file, implementing storage.StatProvider.
-func (s *Storage) Stat(_ context.Context, path string) (storage.FileInfo, error) {
+// Head returns metadata for a single local file.
+func (s *Storage) Head(_ context.Context, path string) (storage.FileInfo, error) {
 	fullPath, err := safePath(s.basePath, path)
 	if err != nil {
 		return storage.FileInfo{}, err
@@ -149,7 +156,7 @@ func (s *Storage) Stat(_ context.Context, path string) (storage.FileInfo, error)
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return storage.FileInfo{}, fmt.Errorf("storage: file not found: %s", path)
+			return storage.FileInfo{}, storage.NotFoundError(path)
 		}
 		return storage.FileInfo{}, fmt.Errorf("storage: stat file: %w", err)
 	}
@@ -166,6 +173,75 @@ func (s *Storage) Stat(_ context.Context, path string) (storage.FileInfo, error)
 		LastModified: info.ModTime(),
 		ContentType:  ct,
 	}, nil
+}
+
+// Copy duplicates the file at srcPath to dstPath, leaving the source in place.
+func (s *Storage) Copy(_ context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Copy", srcPath, dstPath); err != nil {
+		return err
+	}
+	return s.copyFile(srcPath, dstPath)
+}
+
+// Rename moves the file at srcPath to dstPath. It uses an atomic os.Rename when
+// possible and falls back to a copy followed by a delete only when the rename
+// crosses a device boundary (syscall.EXDEV) that os.Rename cannot handle; any
+// other rename error is returned so a permission or I/O failure never silently
+// downgrades to a non-atomic, potentially destructive operation.
+func (s *Storage) Rename(_ context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Rename", srcPath, dstPath); err != nil {
+		return err
+	}
+	srcFull, err := fs.ConfineExistingPath(s.basePath, srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return storage.NotFoundError(srcPath)
+		}
+		return fmt.Errorf("storage: resolve source: %w", err)
+	}
+	dstFull, err := fs.ConfinePath(s.basePath, dstPath)
+	if err != nil {
+		return fmt.Errorf("storage: resolve destination: %w", err)
+	}
+	if mErr := os.MkdirAll(filepath.Dir(dstFull), 0o750); mErr != nil {
+		return fmt.Errorf("storage: create directory: %w", mErr)
+	}
+	rErr := s.renameFile(srcFull, dstFull)
+	if rErr == nil {
+		return nil
+	}
+	if !errors.Is(rErr, syscall.EXDEV) {
+		return fmt.Errorf("storage: rename file: %w", rErr)
+	}
+	if cErr := s.copyFile(srcPath, dstPath); cErr != nil {
+		return cErr
+	}
+	if remErr := os.Remove(srcFull); remErr != nil {
+		return fmt.Errorf("storage: delete source file: %w", remErr)
+	}
+	return nil
+}
+
+// copyFile copies srcPath to dstPath within the base directory. Both paths are
+// resolved through the filesystem (fs.ConfineExistingPath / fs.ConfinePath) so a
+// symlinked key cannot read from or overwrite a file outside basePath, and the
+// source permissions and modification time are preserved.
+func (s *Storage) copyFile(srcPath, dstPath string) error {
+	srcFull, err := fs.ConfineExistingPath(s.basePath, srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return storage.NotFoundError(srcPath)
+		}
+		return fmt.Errorf("storage: resolve source: %w", err)
+	}
+	dstFull, err := fs.ConfinePath(s.basePath, dstPath)
+	if err != nil {
+		return fmt.Errorf("storage: resolve destination: %w", err)
+	}
+	if cErr := util.CopyFile(srcFull, dstFull); cErr != nil {
+		return fmt.Errorf("storage: copy file: %w", cErr)
+	}
+	return nil
 }
 
 // List returns metadata for all files whose relative path starts with prefix.
@@ -218,7 +294,4 @@ func (s *Storage) List(_ context.Context, prefix string) ([]storage.FileInfo, er
 }
 
 // compile-time check
-var (
-	_ storage.Storage      = (*Storage)(nil)
-	_ storage.StatProvider = (*Storage)(nil)
-)
+var _ storage.Storage = (*Storage)(nil)

--- a/storage/local/local_test.go
+++ b/storage/local/local_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/kbukum/gokit/storage"
@@ -823,19 +824,19 @@ func TestRegister_RejectsMultipleConfigs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Stat (storage.StatProvider)
+// Head
 // ---------------------------------------------------------------------------
 
-func TestStat_ReturnsMetadata(t *testing.T) {
+func TestHead_ReturnsMetadata(t *testing.T) {
 	s := newTestStorage(t)
 	ctx := context.Background()
 	if err := s.Upload(ctx, "docs/note.txt", strings.NewReader("hello")); err != nil {
 		t.Fatalf("Upload: %v", err)
 	}
 
-	info, err := s.Stat(ctx, "docs/note.txt")
+	info, err := s.Head(ctx, "docs/note.txt")
 	if err != nil {
-		t.Fatalf("Stat: %v", err)
+		t.Fatalf("Head: %v", err)
 	}
 	if info.Path != "docs/note.txt" {
 		t.Errorf("Path = %q, want %q", info.Path, "docs/note.txt")
@@ -851,13 +852,181 @@ func TestStat_ReturnsMetadata(t *testing.T) {
 	}
 }
 
-func TestStat_MissingFileErrors(t *testing.T) {
+func TestHead_MissingFileErrors(t *testing.T) {
 	s := newTestStorage(t)
-	if _, err := s.Stat(context.Background(), "absent.txt"); err == nil {
-		t.Fatal("Stat for a missing file did not error")
+	if _, err := s.Head(context.Background(), "absent.txt"); err == nil {
+		t.Fatal("Head for a missing file did not error")
 	}
 }
 
-func TestStat_SatisfiesStatProvider(t *testing.T) {
-	var _ storage.StatProvider = newTestStorage(t)
+func TestHead_MissingFileReturnsErrNotFound(t *testing.T) {
+	s := newTestStorage(t)
+	if _, err := s.Head(context.Background(), "absent.txt"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Head error is not storage.ErrNotFound: %v", err)
+	}
+}
+
+func TestCopyRename_RejectSamePath(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	if err := s.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Copy(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Copy same path = %v, want storage.ErrSameObject", err)
+	}
+	if err := s.Rename(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Rename same path = %v, want storage.ErrSameObject", err)
+	}
+	assertContent(t, s, "a.txt", "payload")
+}
+
+func TestCopy_DoesNotFollowSymlinkOutsideBase(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	if err := os.Symlink(secret, filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	s, err := NewStorage(dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if cErr := s.Copy(context.Background(), "link.txt", "copy.txt"); cErr == nil {
+		t.Fatal("Copy through a symlink escaping the base must be rejected")
+	}
+}
+
+func TestCopy_DuplicatesBytesAndKeepsSource(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	if err := s.Upload(ctx, "src/a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Copy(ctx, "src/a.txt", "dst/b.txt"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	assertContent(t, s, "dst/b.txt", "payload")
+	assertContent(t, s, "src/a.txt", "payload")
+}
+
+func TestCopy_MissingSourceErrors(t *testing.T) {
+	s := newTestStorage(t)
+	if err := s.Copy(context.Background(), "absent.txt", "dst.txt"); err == nil {
+		t.Fatal("Copy of a missing source did not error")
+	}
+}
+
+func TestCopy_RejectsSameFileViaAlias(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	if err := s.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	// "a.txt" and "./a.txt" are distinct strings that pass the same-key guard but
+	// resolve to the same file; the copy must be rejected before the destination
+	// is truncated, leaving the source intact.
+	if err := s.Copy(ctx, "a.txt", "./a.txt"); err == nil {
+		t.Fatal("Copy of a destination aliasing the source must be rejected")
+	}
+	assertContent(t, s, "a.txt", "payload")
+}
+
+func TestRename_RejectsSymlinkedDestinationParent(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	s, err := NewStorage(dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	ctx := context.Background()
+	if err := s.Upload(ctx, "src/a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	// "link" is a symlink escaping the base; renaming into it must be rejected so
+	// the object cannot be moved outside the configured store.
+	if err := s.Rename(ctx, "src/a.txt", "link/b.txt"); err == nil {
+		t.Fatal("Rename into a symlinked destination parent escaping the base must be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "b.txt")); statErr == nil {
+		t.Fatal("object was moved outside the base directory through a symlink")
+	}
+	assertContent(t, s, "src/a.txt", "payload")
+}
+
+func TestRename_MovesBytesAndRemovesSource(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	if err := s.Upload(ctx, "src/a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Rename(ctx, "src/a.txt", "dst/b.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	assertContent(t, s, "dst/b.txt", "payload")
+	if ok, err := s.Exists(ctx, "src/a.txt"); err != nil || ok {
+		t.Fatalf("source still present: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRename_MissingSourceErrors(t *testing.T) {
+	s := newTestStorage(t)
+	if err := s.Rename(context.Background(), "absent.txt", "dst.txt"); err == nil {
+		t.Fatal("Rename of a missing source did not error")
+	}
+}
+
+func TestRename_FallsBackToCopyWhenCrossDevice(t *testing.T) {
+	s := newTestStorage(t)
+	s.renameFile = func(_, _ string) error { return &os.LinkError{Op: "rename", Err: syscall.EXDEV} }
+	ctx := context.Background()
+	if err := s.Upload(ctx, "src/a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Rename(ctx, "src/a.txt", "dst/b.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	assertContent(t, s, "dst/b.txt", "payload")
+	if ok, err := s.Exists(ctx, "src/a.txt"); err != nil || ok {
+		t.Fatalf("source still present: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRename_NonCrossDeviceErrorIsNotDowngraded(t *testing.T) {
+	s := newTestStorage(t)
+	s.renameFile = func(_, _ string) error { return &os.LinkError{Op: "rename", Err: syscall.EPERM} }
+	ctx := context.Background()
+	if err := s.Upload(ctx, "src/a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := s.Rename(ctx, "src/a.txt", "dst/b.txt"); err == nil {
+		t.Fatal("Rename must return a non-cross-device error rather than falling back to copy+delete")
+	}
+	// The source must be left in place when the atomic rename fails for a
+	// reason other than a cross-device link.
+	if ok, err := s.Exists(ctx, "src/a.txt"); err != nil || !ok {
+		t.Fatalf("source must remain: ok=%v err=%v", ok, err)
+	}
+}
+
+func assertContent(t *testing.T, s *Storage, path, want string) {
+	t.Helper()
+	rc, err := s.Download(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Download %q: %v", path, err)
+	}
+	defer func() { _ = rc.Close() }()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll %q: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content of %q = %q, want %q", path, got, want)
+	}
 }

--- a/storage/objectops.go
+++ b/storage/objectops.go
@@ -1,0 +1,78 @@
+// Single-object helpers: Head, Copy, and Rename against any Storage.
+package storage
+
+import (
+	"context"
+	"fmt"
+)
+
+// Head returns metadata for a single object. Backends that implement
+// [HeadProvider] answer directly; otherwise Head falls back to an exact-path
+// match within List, so it works against any [Storage].
+func Head(ctx context.Context, s Storage, path string) (FileInfo, error) {
+	if s == nil {
+		return FileInfo{}, fmt.Errorf("storage: Head requires a non-nil store")
+	}
+	if path == "" {
+		return FileInfo{}, fmt.Errorf("storage: Head requires a non-empty path")
+	}
+	if hp, ok := s.(HeadProvider); ok {
+		return hp.Head(ctx, path)
+	}
+	infos, err := s.List(ctx, path)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("storage: Head list %q: %w", path, err)
+	}
+	for _, info := range infos {
+		if info.Path == path {
+			return info, nil
+		}
+	}
+	return FileInfo{}, NotFoundError(path)
+}
+
+// Copy duplicates an object within a single store, leaving the source in place.
+// Backends that implement [CopyProvider] perform a server-side copy; otherwise
+// Copy streams the object through [Transfer], so it works against any [Storage].
+func Copy(ctx context.Context, s Storage, srcPath, dstPath string) error {
+	if err := checkObjectOp("Copy", s, srcPath, dstPath); err != nil {
+		return err
+	}
+	if cp, ok := s.(CopyProvider); ok {
+		return cp.Copy(ctx, srcPath, dstPath)
+	}
+	return Transfer(ctx, s, srcPath, s, dstPath)
+}
+
+// Rename moves an object within a single store. Backends that implement
+// [RenameProvider] perform a server-side move; otherwise Rename copies the
+// object through [Copy] and deletes the source, so it works against any
+// [Storage]. A failed delete leaves the destination in place and is reported.
+func Rename(ctx context.Context, s Storage, srcPath, dstPath string) error {
+	if err := checkObjectOp("Rename", s, srcPath, dstPath); err != nil {
+		return err
+	}
+	if rp, ok := s.(RenameProvider); ok {
+		return rp.Rename(ctx, srcPath, dstPath)
+	}
+	if err := Copy(ctx, s, srcPath, dstPath); err != nil {
+		return fmt.Errorf("storage: Rename copy %q: %w", srcPath, err)
+	}
+	if err := s.Delete(ctx, srcPath); err != nil {
+		return fmt.Errorf("storage: Rename delete %q: %w", srcPath, err)
+	}
+	return nil
+}
+
+// checkObjectOp validates the store and paths shared by the two-path helpers.
+func checkObjectOp(op string, s Storage, srcPath, dstPath string) error {
+	switch {
+	case s == nil:
+		return fmt.Errorf("storage: %s requires a non-nil store", op)
+	case srcPath == "":
+		return fmt.Errorf("storage: %s requires a non-empty source path", op)
+	case dstPath == "":
+		return fmt.Errorf("storage: %s requires a non-empty destination path", op)
+	}
+	return CheckDistinctPaths(op, srcPath, dstPath)
+}

--- a/storage/objectops_test.go
+++ b/storage/objectops_test.go
@@ -1,0 +1,221 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+// bareStore exposes only the required Storage methods, so the capability
+// fallbacks in Head, Copy, and Rename are exercised.
+type bareStore struct{ inner *mapStore }
+
+func newBareStore() *bareStore { return &bareStore{inner: newMapStore()} }
+
+func (b *bareStore) Upload(ctx context.Context, path string, reader io.Reader) error {
+	return b.inner.Upload(ctx, path, reader)
+}
+
+func (b *bareStore) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	return b.inner.Download(ctx, path)
+}
+
+func (b *bareStore) Delete(ctx context.Context, path string) error {
+	return b.inner.Delete(ctx, path)
+}
+
+func (b *bareStore) Exists(ctx context.Context, path string) (bool, error) {
+	return b.inner.Exists(ctx, path)
+}
+
+func (b *bareStore) URL(ctx context.Context, path string) (string, error) {
+	return b.inner.URL(ctx, path)
+}
+
+func (b *bareStore) List(ctx context.Context, prefix string) ([]FileInfo, error) {
+	return b.inner.List(ctx, prefix)
+}
+
+func seed(t *testing.T, s Storage, path, content string) {
+	t.Helper()
+	if err := s.Upload(context.Background(), path, bytes.NewReader([]byte(content))); err != nil {
+		t.Fatalf("seed upload %q: %v", path, err)
+	}
+}
+
+func readAll(t *testing.T, s Storage, path string) string {
+	t.Helper()
+	rc, err := s.Download(context.Background(), path)
+	if err != nil {
+		t.Fatalf("download %q: %v", path, err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestHeadUsesProviderWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	s := newMapStore()
+	seed(t, s, "a.txt", "hi")
+	info, err := Head(context.Background(), s, "a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Size != 2 || info.ContentType != "application/octet-stream" {
+		t.Fatalf("Head = %#v, want the provider result", info)
+	}
+}
+
+func TestHeadFallsBackToList(t *testing.T) {
+	t.Parallel()
+
+	s := newBareStore()
+	seed(t, s, "a.txt", "hi")
+	info, err := Head(context.Background(), s, "a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Path != "a.txt" || info.Size != 2 {
+		t.Fatalf("Head = %#v, want the listing fallback result", info)
+	}
+}
+
+func TestHeadFallbackRejectsPrefixMatch(t *testing.T) {
+	t.Parallel()
+
+	s := newBareStore()
+	seed(t, s, "a.txt.bak", "hi")
+	if _, err := Head(context.Background(), s, "a.txt"); err == nil {
+		t.Fatal("Head matched a prefix rather than the exact path")
+	}
+}
+
+func TestHeadNotFound(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]Storage{"provider": newMapStore(), "fallback": newBareStore()} {
+		_, err := Head(context.Background(), s, "absent")
+		if err == nil {
+			t.Errorf("%s: Head for a missing object did not error", name)
+		}
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("%s: Head error is not ErrNotFound: %v", name, err)
+		}
+	}
+}
+
+func TestHeadValidatesArguments(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Head(context.Background(), nil, "a"); err == nil {
+		t.Error("Head with a nil store did not error")
+	}
+	if _, err := Head(context.Background(), newMapStore(), ""); err == nil {
+		t.Error("Head with an empty path did not error")
+	}
+}
+
+func TestCopyKeepsSourceInPlace(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]Storage{"provider": newMapStore(), "fallback": newBareStore()} {
+		seed(t, s, "src.txt", "payload")
+		if err := Copy(context.Background(), s, "src.txt", "dst.txt"); err != nil {
+			t.Fatalf("%s: Copy: %v", name, err)
+		}
+		if got := readAll(t, s, "dst.txt"); got != "payload" {
+			t.Errorf("%s: destination = %q, want %q", name, got, "payload")
+		}
+		if got := readAll(t, s, "src.txt"); got != "payload" {
+			t.Errorf("%s: source = %q, want it left in place", name, got)
+		}
+	}
+}
+
+func TestCopyMissingSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]Storage{"provider": newMapStore(), "fallback": newBareStore()} {
+		if err := Copy(context.Background(), s, "absent", "dst.txt"); err == nil {
+			t.Errorf("%s: Copy from a missing source did not error", name)
+		}
+	}
+}
+
+func TestRenameMovesObject(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]Storage{"provider": newMapStore(), "fallback": newBareStore()} {
+		seed(t, s, "src.txt", "payload")
+		if err := Rename(context.Background(), s, "src.txt", "dst.txt"); err != nil {
+			t.Fatalf("%s: Rename: %v", name, err)
+		}
+		if got := readAll(t, s, "dst.txt"); got != "payload" {
+			t.Errorf("%s: destination = %q, want %q", name, got, "payload")
+		}
+		exists, err := s.Exists(context.Background(), "src.txt")
+		if err != nil {
+			t.Fatalf("%s: Exists: %v", name, err)
+		}
+		if exists {
+			t.Errorf("%s: source still present after Rename", name)
+		}
+	}
+}
+
+func TestRenameMissingSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]Storage{"provider": newMapStore(), "fallback": newBareStore()} {
+		if err := Rename(context.Background(), s, "absent", "dst.txt"); err == nil {
+			t.Errorf("%s: Rename from a missing source did not error", name)
+		}
+	}
+}
+
+func TestObjectOpsValidateArguments(t *testing.T) {
+	t.Parallel()
+
+	s := newMapStore()
+	ctx := context.Background()
+	for name, tc := range map[string]struct {
+		store            Storage
+		srcPath, dstPath string
+	}{
+		"nil store":     {nil, "a", "b"},
+		"empty srcPath": {s, "", "b"},
+		"empty dstPath": {s, "a", ""},
+	} {
+		if err := Copy(ctx, tc.store, tc.srcPath, tc.dstPath); err == nil {
+			t.Errorf("%s: Copy did not error", name)
+		}
+		if err := Rename(ctx, tc.store, tc.srcPath, tc.dstPath); err == nil {
+			t.Errorf("%s: Rename did not error", name)
+		}
+	}
+}
+
+func TestObjectOpsRejectSamePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newMapStore()
+	seed(t, s, "a.txt", "payload")
+
+	if err := Copy(ctx, s, "a.txt", "a.txt"); !errors.Is(err, ErrSameObject) {
+		t.Errorf("Copy same path = %v, want ErrSameObject", err)
+	}
+	if err := Rename(ctx, s, "a.txt", "a.txt"); !errors.Is(err, ErrSameObject) {
+		t.Errorf("Rename same path = %v, want ErrSameObject", err)
+	}
+	if got := readAll(t, s, "a.txt"); got != "payload" {
+		t.Errorf("object mutated by rejected same-path op: %q", got)
+	}
+}

--- a/storage/provider_test.go
+++ b/storage/provider_test.go
@@ -78,7 +78,41 @@ func (m *mockStorage) List(_ context.Context, prefix string) ([]FileInfo, error)
 	return files, nil
 }
 
-// --- UploadProvider tests ---
+func (m *mockStorage) Head(_ context.Context, path string) (FileInfo, error) {
+	if m.failOn == "head" {
+		return FileInfo{}, fmt.Errorf("mock head error")
+	}
+	v, ok := m.data[path]
+	if !ok {
+		return FileInfo{}, fmt.Errorf("not found: %s", path)
+	}
+	return FileInfo{Path: path, Size: int64(len(v)), LastModified: time.Now()}, nil
+}
+
+func (m *mockStorage) Copy(_ context.Context, srcPath, dstPath string) error {
+	if m.failOn == "copy" {
+		return fmt.Errorf("mock copy error")
+	}
+	v, ok := m.data[srcPath]
+	if !ok {
+		return fmt.Errorf("not found: %s", srcPath)
+	}
+	m.data[dstPath] = append([]byte(nil), v...)
+	return nil
+}
+
+func (m *mockStorage) Rename(_ context.Context, srcPath, dstPath string) error {
+	if m.failOn == "rename" {
+		return fmt.Errorf("mock rename error")
+	}
+	v, ok := m.data[srcPath]
+	if !ok {
+		return fmt.Errorf("not found: %s", srcPath)
+	}
+	m.data[dstPath] = append([]byte(nil), v...)
+	delete(m.data, srcPath)
+	return nil
+}
 
 func TestUploadProvider_Name(t *testing.T) {
 	p := NewUploadProvider("s3-upload", newMockStorage())

--- a/storage/s3/config.go
+++ b/storage/s3/config.go
@@ -23,11 +23,11 @@ type Config struct {
 	// Set = resolve from discovery provider.
 	Resolve string `mapstructure:"resolve" json:"resolve"`
 
-	// AccessKey is the AWS access key ID.
-	AccessKey string `mapstructure:"access_key" json:"access_key"`
+	// AccessKeyID is the AWS access key ID.
+	AccessKeyID string `mapstructure:"access_key_id" json:"access_key_id"`
 
-	// SecretKey is the AWS secret access key.
-	SecretKey string `mapstructure:"secret_key" json:"secret_key"`
+	// SecretAccessKey is the AWS secret access key.
+	SecretAccessKey string `mapstructure:"secret_access_key" json:"secret_access_key"`
 
 	// ForcePathStyle forces path-style URLs instead of virtual-hosted-style.
 	ForcePathStyle bool `mapstructure:"force_path_style" json:"force_path_style"`

--- a/storage/s3/objectops.go
+++ b/storage/s3/objectops.go
@@ -1,0 +1,138 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+// Head returns metadata for a single S3 object via HeadObject. Metadata is
+// populated from the object's user metadata and Checksum from an explicit,
+// algorithm-tagged S3 content checksum when present. The object's ETag is
+// deliberately not used as a checksum: it is not a guaranteed content hash (for
+// example single-part SSE-KMS/SSE-C objects carry a non-MD5 ETag).
+func (s *Storage) Head(ctx context.Context, path string) (storage.FileInfo, error) {
+	out, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket:       aws.String(s.bucket),
+		Key:          aws.String(path),
+		ChecksumMode: s3types.ChecksumModeEnabled,
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return storage.FileInfo{}, storage.NotFoundError(path)
+		}
+		return storage.FileInfo{}, fmt.Errorf("storage: s3 head: %w", err)
+	}
+	fi := storage.FileInfo{
+		Path:        path,
+		Size:        aws.ToInt64(out.ContentLength),
+		ContentType: aws.ToString(out.ContentType),
+		Checksum:    headChecksum(out),
+	}
+	if out.LastModified != nil {
+		fi.LastModified = *out.LastModified
+	}
+	if len(out.Metadata) > 0 {
+		fi.Metadata = make(map[string]string, len(out.Metadata))
+		for k, v := range out.Metadata {
+			fi.Metadata[k] = v
+		}
+	}
+	return fi, nil
+}
+
+// headChecksum renders an explicit S3 content checksum as an algorithm-tagged
+// value (e.g. "sha256:<base64>"), preferring the strongest available algorithm.
+// It returns "" when the object carries no explicit content checksum.
+func headChecksum(out *awss3.HeadObjectOutput) string {
+	switch {
+	case out.ChecksumSHA256 != nil:
+		return "sha256:" + aws.ToString(out.ChecksumSHA256)
+	case out.ChecksumSHA1 != nil:
+		return "sha1:" + aws.ToString(out.ChecksumSHA1)
+	case out.ChecksumCRC32C != nil:
+		return "crc32c:" + aws.ToString(out.ChecksumCRC32C)
+	case out.ChecksumCRC32 != nil:
+		return "crc32:" + aws.ToString(out.ChecksumCRC32)
+	default:
+		return ""
+	}
+}
+
+// isNotFound reports whether err is S3's object-not-found condition. It matches
+// the typed HeadObject NotFound and GetObject/CopyObject NoSuchKey errors, and
+// falls back to any 404 response so Download and Copy translate a missing key
+// even when the SDK surfaces it as a generic response error.
+func isNotFound(err error) bool {
+	var nf *s3types.NotFound
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nf) || errors.As(err, &nsk) {
+		return true
+	}
+	var re *awshttp.ResponseError
+	return errors.As(err, &re) && re.HTTPStatusCode() == http.StatusNotFound
+}
+
+// Copy duplicates an object within the bucket using CopyObject.
+func (s *Storage) Copy(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Copy", srcPath, dstPath); err != nil {
+		return err
+	}
+	if err := s.copyObject(ctx, srcPath, dstPath); err != nil {
+		if isNotFound(err) {
+			return storage.NotFoundError(srcPath)
+		}
+		return fmt.Errorf("storage: s3 copy: %w", err)
+	}
+	return nil
+}
+
+// Rename moves an object within the bucket by copying then deleting the source.
+func (s *Storage) Rename(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Rename", srcPath, dstPath); err != nil {
+		return err
+	}
+	if err := s.copyObject(ctx, srcPath, dstPath); err != nil {
+		if isNotFound(err) {
+			return storage.NotFoundError(srcPath)
+		}
+		return fmt.Errorf("storage: s3 rename copy: %w", err)
+	}
+	if _, err := s.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(srcPath),
+	}); err != nil {
+		return fmt.Errorf("storage: s3 rename delete: %w", err)
+	}
+	return nil
+}
+
+// copyObject issues a server-side copy from srcPath to dstPath within the bucket.
+func (s *Storage) copyObject(ctx context.Context, srcPath, dstPath string) error {
+	_, err := s.client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket:     aws.String(s.bucket),
+		Key:        aws.String(dstPath),
+		CopySource: aws.String(copySource(s.bucket, srcPath)),
+	})
+	return err
+}
+
+// copySource builds a URL-encoded x-amz-copy-source value, escaping each path
+// segment while preserving the separators between the bucket and key.
+func copySource(bucket, key string) string {
+	segments := append([]string{bucket}, strings.Split(key, "/")...)
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return strings.Join(segments, "/")
+}

--- a/storage/s3/objectops_test.go
+++ b/storage/s3/objectops_test.go
@@ -1,0 +1,223 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+// newObjectServer returns a minimal S3-compatible fake supporting PUT (including
+// server-side copy), GET, HEAD, and DELETE against an in-memory object map.
+func newObjectServer(objects map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := strings.TrimPrefix(r.URL.Path, "/bucket/")
+		switch r.Method {
+		case http.MethodPut:
+			if src := r.Header.Get("x-amz-copy-source"); src != "" {
+				srcKey := strings.TrimPrefix(src, "bucket/")
+				body, ok := objects[srcKey]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				objects[key] = body
+				w.Header().Set("Content-Type", "application/xml")
+				_, _ = io.WriteString(w, `<CopyObjectResult><ETag>"abc"</ETag></CopyObjectResult>`)
+				return
+			}
+			b, _ := io.ReadAll(r.Body)
+			objects[key] = string(b)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			body, ok := objects[key]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = io.WriteString(w, body)
+		case http.MethodHead:
+			body, ok := objects[key]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("ETag", `"9a0364b9e99bb480dd25e1f0284c8555"`)
+			w.Header().Set("x-amz-checksum-sha256", "3q2+7w==")
+			w.Header().Set("x-amz-meta-owner", "team")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			delete(objects, key)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func TestHead_ReturnsMetadataAndChecksum(t *testing.T) {
+	t.Parallel()
+	objects := map[string]string{"dir/a.txt": "content"}
+	srv := newObjectServer(objects)
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	info, err := s.Head(context.Background(), "dir/a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Size != int64(len("content")) {
+		t.Errorf("Size = %d", info.Size)
+	}
+	if info.ContentType != "text/plain" {
+		t.Errorf("ContentType = %q", info.ContentType)
+	}
+	if info.Checksum != "sha256:3q2+7w==" {
+		t.Errorf("Checksum = %q, want the explicit S3 content checksum, not the ETag", info.Checksum)
+	}
+	if info.Metadata["owner"] != "team" {
+		t.Errorf("Metadata = %#v", info.Metadata)
+	}
+}
+
+func TestHead_MissingErrors(t *testing.T) {
+	t.Parallel()
+	srv := newObjectServer(map[string]string{})
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	_, err := s.Head(context.Background(), "absent")
+	if err == nil {
+		t.Fatal("Head for a missing object did not error")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Head error is not storage.ErrNotFound: %v", err)
+	}
+}
+
+func TestCopyRename_RejectSamePath(t *testing.T) {
+	t.Parallel()
+	srv := newObjectServer(map[string]string{"a.txt": "payload"})
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	if err := s.Copy(context.Background(), "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Copy same path = %v, want storage.ErrSameObject", err)
+	}
+	if err := s.Rename(context.Background(), "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Rename same path = %v, want storage.ErrSameObject", err)
+	}
+}
+
+func TestCopy_DuplicatesObject(t *testing.T) {
+	t.Parallel()
+	objects := map[string]string{"src.txt": "payload"}
+	srv := newObjectServer(objects)
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	if err := s.Copy(context.Background(), "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if objects["dst.txt"] != "payload" {
+		t.Fatalf("dst = %q", objects["dst.txt"])
+	}
+	if objects["src.txt"] != "payload" {
+		t.Fatalf("src removed: %q", objects["src.txt"])
+	}
+}
+
+func TestRename_MovesObject(t *testing.T) {
+	t.Parallel()
+	objects := map[string]string{"src.txt": "payload"}
+	srv := newObjectServer(objects)
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	if err := s.Rename(context.Background(), "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if objects["dst.txt"] != "payload" {
+		t.Fatalf("dst = %q", objects["dst.txt"])
+	}
+	if _, ok := objects["src.txt"]; ok {
+		t.Fatal("source still present after rename")
+	}
+}
+
+func TestHead_EnablesChecksumMode(t *testing.T) {
+	t.Parallel()
+	modeCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			select {
+			case modeCh <- r.Header.Get("x-amz-checksum-mode"):
+			default:
+			}
+			w.Header().Set("Content-Length", "7")
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	if _, err := s.Head(context.Background(), "dir/a.txt"); err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	select {
+	case mode := <-modeCh:
+		if mode != "ENABLED" {
+			t.Fatalf("HeadObject x-amz-checksum-mode = %q, want ENABLED", mode)
+		}
+	default:
+		t.Fatal("HeadObject request was not observed")
+	}
+}
+
+func TestDownload_MissingReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	srv := newObjectServer(map[string]string{})
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	_, err := s.Download(context.Background(), "absent")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Download of a missing object = %v, want storage.ErrNotFound", err)
+	}
+}
+
+func TestCopy_MissingSourceReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	srv := newObjectServer(map[string]string{})
+	defer srv.Close()
+
+	s := newTestStorage(t, srv.URL)
+	err := s.Copy(context.Background(), "absent", "dst.txt")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Copy of a missing source = %v, want storage.ErrNotFound", err)
+	}
+}
+
+func TestConfig_UsesAWSCredentialKeys(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Bucket:          "bucket",
+		Region:          DefaultRegion,
+		AccessKeyID:     "AKIA_TEST",
+		SecretAccessKey: "secret",
+	}
+	if _, err := NewStorage(context.Background(), cfg); err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+}

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -49,9 +49,9 @@ func NewStorage(ctx context.Context, cfg *Config) (*Storage, error) {
 		awsconfig.WithRegion(cfg.Region),
 	}
 
-	if cfg.AccessKey != "" && cfg.SecretKey != "" {
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
 		opts = append(opts, awsconfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, ""),
+			credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
 		))
 	}
 
@@ -96,6 +96,9 @@ func (s *Storage) Download(ctx context.Context, path string) (io.ReadCloser, err
 		Key:    aws.String(path),
 	})
 	if err != nil {
+		if isNotFound(err) {
+			return nil, storage.NotFoundError(path)
+		}
 		return nil, fmt.Errorf("storage: s3 download: %w", err)
 	}
 	return out.Body, nil

--- a/storage/s3/s3_test.go
+++ b/storage/s3/s3_test.go
@@ -18,12 +18,12 @@ import (
 func newTestStorage(t *testing.T, endpoint string) *Storage {
 	t.Helper()
 	cfg := &Config{
-		Bucket:         "bucket",
-		Region:         DefaultRegion,
-		Endpoint:       endpoint,
-		AccessKey:      "AKIA_TEST",
-		SecretKey:      "secret",
-		ForcePathStyle: true,
+		Bucket:          "bucket",
+		Region:          DefaultRegion,
+		Endpoint:        endpoint,
+		AccessKeyID:     "AKIA_TEST",
+		SecretAccessKey: "secret",
+		ForcePathStyle:  true,
 	}
 	s, err := NewStorage(context.Background(), cfg)
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -8,14 +8,6 @@ import (
 	"time"
 )
 
-// FileInfo contains metadata about a stored object.
-type FileInfo struct {
-	Path         string
-	Size         int64
-	LastModified time.Time
-	ContentType  string
-}
-
 // Storage defines the interface for object storage operations.
 type Storage interface {
 	// Upload writes data from reader to the given path.
@@ -36,6 +28,28 @@ type Storage interface {
 
 	// List returns metadata for all objects whose path starts with prefix.
 	List(ctx context.Context, prefix string) ([]FileInfo, error)
+}
+
+// HeadProvider is optionally implemented by storage backends that can return metadata for a single object more efficiently than scanning a listing. Use [Head] to call it with a listing-based fallback.
+type HeadProvider interface {
+	// Head returns metadata for the single object at path, including its size,
+	// last-modified time, content type, and any metadata or checksum the backend
+	// provides. It returns a not-found error when no object exists at path.
+	Head(ctx context.Context, path string) (FileInfo, error)
+}
+
+// CopyProvider is optionally implemented by storage backends that support a server-side copy within the store. Use [Copy] to call it with a streaming fallback.
+type CopyProvider interface {
+	// Copy duplicates the object at srcPath to dstPath within the store,
+	// leaving the source in place.
+	Copy(ctx context.Context, srcPath, dstPath string) error
+}
+
+// RenameProvider is optionally implemented by storage backends that support a server-side move within the store. Use [Rename] to call it with a copy-then-delete fallback.
+type RenameProvider interface {
+	// Rename moves the object at srcPath to dstPath within the store,
+	// removing the source once the destination is written.
+	Rename(ctx context.Context, srcPath, dstPath string) error
 }
 
 // SignedURLProvider is optionally implemented by storage backends that support generating time-limited signed URLs for private object access.

--- a/storage/supabase/objectops.go
+++ b/storage/supabase/objectops.go
@@ -1,0 +1,123 @@
+package supabase
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+// Head returns metadata for a single object using the Supabase object info endpoint.
+func (s *Storage) Head(ctx context.Context, path string) (storage.FileInfo, error) {
+	u := fmt.Sprintf("%s/object/info/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return storage.FileInfo{}, fmt.Errorf("storage: supabase create request: %w", err)
+	}
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return storage.FileInfo{}, fmt.Errorf("storage: supabase head: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Error on close is safe to ignore for read operations
+
+	if resp.StatusCode == http.StatusNotFound {
+		return storage.FileInfo{}, storage.NotFoundError(path)
+	}
+	if resp.StatusCode >= 400 {
+		body := readErrorBody(resp.Body)
+		return storage.FileInfo{}, fmt.Errorf("storage: supabase head failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var item objectInfo
+	if err := decodeJSONBody(resp.Body, &item); err != nil {
+		return storage.FileInfo{}, fmt.Errorf("storage: supabase decode response: %w", err)
+	}
+	return item.toFileInfo(path), nil
+}
+
+// Copy duplicates an object within the bucket using the Supabase copy endpoint.
+func (s *Storage) Copy(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Copy", srcPath, dstPath); err != nil {
+		return err
+	}
+	return s.objectOp(ctx, "copy", srcPath, dstPath)
+}
+
+// Rename moves an object within the bucket using the Supabase move endpoint.
+func (s *Storage) Rename(ctx context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Rename", srcPath, dstPath); err != nil {
+		return err
+	}
+	return s.objectOp(ctx, "move", srcPath, dstPath)
+}
+
+// objectOp issues a copy or move request against the Supabase storage API.
+func (s *Storage) objectOp(ctx context.Context, op, srcPath, dstPath string) error {
+	u := fmt.Sprintf("%s/object/%s", s.baseURL, op)
+	payload := map[string]string{
+		"bucketId":       s.bucket,
+		"sourceKey":      srcPath,
+		"destinationKey": dstPath,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("storage: supabase marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("storage: supabase create request: %w", err)
+	}
+	s.setHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("storage: supabase %s: %w", op, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Error on close is safe to ignore for read operations
+
+	if resp.StatusCode == http.StatusNotFound {
+		return storage.NotFoundError(srcPath)
+	}
+	if resp.StatusCode >= 400 {
+		respBody := readErrorBody(resp.Body)
+		return fmt.Errorf("storage: supabase %s failed (status %d): %s", op, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// objectInfo mirrors the object metadata returned by the Supabase info endpoint.
+type objectInfo struct {
+	Name     string `json:"name"`
+	Metadata struct {
+		Size        int64  `json:"size"`
+		ContentType string `json:"mimetype"`
+	} `json:"metadata"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// toFileInfo converts a decoded info response into a storage.FileInfo. The
+// Supabase eTag is not a guaranteed content hash, so it is not surfaced as a
+// Checksum; FileInfo.Checksum is left empty until a verified checksum is
+// available.
+func (o objectInfo) toFileInfo(path string) storage.FileInfo {
+	fi := storage.FileInfo{
+		Path:        path,
+		Size:        o.Metadata.Size,
+		ContentType: o.Metadata.ContentType,
+	}
+	if o.UpdatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, o.UpdatedAt); err == nil {
+			fi.LastModified = t
+		}
+	}
+	return fi
+}

--- a/storage/supabase/objectops_test.go
+++ b/storage/supabase/objectops_test.go
@@ -1,0 +1,202 @@
+package supabase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+func TestHeadReturnsMetadata(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertHeaderOnlyToken(t, r)
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.HasPrefix(r.URL.Path, "/storage/v1/object/info/bucket/") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"a.txt","metadata":{"size":5,"mimetype":"text/plain","eTag":"\"abc123\""},"updated_at":"2023-01-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	info, err := s.Head(context.Background(), "dir/a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Size != 5 || info.ContentType != "text/plain" {
+		t.Fatalf("info = %#v", info)
+	}
+	if info.Checksum != "" {
+		t.Errorf("Checksum = %q, want empty: the Supabase eTag is not a verified content hash", info.Checksum)
+	}
+	if info.LastModified.IsZero() {
+		t.Error("expected parsed LastModified")
+	}
+}
+
+func TestHeadNotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	_, err := s.Head(context.Background(), "absent")
+	if err == nil {
+		t.Fatal("Head for a missing object did not error")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Head error is not storage.ErrNotFound: %v", err)
+	}
+}
+
+func TestHeadRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A single JSON string value larger than the metadata decode limit must
+		// be rejected rather than read unbounded into memory.
+		_, _ = io.WriteString(w, `{"name":"`)
+		_, _ = io.WriteString(w, strings.Repeat("a", maxMetadataBodyBytes+(1<<20)))
+		_, _ = io.WriteString(w, `","metadata":{"size":1}}`)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if _, err := s.Head(context.Background(), "dir/a.txt"); err == nil {
+		t.Fatal("Head must reject a response body exceeding the metadata decode limit")
+	}
+}
+
+func TestCopyRenameRejectSamePath(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("same-path op must not issue a request, got %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if err := s.Copy(context.Background(), "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Copy same path = %v, want storage.ErrSameObject", err)
+	}
+	if err := s.Rename(context.Background(), "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Rename same path = %v, want storage.ErrSameObject", err)
+	}
+}
+
+func TestCopyPostsToCopyEndpoint(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	var body map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertHeaderOnlyToken(t, r)
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if err := s.Copy(context.Background(), "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if gotPath != "/storage/v1/object/copy" {
+		t.Errorf("path = %s", gotPath)
+	}
+	if body["bucketId"] != "bucket" || body["sourceKey"] != "src.txt" || body["destinationKey"] != "dst.txt" {
+		t.Errorf("body = %#v", body)
+	}
+}
+
+func TestRenamePostsToMoveEndpoint(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertHeaderOnlyToken(t, r)
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if err := s.Rename(context.Background(), "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if gotPath != "/storage/v1/object/move" {
+		t.Errorf("path = %s", gotPath)
+	}
+}
+
+func TestObjectOpFailureErrors(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if err := s.Copy(context.Background(), "a", "b"); err == nil {
+		t.Fatal("expected copy error")
+	}
+}
+
+func TestEscapeObjectPathEncodesDotSegments(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"a/./b":   "a/%2E/b",
+		"a/../b":  "a/%2E%2E/b",
+		"../x":    "%2E%2E/x",
+		"a/b.txt": "a/b.txt",
+		"a b":     "a%20b",
+	}
+	for in, want := range cases {
+		if got := escapeObjectPath(in); got != want {
+			t.Errorf("escapeObjectPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestObjectPathsAreEscaped(t *testing.T) {
+	t.Parallel()
+
+	const key = "dir/a b?admin=1#frag.txt"
+	var gotPath, gotQuery, gotFragment string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery, gotFragment = r.URL.Path, r.URL.RawQuery, r.URL.Fragment
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"a.txt","metadata":{"size":1}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestStorage(t, srv)
+	if _, err := s.Head(context.Background(), key); err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if want := "/storage/v1/object/info/bucket/" + key; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if gotQuery != "" || gotFragment != "" {
+		t.Errorf("key injected query %q / fragment %q into the request target", gotQuery, gotFragment)
+	}
+
+	url, err := s.URL(context.Background(), key)
+	if err != nil {
+		t.Fatalf("URL: %v", err)
+	}
+	if strings.Contains(url, "?") || strings.Contains(url, "#") {
+		t.Errorf("public URL = %q, want the key percent-encoded", url)
+	}
+}

--- a/storage/supabase/supabase.go
+++ b/storage/supabase/supabase.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -19,11 +20,43 @@ import (
 // diagnostics, so a misbehaving or hostile endpoint cannot exhaust memory.
 const maxErrorBodyBytes = 8 << 10
 
+// maxMetadataBodyBytes bounds how much of a success response body is decoded for
+// object metadata (info, list, and signed-URL responses), so a misconfigured or
+// hostile endpoint cannot force unbounded memory consumption.
+const maxMetadataBodyBytes = 1 << 20
+
 // readErrorBody reads at most [maxErrorBodyBytes] from a response body for use
 // in an error message.
 func readErrorBody(r io.Reader) []byte {
 	b, _ := io.ReadAll(io.LimitReader(r, maxErrorBodyBytes))
 	return b
+}
+
+// decodeJSONBody decodes at most [maxMetadataBodyBytes] of r into v. A response
+// whose JSON is not complete within the limit is rejected with a decode error
+// rather than read unbounded.
+func decodeJSONBody(r io.Reader, v any) error {
+	return json.NewDecoder(io.LimitReader(r, maxMetadataBodyBytes)).Decode(v)
+}
+
+// escapeObjectPath percent-encodes each segment of an object key so a caller-supplied
+// key cannot inject query parameters, fragments, or extra path elements into the
+// request target. Dot-only segments ("." and "..") are encoded explicitly so an
+// intermediary or router cannot normalize them to address a different object.
+// Separators between segments are preserved.
+func escapeObjectPath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		switch seg {
+		case ".":
+			segments[i] = "%2E"
+		case "..":
+			segments[i] = "%2E%2E"
+		default:
+			segments[i] = url.PathEscape(seg)
+		}
+	}
+	return strings.Join(segments, "/")
 }
 
 // Register registers a configured Supabase storage provider into the given registry.
@@ -81,7 +114,7 @@ func NewStorage(cfg *Config) (*Storage, error) {
 
 // Upload writes data from reader to Supabase storage.
 func (s *Storage) Upload(ctx context.Context, path string, reader io.Reader) error {
-	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, path)
+	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, reader)
 	if err != nil {
@@ -106,7 +139,7 @@ func (s *Storage) Upload(ctx context.Context, path string, reader io.Reader) err
 
 // Download returns a reader for the object at the given path.
 func (s *Storage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
-	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, path)
+	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {
@@ -121,7 +154,7 @@ func (s *Storage) Download(ctx context.Context, path string) (io.ReadCloser, err
 
 	if resp.StatusCode == http.StatusNotFound {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("storage: file not found: %s", path)
+		return nil, storage.NotFoundError(path)
 	}
 	if resp.StatusCode >= 400 {
 		body := readErrorBody(resp.Body)
@@ -133,7 +166,7 @@ func (s *Storage) Download(ctx context.Context, path string) (io.ReadCloser, err
 
 // Delete removes an object. Returns nil if the object does not exist.
 func (s *Storage) Delete(ctx context.Context, path string) error {
-	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, path)
+	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, http.NoBody)
 	if err != nil {
@@ -156,7 +189,7 @@ func (s *Storage) Delete(ctx context.Context, path string) error {
 
 // Exists checks whether an object exists.
 func (s *Storage) Exists(ctx context.Context, path string) (bool, error) {
-	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, path)
+	u := fmt.Sprintf("%s/object/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u, http.NoBody)
 	if err != nil {
@@ -181,7 +214,7 @@ func (s *Storage) Exists(ctx context.Context, path string) (bool, error) {
 
 // URL returns a public URL for the object.
 func (s *Storage) URL(_ context.Context, path string) (string, error) {
-	return fmt.Sprintf("%s/object/public/%s/%s", s.baseURL, s.bucket, path), nil
+	return fmt.Sprintf("%s/object/public/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path)), nil
 }
 
 // List returns metadata for all objects whose path starts with prefix.
@@ -238,7 +271,7 @@ func (s *Storage) List(ctx context.Context, prefix string) ([]storage.FileInfo, 
 		} `json:"metadata"`
 		UpdatedAt string `json:"updated_at"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+	if err := decodeJSONBody(resp.Body, &items); err != nil {
 		return nil, fmt.Errorf("storage: supabase decode response: %w", err)
 	}
 
@@ -270,7 +303,7 @@ func (s *Storage) setHeaders(req *http.Request) {
 
 // SignedURL returns a pre-signed URL valid for the specified duration.
 func (s *Storage) SignedURL(ctx context.Context, path string, expiry time.Duration) (string, error) {
-	u := fmt.Sprintf("%s/object/sign/%s/%s", s.baseURL, s.bucket, path)
+	u := fmt.Sprintf("%s/object/sign/%s/%s", s.baseURL, s.bucket, escapeObjectPath(path))
 
 	body := fmt.Sprintf(`{"expiresIn": %d}`, int(expiry.Seconds()))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(body))
@@ -294,7 +327,7 @@ func (s *Storage) SignedURL(ctx context.Context, path string, expiry time.Durati
 	var result struct {
 		SignedURL string `json:"signedURL"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := decodeJSONBody(resp.Body, &result); err != nil {
 		return "", fmt.Errorf("storage: supabase decode sign response: %w", err)
 	}
 

--- a/storage/testutil/component.go
+++ b/storage/testutil/component.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"sort"
@@ -20,6 +22,8 @@ type memFile struct {
 	data        []byte
 	contentType string
 	modTime     time.Time
+	checksum    string
+	metadata    map[string]string
 }
 
 // Component is a test storage component backed by an in-memory map.
@@ -103,9 +107,7 @@ func (c *Component) Snapshot(_ context.Context) (any, error) {
 	}
 	snap := make(map[string]*memFile, len(c.files))
 	for k, v := range c.files {
-		cp := *v
-		cp.data = append([]byte(nil), v.data...)
-		snap[k] = &cp
+		snap[k] = v.clone()
 	}
 	return snap, nil
 }
@@ -122,9 +124,7 @@ func (c *Component) Restore(_ context.Context, snap any) error {
 	}
 	c.files = make(map[string]*memFile, len(s))
 	for k, v := range s {
-		cp := *v
-		cp.data = append([]byte(nil), v.data...)
-		c.files[k] = &cp
+		c.files[k] = v.clone()
 	}
 	return nil
 }
@@ -138,7 +138,12 @@ func (c *Component) Upload(_ context.Context, path string, reader io.Reader) err
 	if err != nil {
 		return fmt.Errorf("read upload data: %w", err)
 	}
-	c.files[path] = &memFile{data: data, modTime: time.Now()}
+	sum := sha256.Sum256(data)
+	c.files[path] = &memFile{
+		data:     data,
+		modTime:  time.Now(),
+		checksum: hex.EncodeToString(sum[:]),
+	}
 	return nil
 }
 
@@ -147,7 +152,7 @@ func (c *Component) Download(_ context.Context, path string) (io.ReadCloser, err
 	defer c.mu.RUnlock()
 	f, ok := c.files[path]
 	if !ok {
-		return nil, fmt.Errorf("file not found: %s", path)
+		return nil, storage.NotFoundError(path)
 	}
 	return io.NopCloser(bytes.NewReader(f.data)), nil
 }
@@ -176,14 +181,82 @@ func (c *Component) List(_ context.Context, prefix string) ([]storage.FileInfo, 
 	var result []storage.FileInfo
 	for path, f := range c.files {
 		if strings.HasPrefix(path, prefix) {
-			result = append(result, storage.FileInfo{
-				Path:         path,
-				Size:         int64(len(f.data)),
-				LastModified: f.modTime,
-				ContentType:  f.contentType,
-			})
+			result = append(result, f.toFileInfo(path))
 		}
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
 	return result, nil
+}
+
+// Head returns metadata for the object at path, including its sha256 checksum.
+func (c *Component) Head(_ context.Context, path string) (storage.FileInfo, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	f, ok := c.files[path]
+	if !ok {
+		return storage.FileInfo{}, storage.NotFoundError(path)
+	}
+	return f.toFileInfo(path), nil
+}
+
+// Copy duplicates the object at srcPath to dstPath, leaving the source in place.
+func (c *Component) Copy(_ context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Copy", srcPath, dstPath); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	src, ok := c.files[srcPath]
+	if !ok {
+		return storage.NotFoundError(srcPath)
+	}
+	c.files[dstPath] = src.clone()
+	return nil
+}
+
+// Rename moves the object at srcPath to dstPath, removing the source.
+func (c *Component) Rename(_ context.Context, srcPath, dstPath string) error {
+	if err := storage.CheckDistinctPaths("Rename", srcPath, dstPath); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	src, ok := c.files[srcPath]
+	if !ok {
+		return storage.NotFoundError(srcPath)
+	}
+	c.files[dstPath] = src.clone()
+	delete(c.files, srcPath)
+	return nil
+}
+
+// toFileInfo renders the stored file's metadata as a storage.FileInfo.
+func (f *memFile) toFileInfo(path string) storage.FileInfo {
+	fi := storage.FileInfo{
+		Path:         path,
+		Size:         int64(len(f.data)),
+		LastModified: f.modTime,
+		ContentType:  f.contentType,
+		Checksum:     f.checksum,
+	}
+	if len(f.metadata) > 0 {
+		fi.Metadata = make(map[string]string, len(f.metadata))
+		for k, v := range f.metadata {
+			fi.Metadata[k] = v
+		}
+	}
+	return fi
+}
+
+// clone returns a deep copy of the stored file.
+func (f *memFile) clone() *memFile {
+	cp := *f
+	cp.data = append([]byte(nil), f.data...)
+	if len(f.metadata) > 0 {
+		cp.metadata = make(map[string]string, len(f.metadata))
+		for k, v := range f.metadata {
+			cp.metadata[k] = v
+		}
+	}
+	return &cp
 }

--- a/storage/testutil/objectops_test.go
+++ b/storage/testutil/objectops_test.go
@@ -1,0 +1,149 @@
+package testutil
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kbukum/gokit/storage"
+)
+
+func startComponent(t *testing.T) (*Component, context.Context) {
+	t.Helper()
+	comp := NewComponent()
+	ctx := context.Background()
+	if err := comp.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = comp.Stop(ctx) })
+	return comp, ctx
+}
+
+func TestComponent_HeadReturnsMetadataAndChecksum(t *testing.T) {
+	comp, ctx := startComponent(t)
+	const payload = "hello world"
+	if err := comp.Upload(ctx, "a.txt", strings.NewReader(payload)); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+
+	info, err := comp.Head(ctx, "a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if info.Size != int64(len(payload)) {
+		t.Errorf("Size = %d, want %d", info.Size, len(payload))
+	}
+	sum := sha256.Sum256([]byte(payload))
+	if want := hex.EncodeToString(sum[:]); info.Checksum != want {
+		t.Errorf("Checksum = %q, want %q", info.Checksum, want)
+	}
+}
+
+func TestComponent_HeadMissingErrors(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if _, err := comp.Head(ctx, "absent"); err == nil {
+		t.Fatal("Head for a missing object did not error")
+	}
+}
+
+func TestComponent_ChecksumIsStable(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	first, err := comp.Head(ctx, "a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if err := comp.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("re-Upload: %v", err)
+	}
+	second, err := comp.Head(ctx, "a.txt")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if first.Checksum == "" || first.Checksum != second.Checksum {
+		t.Fatalf("checksum not stable: %q vs %q", first.Checksum, second.Checksum)
+	}
+}
+
+func TestComponent_CopyDuplicatesAndKeepsSource(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Upload(ctx, "src.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := comp.Copy(ctx, "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	assertContent(t, comp, ctx, "dst.txt", "payload")
+	assertContent(t, comp, ctx, "src.txt", "payload")
+}
+
+func TestComponent_CopyMissingSourceErrors(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Copy(ctx, "absent", "dst"); err == nil {
+		t.Fatal("Copy of a missing source did not error")
+	}
+}
+
+func TestComponent_RenameMovesAndRemovesSource(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Upload(ctx, "src.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := comp.Rename(ctx, "src.txt", "dst.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	assertContent(t, comp, ctx, "dst.txt", "payload")
+	if ok, err := comp.Exists(ctx, "src.txt"); err != nil || ok {
+		t.Fatalf("source still present: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestComponent_RenameMissingSourceErrors(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Rename(ctx, "absent", "dst"); err == nil {
+		t.Fatal("Rename of a missing source did not error")
+	}
+}
+
+func TestComponent_MissingReturnsErrNotFound(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if _, err := comp.Head(ctx, "absent"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("Head error is not storage.ErrNotFound: %v", err)
+	}
+}
+
+func TestComponent_CopyRenameRejectSamePath(t *testing.T) {
+	comp, ctx := startComponent(t)
+	if err := comp.Upload(ctx, "a.txt", strings.NewReader("payload")); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if err := comp.Copy(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Copy same path = %v, want storage.ErrSameObject", err)
+	}
+	if err := comp.Rename(ctx, "a.txt", "a.txt"); !errors.Is(err, storage.ErrSameObject) {
+		t.Errorf("Rename same path = %v, want storage.ErrSameObject", err)
+	}
+	assertContent(t, comp, ctx, "a.txt", "payload")
+}
+
+func assertContent(t *testing.T, comp *Component, ctx context.Context, path, want string) {
+	t.Helper()
+	rc, err := comp.Download(ctx, path)
+	if err != nil {
+		t.Fatalf("Download %q: %v", path, err)
+	}
+	defer func() { _ = rc.Close() }()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll %q: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content of %q = %q, want %q", path, got, want)
+	}
+}

--- a/storage/transfer.go
+++ b/storage/transfer.go
@@ -1,42 +1,10 @@
-// Cross-store helpers: single-object Stat and streaming Transfer.
+// Cross-store helper: streaming Transfer between stores.
 package storage
 
 import (
 	"context"
 	"fmt"
 )
-
-// StatProvider is optionally implemented by storage backends that can return
-// metadata for a single object more efficiently than scanning a listing.
-type StatProvider interface {
-	// Stat returns metadata for the object at path.
-	Stat(ctx context.Context, path string) (FileInfo, error)
-}
-
-// Stat returns metadata for a single object. Backends that implement
-// [StatProvider] answer directly; otherwise Stat falls back to an exact-path
-// match within List, so it works against any [Storage].
-func Stat(ctx context.Context, s Storage, path string) (FileInfo, error) {
-	if s == nil {
-		return FileInfo{}, fmt.Errorf("storage: Stat requires a non-nil store")
-	}
-	if path == "" {
-		return FileInfo{}, fmt.Errorf("storage: Stat requires a non-empty path")
-	}
-	if sp, ok := s.(StatProvider); ok {
-		return sp.Stat(ctx, path)
-	}
-	infos, err := s.List(ctx, path)
-	if err != nil {
-		return FileInfo{}, fmt.Errorf("storage: Stat list %q: %w", path, err)
-	}
-	for _, info := range infos {
-		if info.Path == path {
-			return info, nil
-		}
-	}
-	return FileInfo{}, fmt.Errorf("storage: object not found: %s", path)
-}
 
 // Transfer streams the object at srcPath in src to dstPath in dst. It downloads
 // and uploads without buffering the whole object in memory, so it works across

--- a/storage/transfer_test.go
+++ b/storage/transfer_test.go
@@ -14,7 +14,6 @@ import (
 var errMissing = errors.New("object not found")
 
 // mapStore is a minimal in-memory Storage used to exercise cross-store helpers.
-// It deliberately does not implement StatProvider.
 type mapStore struct {
 	mu    sync.Mutex
 	files map[string][]byte
@@ -22,13 +21,6 @@ type mapStore struct {
 
 func newMapStore() *mapStore {
 	return &mapStore{files: map[string][]byte{}}
-}
-
-// statStore is a mapStore that also implements StatProvider.
-type statStore struct{ *mapStore }
-
-func newStatStore() statStore {
-	return statStore{newMapStore()}
 }
 
 func (m *mapStore) Upload(_ context.Context, path string, reader io.Reader) error {
@@ -81,14 +73,37 @@ func (m *mapStore) List(_ context.Context, prefix string) ([]FileInfo, error) {
 	return out, nil
 }
 
-func (m statStore) Stat(_ context.Context, path string) (FileInfo, error) {
+func (m *mapStore) Head(_ context.Context, path string) (FileInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	data, ok := m.files[path]
 	if !ok {
-		return FileInfo{}, errMissing
+		return FileInfo{}, NotFoundError(path)
 	}
 	return FileInfo{Path: path, Size: int64(len(data)), ContentType: "application/octet-stream"}, nil
+}
+
+func (m *mapStore) Copy(_ context.Context, srcPath, dstPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.files[srcPath]
+	if !ok {
+		return errMissing
+	}
+	m.files[dstPath] = append([]byte(nil), data...)
+	return nil
+}
+
+func (m *mapStore) Rename(_ context.Context, srcPath, dstPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.files[srcPath]
+	if !ok {
+		return errMissing
+	}
+	m.files[dstPath] = append([]byte(nil), data...)
+	delete(m.files, srcPath)
+	return nil
 }
 
 func TestTransferCopiesBytesBetweenStores(t *testing.T) {
@@ -141,47 +156,5 @@ func TestTransferValidatesArguments(t *testing.T) {
 		if err := Transfer(ctx, tc.src, tc.srcPath, tc.dst, tc.dstPath); err == nil {
 			t.Errorf("%s: Transfer did not error", name)
 		}
-	}
-}
-
-func TestStatUsesStatProviderWhenAvailable(t *testing.T) {
-	t.Parallel()
-
-	s := newStatStore()
-	ctx := context.Background()
-	if err := s.Upload(ctx, "a.txt", bytes.NewReader([]byte("hi"))); err != nil {
-		t.Fatalf("upload: %v", err)
-	}
-	info, err := Stat(ctx, s, "a.txt")
-	if err != nil {
-		t.Fatalf("Stat: %v", err)
-	}
-	if info.ContentType != "application/octet-stream" {
-		t.Fatalf("Stat did not use StatProvider (ContentType = %q)", info.ContentType)
-	}
-}
-
-func TestStatFallsBackToList(t *testing.T) {
-	t.Parallel()
-
-	s := newMapStore() // no StatProvider
-	ctx := context.Background()
-	if err := s.Upload(ctx, "dir/a.txt", bytes.NewReader([]byte("data"))); err != nil {
-		t.Fatalf("upload: %v", err)
-	}
-	info, err := Stat(ctx, s, "dir/a.txt")
-	if err != nil {
-		t.Fatalf("Stat fallback: %v", err)
-	}
-	if info.Size != 4 {
-		t.Fatalf("Stat fallback Size = %d, want 4", info.Size)
-	}
-}
-
-func TestStatNotFound(t *testing.T) {
-	t.Parallel()
-
-	if _, err := Stat(context.Background(), newMapStore(), "absent"); err == nil {
-		t.Fatal("Stat for a missing object did not error")
 	}
 }

--- a/util/files.go
+++ b/util/files.go
@@ -13,6 +13,8 @@ import (
 // Both src and dst are resolved through symlinks (os.Stat / os.Open follow symlinks),
 // so if src is a symlink its target's content is copied;
 // if dst is an existing symlink the link target is overwritten.
+// It returns an error without modifying anything when src and dst resolve to the
+// same file (via os.SameFile), so a self-copy cannot truncate the source.
 // Use CopyDir to copy directory trees (symlinks inside are recreated as symlinks, not followed).
 // Parent directories of dst are created as needed.
 func CopyFile(src, dst string) error {
@@ -22,6 +24,13 @@ func CopyFile(src, dst string) error {
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("source is not a regular file: %s", src)
+	}
+	// Reject copying a file onto itself before opening the destination with
+	// O_TRUNC, which would otherwise erase the source content. os.SameFile
+	// catches path aliases (e.g. "a" and "./a"), symlinks, and hard links that
+	// a string comparison of src and dst would miss.
+	if dstInfo, statErr := os.Stat(dst); statErr == nil && os.SameFile(info, dstInfo) {
+		return fmt.Errorf("source and destination are the same file: %s", src)
 	}
 	if ensureErr := EnsureDir(filepath.Dir(dst)); ensureErr != nil {
 		return ensureErr

--- a/util/files_test.go
+++ b/util/files_test.go
@@ -154,6 +154,33 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
+func TestCopyFileRejectsSameFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(src, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("WriteFile(src) failed: %v", err)
+	}
+
+	if err := CopyFile(src, src); err == nil {
+		t.Fatal("CopyFile onto the same path must be rejected")
+	}
+	// An aliased destination ("dir/./a.txt") resolves to the same file and must
+	// also be rejected before the source is truncated.
+	if err := CopyFile(src, filepath.Join(dir, ".", "a.txt")); err == nil {
+		t.Fatal("CopyFile onto an alias of the source must be rejected")
+	}
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("ReadFile(src) failed: %v", err)
+	}
+	if !bytes.Equal(data, []byte("keep")) {
+		t.Fatalf("source content = %q, want %q (a rejected self-copy must not truncate)", data, "keep")
+	}
+}
+
 func TestCopyDir(t *testing.T) {
 	t.Parallel()
 

--- a/vectorstore/filter_test.go
+++ b/vectorstore/filter_test.go
@@ -1,0 +1,52 @@
+package vectorstore
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFilterConditionJSONShape(t *testing.T) {
+	t.Parallel()
+
+	cond := FilterCondition{Field: "status", Value: "active"}
+	data, err := json.Marshal(cond)
+	if err != nil {
+		t.Fatalf("marshal FilterCondition: %v", err)
+	}
+
+	const want = `{"field":"status","equals":"active"}`
+	if got := string(data); got != want {
+		t.Fatalf("FilterCondition JSON = %s, want %s", got, want)
+	}
+}
+
+func TestSearchFilterJSONShape(t *testing.T) {
+	t.Parallel()
+
+	f := NewSearchFilter().MustMatch("status", "active")
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal SearchFilter: %v", err)
+	}
+
+	const want = `{"must":[{"field":"status","equals":"active"}]}`
+	if got := string(data); got != want {
+		t.Fatalf("SearchFilter JSON = %s, want %s", got, want)
+	}
+}
+
+func TestFilterConditionJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const wire = `{"field":"score","equals":42}`
+	var cond FilterCondition
+	if err := json.Unmarshal([]byte(wire), &cond); err != nil {
+		t.Fatalf("unmarshal FilterCondition: %v", err)
+	}
+	if cond.Field != "score" {
+		t.Errorf("Field = %q, want %q", cond.Field, "score")
+	}
+	if got, ok := cond.Value.(float64); !ok || got != 42 {
+		t.Errorf("Value = %v (%T), want 42", cond.Value, cond.Value)
+	}
+}

--- a/vectorstore/store.go
+++ b/vectorstore/store.go
@@ -102,13 +102,13 @@ type SearchResult struct {
 // Value is a JSON-representable payload value (the documented opaque exception);
 // backends restrict it to supported scalar types where required.
 type FilterCondition struct {
-	Field string
-	Value any
+	Field string `json:"field"`
+	Value any    `json:"equals"`
 }
 
 // SearchFilter represents optional filters for search queries.
 type SearchFilter struct {
-	Must []FilterCondition
+	Must []FilterCondition `json:"must"`
 }
 
 // NewSearchFilter creates a new empty SearchFilter.


### PR DESCRIPTION
## Description

Aligns auth, authz, messaging, storage, and vectorstore wire contracts across the gokit/rskit kits so serialized shapes match on both sides, and rounds out the storage object API with portable single-object operations. This is a pre-stable breaking change: it renames on-the-wire fields and reshapes serialized boundaries rather than layering compatibility shims.

## Motivation

Cross-kit interoperability requires the two kits to agree on serialized field names and decision shapes. Several contracts had drifted (OIDC `redirect_url`, messaging envelope `body`, non-standard S3 credential keys, untagged authz decisions and vectorstore filters), which breaks the wire when a gokit service talks to an rskit peer. This change makes the contracts authoritative and standards-aligned.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Module(s) Affected

- auth (oidc)
- authz
- messaging
- storage (local, gcs, s3, supabase)
- vectorstore
- cache, bench (test coverage)

## Changes Made

- **auth/oidc**: rename `redirect_url` to `redirect_uri`.
- **authz**: add a serialized decision boundary (`Allow` / `Deny` / `RequiresHumanApproval`) with snake_case engine tags.
- **messaging**: switch the envelope body field to `payload`.
- **vectorstore**: tag `FilterCondition` as `field` / `equals`.
- **storage/s3**: adopt AWS-standard credential keys.
- **storage**: add single-object `Head`, `Copy`, and `Rename` as opt-in capability interfaces with portable package-level fallbacks; `FileInfo` carries backend metadata and checksums.
- **storage/supabase**: percent-encode object keys per segment so a key cannot inject query parameters or fragments into the request target.

## Testing

- [ ] `make test` (or `make test M=<module>` / `make test-affected`) passes locally
- [ ] `make lint` is clean (includes `vet` + `depguard` layering)
- [ ] `make fmt` reports no diffs (`gofmt -s`)
- [ ] `govulncheck ./...` passes for the affected module(s)
- [ ] `make check-<domain>` passes for the affected domain
- [ ] Manual testing performed (describe below if applicable)

## Breaking Changes

Serialized field renames and reshaped boundaries: OIDC `redirect_url` → `redirect_uri`, messaging envelope `body` → `payload`, S3 credential keys switched to AWS-standard names, authz decisions and vectorstore filters now carry explicit tags. Pre-stable, so consumers move to the new contract directly; no compatibility shim is provided.

## Sibling Parity

- [x] Sibling-parity tracked: aligns wire contracts with https://github.com/kbukum/rskit

## Checklist

- [x] Code follows the coding standards in CONTRIBUTING.md
- [x] Behavior was developed test-first; new/changed behavior has tests (failure paths included)
- [x] No public `interface{}`/`any` (generics/typed); documented exceptions only
- [x] No `panic`/`log.Fatal`/ignored errors/unchecked type assertions on runtime paths
- [x] Dependencies (logger/tracer/policies/registries) injected — no globals or `init()` side effects
- [x] Code split by concern into focused files — not piled into one file
- [x] Exported items have godoc; each package has a `doc.go`; docs updated

## Additional Notes

Adds new storage object operations (`objectops.go`, `fileinfo.go`) with per-adapter implementations and matching `testutil` coverage.
