### PR TITLE
docs(skills): raise the engineering-baseline bar for reviews and plans

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ Shared engineering baseline — apply to all work here:
 
 - **Phases:** discover → decide (Redesign / Align / Enhance / Drop / Leave) → implement completely → validate.
   Prefer root-cause redesign over symptom patches; no compatibility shims in pre-stable code.
+  Implement the *simplest* design that fully solves it — flexible, extensible, and scalable — on current idiomatic best practices, not folklore; complexity must earn its place.
 - **Layering & reuse:** explicit, acyclic dependency direction —
   lower layers never import higher (enforced by `depguard`). Reuse
   or enhance the canonical owner before writing new code;
@@ -30,7 +31,8 @@ Shared engineering baseline — apply to all work here:
 - **Composition:** explicit injected registries and config-driven selection;
   no `init()` side effects, no mutable package-global registries;
   inject logger / tracer / policies rather than reaching for globals.
-- **Tests:** behavioral and deterministic; green under `-race -shuffle=on -count=1`;
+- **Tests:** behavioral and deterministic; **test-first** (failing test → minimal code → refactor while green);
+  green under `-race -shuffle=on -count=1`;
   cover failure paths; injected clocks (never `time.Sleep`); fixtures over embedded config;
   regression-test every fix.
 - **AI / model features:** treat model output and retrieved context as untrusted;
@@ -45,7 +47,7 @@ Shared engineering baseline — apply to all work here:
 Standing,
 re-runnable development skills encoding this baseline live in [`.github/skills/`](skills/README.md)
 — the `review` skill runs the review passes in a fresh, clean-context agent after every change set
-and before releases; `create-branch`, `create-plan`, `apply-plan`, `apply-step`, `create-pr`,
+and before releases (reviewing the change's **blast radius** — surrounding and related code, not just the diff — and reporting/fixing the pre-existing problems it surfaces, redesign over patch); `create-branch`, `create-plan`, `apply-plan`, `apply-step`, `create-pr`,
 `validate`, `new-module`, `new-backend`, `parity`, and `release` cover the rest of the workflow.
 Validation is driven through `toven` (see `toven.toml`).
 

--- a/.github/skills/apply-step/SKILL.md
+++ b/.github/skills/apply-step/SKILL.md
@@ -33,6 +33,7 @@ Apply the current step's actions **test-first**, honoring gokit's engineering ba
 
 - **TDD.** For each behavior: failing test → minimal code → refactor while green,
   failure paths included. Never write the production code first and add tests after.
+- **Best-practices bar.** Deliver the *simplest* design that fully solves the step — simple, not shortsighted: keep it flexible and extensible (small typed seams / functional options over rigid or speculative abstraction) and scalable (bounded resources, no accidental O(n²) or unbounded buffering). Use current, idiomatic Go — the right implementation for today's stdlib/spec/security guidance, not folklore. Complexity must earn its place; if a simpler correct design exists, take it and delete the rest.
 - **Placement & layering.** Right module (root vs sub-module vs nested adapter);
   acyclic imports (lower layers never import higher); new packages get `doc.go`.
 - **Canonical reuse.** Before writing a new type/helper, open [`docs/concern-owners.md`](../../../docs/concern-owners.md), find the concern's owner, and reuse or extend it — never duplicate a shared concern (errors, config, logging, path safety, retries, HTTP, registries). Put new logic in concern-named files; never in `doc.go`.

--- a/.github/skills/create-plan/SKILL.md
+++ b/.github/skills/create-plan/SKILL.md
@@ -70,6 +70,7 @@ A plan may **not** invent a lighter standard than gokit's. Its cross-cutting rul
 - **Test-first (TDD).** Each behavior gets a failing test first, then minimal code,
   then refactor while green — failure paths included. Never batch production code
   and bolt tests on later.
+- **Best-practices bar.** Prefer the *simplest* design that fully solves each step — flexible and extensible (small typed seams / functional options, no rigid or speculative abstraction), scalable (bounded resources, no accidental O(n²) or unbounded buffering), on current idiomatic Go best practices, not folklore. Complexity must earn its place.
 - **Structure & placement.** Correct module (root vs sub-module vs nested adapter);
   acyclic layering (lower layers never import higher); every new package has `doc.go`.
 - **Canonical reuse.** Reuse or enhance the owning package / stdlib before writing new code; never duplicate a shared concern. Consult [`docs/concern-owners.md`](../../../docs/concern-owners.md) for the canonical owner (formats → `codec`, helpers → `util`, paths → `fs`, …).

--- a/.github/skills/fix-reviews/SKILL.md
+++ b/.github/skills/fix-reviews/SKILL.md
@@ -52,7 +52,7 @@ For every comment, decide before touching code:
   - `interface{}`/`any` in one signature → *every public surface touched*
   - a naming/formatting nit → *the same construct everywhere in the diff*
   - a duplicated-concern note → *every place that reinvents the canonical owner*
-- **Scope of the sweep.** Default to the PR's change set (`git diff origin/main...HEAD`). Widen to neighbouring files only when the pattern clearly extends there and the fix stays coherent; note the widening. Do not silently refactor unrelated code.
+- **Scope of the sweep.** Default to the PR's change set (`git diff origin/main...HEAD`). Widen to neighbouring files only when the pattern clearly extends there and the fix stays coherent; note the widening. Do not silently refactor unrelated code. A comment often surfaces a **pre-existing** defect in the blast radius (the touched file and its close callers/callees), not just the flagged line — that is in scope too; prefer a root-cause redesign over patching the symptom (pre-stable — no backward compatibility owed).
 
 ## 3. Apply the pattern across the change set
 
@@ -64,6 +64,7 @@ git diff origin/main...HEAD --name-only     # the files in scope
 
 - Search the whole change set for the pattern (grep/glob) and fix every occurrence.
 - Make the same class of fix consistently; prefer a root-cause change over repeating a patch.
+- Where a fix changes behavior, do it **test-first** (failing test → fix → green, failure paths included); keep the fix the simplest correct design on current idiomatic best practices, not a bolt-on shim.
 - Keep each pattern's fixes cohesive so the follow-up commit reads as one intent.
 
 ## 4. Validate — scoped to what changed

--- a/.github/skills/review/SKILL.md
+++ b/.github/skills/review/SKILL.md
@@ -20,6 +20,10 @@ A plan, issue, or roadmap may be passed in **as a scope checklist only** — it 
 
 **Always dispatch a review to a fresh reviewer with no shared session context** — never inline in the session that wrote the code. A reviewer that "remembers" writing the change rationalizes it; an independent agent re-derives every judgment from the code and the principles. Hand it only the scope (diff or module/domain) and this skill.
 
+## Scope: the blast radius, not just the diff
+
+A change is a probe into its neighborhood, not an island. Review the changed lines **and** their blast radius — the rest of each touched file, the code the change calls and is called by, and closely-related files in the same module. Pre-existing defects, dead code, duplicated concerns, and design smells in that blast radius are **in scope** and reported like any other finding; the change set is not a shield for the code around it. Because gokit is pre-stable with **no backward compatibility owed**, prefer a root-cause redesign over patching the symptom — decide Redesign / Align / Enhance / Drop, never "leave it patched." Don't expand into unrelated code silently; when a fix reaches past the touched files, say so and keep it coherent. (A whole-tree audit is [`references/review-project.md`](references/review-project.md).)
+
 ## Pick a driver
 
 - **Change set** → [`references/review-changes.md`](references/review-changes.md).

--- a/.github/skills/review/references/04-quality.md
+++ b/.github/skills/review/references/04-quality.md
@@ -37,6 +37,7 @@ This is the pass the user cares about most: **is the code readable, maintainable
 
 ## Maintainability
 
+- **Root-cause over patches.** gokit is pre-stable — **no compatibility shims, no backward compatibility owed**. Prefer a clean redesign over a symptom patch; flag a shim/hedge/"leave the old path too" as should-fix with a redesign suggestion. Pre-existing defects and design smells in the change's blast radius (touched files and their close callers/callees) are in scope — report them, don't wave them through because "the diff didn't add them."
 - **DRY within reason.** Copy-pasted blocks with small tweaks → one parameterized helper.
   (But do not over-abstract a single use.)
 - **No dead or speculative code.** No commented-out blocks (git history exists), no unused exports,

--- a/.github/skills/review/references/review-changes.md
+++ b/.github/skills/review/references/review-changes.md
@@ -12,7 +12,8 @@ Standing, re-runnable review of a **change set** in this repository — a branch
 
 ## Pass 0 — Scope and context
 
-- Get the actual diff: `git diff <base>...HEAD --stat`, then per file. Review only what changed plus its affected area; do not audit the whole repo (that is [`review-project.md`](./review-project.md)).
+- Get the actual diff: `git diff <base>...HEAD --stat`, then per file. Review what changed **plus its blast radius** — the rest of each touched file, the code the change calls and is called by, and closely-related files in the same module. Do not audit the whole repo (that is [`review-project.md`](./review-project.md)), but do not tunnel-vision on the diff lines either.
+- **Pre-existing problems in the blast radius are in scope.** A defect, dead code, duplicated concern, or design smell you read while reviewing is reported like any other finding — the change set is not a shield for the code around it. Because gokit is pre-stable with **no backward compatibility owed**, prefer a root-cause **redesign** over patching the symptom (decide Redesign / Align / Enhance / Drop; "leave it patched" is not an option). Flag when a fix reaches beyond the touched files and keep it coherent; never silently refactor unrelated code.
 - gokit is a foundation toolkit: a change to a core package's public surface fans out to every sub-module, nested adapter, and downstream repo (rskit parity, consuming services). List that affected area before reviewing.
 - Note whether the change belongs in the **root module**, a **sub-module** (own `go.mod`), or a **nested adapter** (e.g. `storage/s3`), and whether it belongs in *this* package at all.
 


### PR DESCRIPTION
## Summary

Splits the engineering-baseline / skills policy edits out of the SSE header-auth PR (#359) into their own change, as requested in review.

These are documentation-only edits to the shared baseline and the standing skills — no code is affected:

- Add the *simplest-correct-design* bar (flexible, extensible, scalable; current idiomatic Go, not folklore) to the shared baseline and to the `apply-step`, `create-plan`, and `fix-reviews` skills.
- Make **test-first (TDD)** explicit in the baseline and for behavior-changing fixes in `fix-reviews`.
- Scope the `review` and `fix-reviews` skills to the change's **blast radius**, with pre-existing defects in that radius in scope and root-cause redesign preferred over patching.

## Testing

Docs-only; no build/test impact.
